### PR TITLE
feat: skill-manager 支持 Openclaw 目录规则

### DIFF
--- a/skills/skill-manager/scripts/install.sh
+++ b/skills/skill-manager/scripts/install.sh
@@ -44,12 +44,25 @@ detect_source_type() {
 
 # 检测目标目录（支持 skills 和 commands）
 # 优先从当前工作目录查找 .claude，适用于在项目内调用
+# 特殊规则：当在 ~/.openclaw/ 目录下时，使用 ~/.openclaw/skills/ 作为目标
 find_claude_dir() {
     # 首先尝试从调用者的原始工作目录查找（项目本地）
     local current="$ORIGINAL_PWD"
     local current_name="$(basename "$current")"
     local max_iterations=10
     local iteration=0
+
+    # 获取用户主目录
+    local home_dir="${HOME:-/Users/${USER}}"
+
+    # 特殊规则：检测是否在 ~/.openclaw/ 目录下
+    # 如果是，使用 ~/.openclaw/skills/ 作为目标目录
+    # 注意：返回 ~/.openclaw/ 而不是 ~/.openclaw/skills/，因为后续会自动拼接 /skills
+    if [[ "$current" == "$home_dir/.openclaw"* ]]; then
+        # 在 openclaw 目录下，直接使用 openclaw 目录本身
+        echo "$home_dir/.openclaw"
+        return 0
+    fi
 
     # 如果当前目录本身就是 .claude，直接使用
     if [ "$current_name" = ".claude" ]; then

--- a/skills/skill-manager/scripts/list.sh
+++ b/skills/skill-manager/scripts/list.sh
@@ -8,10 +8,21 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MANAGER_DIR="$(dirname "$SCRIPT_DIR")"
 
 # 查找 .claude 目录
+# 特殊规则：当在 ~/.openclaw/ 目录下时，使用 ~/.openclaw/ 作为目标
 find_claude_dir() {
     local current="$MANAGER_DIR"
     local max_iterations=10
     local iteration=0
+
+    # 获取用户主目录
+    local home_dir="${HOME:-/Users/${USER}}"
+
+    # 特殊规则：检测是否在 ~/.openclaw/ 目录下
+    # 如果是，使用 ~/.openclaw/ 作为目标目录
+    if [[ "$current" == "$home_dir/.openclaw"* ]]; then
+        echo "$home_dir/.openclaw"
+        return 0
+    fi
 
     while [ $iteration -lt $max_iterations ]; do
         local parent="$(dirname "$current")"

--- a/skills/skill-manager/scripts/remove.sh
+++ b/skills/skill-manager/scripts/remove.sh
@@ -9,10 +9,21 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MANAGER_DIR="$(dirname "$SCRIPT_DIR")"
 
 # 查找 .claude 目录
+# 特殊规则：当在 ~/.openclaw/ 目录下时，使用 ~/.openclaw/ 作为目标
 find_claude_dir() {
     local current="$MANAGER_DIR"
     local max_iterations=10
     local iteration=0
+
+    # 获取用户主目录
+    local home_dir="${HOME:-/Users/${USER}}"
+
+    # 特殊规则：检测是否在 ~/.openclaw/ 目录下
+    # 如果是，使用 ~/.openclaw/ 作为目标目录
+    if [[ "$current" == "$home_dir/.openclaw"* ]]; then
+        echo "$home_dir/.openclaw"
+        return 0
+    fi
 
     while [ $iteration -lt $max_iterations ]; do
         local parent="$(dirname "$current")"

--- a/skills/skill-manager/scripts/update.sh
+++ b/skills/skill-manager/scripts/update.sh
@@ -10,10 +10,21 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MANAGER_DIR="$(dirname "$SCRIPT_DIR")"
 
 # 查找 .claude 目录
+# 特殊规则：当在 ~/.openclaw/ 目录下时，使用 ~/.openclaw/ 作为目标
 find_claude_dir() {
     local current="$MANAGER_DIR"
     local max_iterations=10
     local iteration=0
+
+    # 获取用户主目录
+    local home_dir="${HOME:-/Users/${USER}}"
+
+    # 特殊规则：检测是否在 ~/.openclaw/ 目录下
+    # 如果是，使用 ~/.openclaw/ 作为目标目录
+    if [[ "$current" == "$home_dir/.openclaw"* ]]; then
+        echo "$home_dir/.openclaw"
+        return 0
+    fi
 
     while [ $iteration -lt $max_iterations ]; do
         local parent="$(dirname "$current")"


### PR DESCRIPTION
## Summary
- 为 skill-manager 添加 Openclaw 目录支持规则
- 当在 ~/.openclaw/ 目录下运行时，自动使用 ~/.openclaw/skills/ 作为目标目录
- 更新了 install.sh、list.sh、remove.sh、update.sh 四个脚本

## Test plan
- [ ] 在普通项目目录下测试 skill-manager 功能正常
- [ ] 在 ~/.openclaw/ 目录下测试安装 skill 到正确位置

🤖 Generated with [Claude Code](https://claude.com/claude-code)