### PR TITLE
fix(clawhub-sync): prepare-publish.sh 未正确过滤 .env 等敏感文件

### DIFF
--- a/skills/clawhub-sync/scripts/prepare-publish.sh
+++ b/skills/clawhub-sync/scripts/prepare-publish.sh
@@ -101,6 +101,12 @@ RSYNC_ARGS=(
     --exclude='node_modules/'  # 排除 node_modules
     --exclude='__pycache__/'   # 排除 Python 缓存
     --exclude='.DS_Store'      # 排除 macOS 系统文件
+    --exclude='**/.env'        # 排除环境变量文件（防止凭证泄露）
+    --exclude='**/*.db'        # 排除数据库文件
+    --exclude='**/*.sqlite'    # 排除 SQLite 文件
+    --exclude='**/logs/'       # 排除日志目录
+    --exclude='**/output/'     # 排除输出目录
+    --exclude='**/downloads/'  # 排除下载目录
 )
 
 # 检查项目根目录的 .gitignore


### PR DESCRIPTION
## 问题

`prepare-publish.sh` 使用 `rsync --filter=":- .gitignore"` 来应用 .gitignore 过滤规则，但 rsync 的 merge-file 模式**不能正确处理** git 的 `**/` 通配符模式。这导致 `.env`、`*.db` 等被 .gitignore 忽略的敏感文件仍然被包含在 ClawHub 发布目录中。

## 修复

在 `RSYNC_ARGS` 默认排除列表中添加敏感文件模式作为硬编码安全兜底：

- `**/.env` — 环境变量文件（防止凭证泄露）
- `**/*.db` — 数据库文件
- `**/*.sqlite` — SQLite 文件
- `**/logs/` — 日志目录
- `**/output/` — 输出目录
- `**/downloads/` — 下载目录

> 注意：未添加 `**/config.yaml` 排除，因为部分 skill 的 config.yaml 是正常功能文件而非敏感配置。

## 验证

使用 `yuandian-law-search` 测试：
```bash
bash skills/clawhub-sync/scripts/prepare-publish.sh skills/yuandian-law-search
```

确认：
- `scripts/.env` **不在**发布目录中（`No such file or directory`）
- `scripts/.env.example` **正常保留**在发布目录中

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)