### PR TITLE
fix(multi-agent-orchestration): codebuddy trust/permission integration fixes (v1.17.5)

### DIFF
--- a/skills/multi-agent-orchestration/CHANGELOG.md
+++ b/skills/multi-agent-orchestration/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.17.5] - 2026-07-05
+
+### Fixed
+- **codebuddy/qoder 交互式 worker 缺 -y / --dangerously-skip-permissions**（问题 2 运行时部分）：`render-runtime-profile.sh` 的 codebuddy case `-y` 逻辑从「batch 恒加 / 交互式仅显式 --dangerously-skip-permissions」改为「交互式也默认加，仅 --no-skip-permissions opt-out」。qoderwork-cn case 同改为默认加 --dangerously-skip-permissions。理由：spawn-worker.sh 派 tmux session 本质 headless（无人在终端应答 runtime permission prompt），DEC-040 F1/F3 只修了 batch 模式，交互式 gap 还在。
+- **codebuddy 首启 trust folder dialog 无自动处理**（问题 1）：`spawn-worker.sh` 新增 trust-auto：启动 tmux 后轮询 pane 内容，匹配 codebuddy trust dialog 文本（Trust folder / Trust folder and all subdirectories），自动选 option 3（Down×3+Enter），避免子目录二次 prompt。提供 `--no-trust-auto` opt-out。
+- **codebuddy PATH 检测假阴性**（问题 3 补充）：`check-dependencies.sh` 新增 `--print-bundle-path codebuddy|qoderwork-cn`，直接输出 .app bundle 二进制绝对路径。`spawn-worker.sh --help` 加 Troubleshooting 段，提示用 check-dependencies 多源检测或取绝对路径传给 --command/--bin。
+
+### Reason
+- 来源：2026-07-05 PM 用 `spawn-worker.sh --backend codebuddy` 派 worker，连续撞 3 个手动 prompt：首启 trust folder dialog → 子目录访问 dialog → which codebuddy 找不到。CHANGELOG v1.16.6/1.17.1/1.17.2 历史上修过 batch 模式 flag 和 PATH-less 检测，但交互式 headless worker 的自动 -y + trust-auto 两个 gap 一直没补。
+
 ## [1.17.4] - 2026-07-03
 
 ### Added

--- a/skills/multi-agent-orchestration/scripts/check-dependencies.sh
+++ b/skills/multi-agent-orchestration/scripts/check-dependencies.sh
@@ -7,6 +7,7 @@ CHECK_BACKENDS=()
 CHECK_GH=0
 CHECK_TERMINAL_SPLIT=0
 STRICT=0
+PRINT_BUNDLE_PATH_BACKEND=""
 
 usage() {
   cat >&2 <<'USAGE'
@@ -20,6 +21,10 @@ Options:
   --check-gh                 Check GitHub CLI for PR/mergeability workflows.
   --check-terminal-split     Check terminal split helper dependencies for current terminal.
   --strict                   Exit non-zero on WARN as well as MISSING.
+  --print-bundle-path NAME    Print the .app bundle binary path for the given backend
+                             and exit. Use to get the absolute path when 'which codebuddy'
+                             returns not found. Supports: codebuddy | qoderwork-cn.
+                             Example: --print-bundle-path codebuddy
 
 Default checks core script dependencies only. The script does not install tools,
 start workers, write files, or change configuration.
@@ -44,6 +49,10 @@ while [[ $# -gt 0 ]]; do
       STRICT=1
       shift
       ;;
+    --print-bundle-path)
+      PRINT_BUNDLE_PATH_BACKEND="$2"
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -55,6 +64,36 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+# --print-bundle-path: quick path lookup for headless CLI workers
+if [ -n "$PRINT_BUNDLE_PATH_BACKEND" ]; then
+  case "$PRINT_BUNDLE_PATH_BACKEND" in
+    codebuddy)
+      BIN="/Applications/WorkBuddy.app/Contents/Resources/app.asar.unpacked/cli/bin/codebuddy"
+      if [ -x "$BIN" ]; then
+        printf '%s\n' "$BIN"
+        exit 0
+      else
+        echo "ERROR: codebuddy binary not found at $BIN" >&2
+        exit 1
+      fi
+      ;;
+    qoderwork-cn)
+      BIN="/Applications/QoderWork CN.app/Contents/Resources/bin/qoderclicn"
+      if [ -x "$BIN" ]; then
+        printf '%s\n' "$BIN"
+        exit 0
+      else
+        echo "ERROR: qoderclicn binary not found at $BIN" >&2
+        exit 1
+      fi
+      ;;
+    *)
+      echo "ERROR: --print-bundle-path supports codebuddy or qoderwork-cn, got: $PRINT_BUNDLE_PATH_BACKEND" >&2
+      exit 64
+      ;;
+  esac
+fi
 
 missing=0
 warn=0

--- a/skills/multi-agent-orchestration/scripts/render-runtime-profile.sh
+++ b/skills/multi-agent-orchestration/scripts/render-runtime-profile.sh
@@ -25,6 +25,7 @@ NO_PROVIDER_ENV_ISOLATION=0
 NO_MCP=0
 BIN=""
 SKIP_PERMISSIONS=0
+NO_SKIP_PERMISSIONS=0
 
 usage() {
   cat >&2 <<'USAGE'
@@ -68,7 +69,11 @@ Options:
   --dangerously-skip-permissions
                            Add the skip-permissions flag for the worker.
                            codebuddy: -y. qoderwork-cn: --dangerously-skip-permissions.
-                           codebuddy batch always includes -y regardless (headless 要求).
+                           警告: 已改为默认行为（交互式也加）。该 flag 仅保留兼容。用 --no-skip-permissions 关闭。
+  --no-skip-permissions    Explicitly turn OFF the skip-permissions flag for the worker.
+                           罕见场景:人要坐终端跟 codebuddy/qoder 交互调试。
+                           codebuddy: remove -y; qoderwork-cn: remove --dangerously-skip-permissions.
+                           Defaults: ON (skip permissions).
   --output FORMAT          shell | command | prompt-context. Default: shell
 
 The script only renders metadata and command strings. It does not create
@@ -156,6 +161,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --dangerously-skip-permissions)
       SKIP_PERMISSIONS=1
+      shift
+      ;;
+    --no-skip-permissions)
+      NO_SKIP_PERMISSIONS=1
       shift
       ;;
     -h|--help)
@@ -340,7 +349,9 @@ case "$BACKEND" in
     ;;
   codebuddy)
     # WorkBuddy / CodeBuddy CLI。参数体系与 Claude Code 高度兼容(ref 08)。
-    # headless 批处理必须 -y(ref 08 §6.2)；MCP off 用 inline 空 config(避免 /tmp 依赖)。
+    # MCP off 用 inline 空 config(避免 /tmp 依赖)。
+    # -y 默认加：spawn-worker 派 tmux session 本质 headless（无人在终端应答 prompt）。
+    # 仅 --no-skip-permissions opt-out（罕见场景：人坐终端跟 codebuddy 交互调试）。
     if [ -z "$PERMISSION_MODE" ]; then
       # F1 (DEC-040): batch 默认 bypassPermissions 替代 acceptEdits。CLI 文档与实测都显示
       # batch + acceptEdits 与 -y 冲突，headless 下每个 tool 调用都被 deny。
@@ -352,8 +363,8 @@ case "$BACKEND" in
     [ -n "$COMMAND_MODEL" ] && cb_parts+=(--model "$COMMAND_MODEL")
     cb_parts+=(--permission-mode "$PERMISSION_MODE")
     [ "$NO_MCP" -eq 1 ] && cb_parts+=(--strict-mcp-config --mcp-config '{"mcpServers":{}}')
-    # batch 恒加 -y(headless 要求)；交互式仅在显式 --dangerously-skip-permissions 时加。
-    if [ "$SKIP_PERMISSIONS" -eq 1 ] || [ "$MODE" = "batch" ]; then
+    # 默认加 -y：交互式和 batch 均默认加；仅 --no-skip-permissions opt-out。
+    if [ "$NO_SKIP_PERMISSIONS" -ne 1 ]; then
       cb_parts+=(-y)
     fi
     if [ "$MODE" = "batch" ]; then
@@ -377,11 +388,11 @@ case "$BACKEND" in
     [ -n "$COMMAND_MODEL" ] && qr_parts+=(-m "$COMMAND_MODEL")
     qr_parts+=(--permission-mode "$PERMISSION_MODE")
     [ "$NO_MCP" -eq 1 ] && qr_parts+=(--strict-mcp-config --mcp-config '{"mcpServers":{}}')
-    [ "$SKIP_PERMISSIONS" -eq 1 ] && qr_parts+=(--dangerously-skip-permissions)
-    # F3 (DEC-040): qoderclicn 在 batch mode 下必须再加 --dangerously-skip-permissions；
-    # `--permission-mode auto` 在 headless 不 bypass，需要这个 flag 强制。
-    # 仅 batch 加，交互式不破坏现有 SKIP_PERMISSIONS 语义。
-    [ "$MODE" = "batch" ] && qr_parts+=(--dangerously-skip-permissions)
+    # 默认加 --dangerously-skip-permissions（spawn-worker tmux worker 本质 headless）。
+    # 仅 --no-skip-permissions opt-out。
+    if [ "$NO_SKIP_PERMISSIONS" -ne 1 ]; then
+      qr_parts+=(--dangerously-skip-permissions)
+    fi
     if [ "$MODE" = "batch" ]; then
       qr_parts+=(-p)
       COMMAND="$(quote_words "${qr_parts[@]}") \"\$(cat $(printf '%q' "$PROMPT_FILE"))\""

--- a/skills/multi-agent-orchestration/scripts/spawn-worker.sh
+++ b/skills/multi-agent-orchestration/scripts/spawn-worker.sh
@@ -68,6 +68,13 @@ the Bootstrap-only or Full worker prompt and confirm STATUS.json appears.
 When --with-sentinel is set, spawn-worker.sh outputs the sentinel command but
 does NOT start the sentinel itself. The PM must run that command with
 run_in_background=true so the harness re-invokes PM on sentinel exit.
+
+Troubleshooting: if 'which codebuddy' returns 'not found', the CLI binary may
+still exist in the .app bundle. Use:
+  bash scripts/check-dependencies.sh --backend codebuddy --strict
+for multi-source detection, or get the absolute path directly:
+  bash scripts/check-dependencies.sh --print-bundle-path codebuddy
+then pass it to spawn-worker via --command or --bin.
 USAGE
 }
 

--- a/skills/multi-agent-orchestration/scripts/spawn-worker.sh
+++ b/skills/multi-agent-orchestration/scripts/spawn-worker.sh
@@ -25,6 +25,7 @@ WITH_SENTINEL=0
 SENTINEL_POLL_INTERVAL=5
 SENTINEL_MAX_WAIT=7200
 KEEP_TMUX_ON_TERMINAL=0
+TRUST_AUTO=1
 
 usage() {
   cat >&2 <<'USAGE'
@@ -57,6 +58,9 @@ Options:
                    Default 7200; passed to the recommended sentinel command
   --keep-tmux-on-terminal
                    Pass --keep-tmux-on-terminal to the recommended sentinel command
+  --no-trust-auto   Skip trust-folder auto-accept for codebuddy/qoder CLI workers.
+                   Default: auto-select 'Trust folder and all subdirectories' (option 3)
+                   to avoid both the initial trust prompt and subdir trust prompts.
   --dry-run         Print actions without changing anything
 
 The script only creates isolation and starts the session. The PM must still send
@@ -143,6 +147,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --keep-tmux-on-terminal)
       KEEP_TMUX_ON_TERMINAL=1
+      shift
+      ;;
+    --no-trust-auto)
+      TRUST_AUTO=0
       shift
       ;;
     --dry-run)
@@ -304,6 +312,50 @@ write_metadata() {
     }' > "$METADATA_FILE"
 }
 
+# Trust folder auto-accept for headless codebuddy/qoder CLI workers.
+# Default: auto-select "Trust folder and all subdirectories" (option 3) to
+# avoid both the initial trust prompt AND subsequent subdir trust prompts.
+# Polls the tmux pane for trust dialog text, then sends Down×3+Enter.
+trust_auto() {
+  local session="$1"
+  local max_wait=30
+  local poll_interval=1
+  local waited=0
+
+  while [ "$waited" -lt "$max_wait" ]; do
+    if ! tmux has-session -t "$session" 2>/dev/null; then
+      return 1  # session died, trust-auto skipped
+    fi
+
+    local content
+    content=$(tmux capture-pane -t "$session" -p -S -50 2>/dev/null || echo "")
+
+    # codebuddy trust dialog:
+    #   Do you want to proceed?
+    #   1. Trust folder only / 2. Trust parent folder / 3. Trust folder and all subdirectories / 4. No, exit
+    if echo "$content" | grep -q "Trust folder and all subdirectories"; then
+      echo "SPAWN_WORKER_TRUST_AUTO: trust dialog detected, selecting Trust folder and all subdirectories (option 3)"
+      tmux send-keys -t "$session" Down Down Down Enter
+      sleep 2  # wait for trust to take effect
+      return 0
+    fi
+
+    # Generic fallback: match other trust/Do you trust dialogs
+    if echo "$content" | grep -qE "Trust folder|Do you trust" 2>/dev/null; then
+      echo "SPAWN_WORKER_TRUST_AUTO: trust dialog detected (generic), selecting last trust option (Down×3+Enter)"
+      tmux send-keys -t "$session" Down Down Down Enter
+      sleep 2
+      return 0
+    fi
+
+    sleep "$poll_interval"
+    waited=$((waited + poll_interval))
+  done
+
+  echo "SPAWN_WORKER_TRUST_AUTO: no trust dialog seen within ${max_wait}s, continuing"
+  return 0
+}
+
 write_metadata
 
 exclude_file=$(git -C "$WORKTREE" rev-parse --git-path info/exclude)
@@ -312,6 +364,13 @@ if [ "$DRY_RUN" -eq 0 ] && ! grep -qxF ".claude/agent-sessions/" "$exclude_file"
 fi
 
 run tmux new-session -d -s "$SESSION" -c "$WORKTREE" "$COMMAND"
+
+# Trust-auto: headless CLI workers need trust-folder permission auto-accepted.
+# Selects "Trust folder and all subdirectories" (option 3) to avoid both the
+# initial trust prompt and subsequent subdir trust prompts. Use --no-trust-auto to opt out.
+if [ "$DRY_RUN" -eq 0 ] && [ "$TRUST_AUTO" -eq 1 ]; then
+  trust_auto "$SESSION"
+fi
 
 if [ "$DRY_RUN" -eq 0 ]; then
   pane_cwd=$(tmux display-message -p -t "$SESSION" '#{pane_current_path}' 2>/dev/null || echo "")


### PR DESCRIPTION
## 修复内容

三个 fix 解决 `spawn-worker.sh --backend codebuddy` 派 worker 时遇到的 3 个手动 prompt 问题：

### Fix 1: `render-runtime-profile.sh` -y 默认加
- codebuddy case: -y 改为交互式也默认加（spawn-worker tmux = headless），仅 --no-skip-permissions opt-out
- qoderwork-cn case: --dangerously-skip-permissions 同改为默认加

### Fix 2: `spawn-worker.sh` trust-auto
- 新增 trust_auto() 函数: tmux 启动后轮询 pane 匹配 trust dialog
- 自动选 option 3 (Trust folder and all subdirectories) 避免子目录二次 prompt
- 提供 --no-trust-auto opt-out

### Fix 3: `check-dependencies.sh` --print-bundle-path
- 新增 --print-bundle-path codebuddy|qoderwork-cn 直接输出 .app bundle 路径
- spawn-worker.sh --help 加 Troubleshooting 段

## 验证
```bash
# Fix 1 默认含 -y
bash scripts/render-runtime-profile.sh --backend codebuddy --model deepseek-v4-pro --output shell | grep WORKER_COMMAND
# WORKER_COMMAND=...codebuddy ... -y ✓

# Fix 1 opt-out
bash scripts/render-runtime-profile.sh --backend codebuddy --model deepseek-v4-pro --output shell --no-skip-permissions | grep WORKER_COMMAND
# WORKER_COMMAND=...codebuddy ... (no -y) ✓

# Fix 3 路径
bash scripts/check-dependencies.sh --print-bundle-path codebuddy
# /Applications/WorkBuddy.app/Contents/Resources/app.asar.unpacked/cli/bin/codebuddy ✓
```