### PR TITLE
[legal-ocr] v1.5.0 PDF 原生文本层双路径（先直读，不达标再 OCR）

### DIFF
--- a/skills/legal-ocr/CHANGELOG.md
+++ b/skills/legal-ocr/CHANGELOG.md
@@ -1,5 +1,74 @@
 # 变更记录
 
+## [1.5.0] - 2026-07-10
+
+### 新增：PDF 原生文本层双路径（先直读，不达标再 OCR）
+
+> **背景**：法律场景里法院电子送达的判决书、电子合同、政府公文等相当一部分 PDF
+> 本就带可靠的原生文本层。直读比 OCR 更准（避免识别错误）、更快（无网络往返）、
+> 更省（不耗 PaddleOCR / MinerU 额度）。借鉴 DataInfra-RedactionEverything 调研
+> Part B §一：用文本密度阈值重判 `is_scanned` 决定走文本管线 vs OCR 管线。
+
+#### 行为
+
+- 进入 OCR 后端之前，新增「文本层直读分支」（仅本地 `.pdf`）：
+  1. 用 `pypdfium2` 逐页 `get_textpage().get_text_range()` 抽取文字；
+  2. 计算质量指标（文本页覆盖率、平均 CJK / 页、乱码比例、总字符数）；
+  3. 全部阈值达标 → 直接转 Markdown，复用既有 post-process（法律术语 → 硬换行整理 → 基础清理）；
+  4. 任一不达标 → 落回原有 OCR 候选（PaddleOCR → MinerU）。
+- 文本层分支排在 **所有 OCR 后端之前**；不可用时透明回退，旧工作流完全兼容。
+
+#### 新参数
+
+- `--text-layer auto|never|always`（CLI）
+- `LEGAL_OCR_TEXT_LAYER`（env，等价）
+- `LEGAL_OCR_TEXT_LAYER_MIN_COVERAGE`（默认 `0.8`，文本页覆盖率下限）
+- `LEGAL_OCR_TEXT_LAYER_MIN_CHARS_PER_PAGE`（默认 `50`，文本页平均 CJK 字符下限）
+- `LEGAL_OCR_TEXT_LAYER_MAX_GARBLE_RATIO`（默认 `0.05`，PUA + 替换字符 + 非常见字符占比上限）
+- `LEGAL_OCR_TEXT_LAYER_MIN_TOTAL_CHARS`（默认 `100`，非空白字符总数下限）
+
+阈值默认值依据见 `DECISIONS.md`「文本层质量阈值（v1.5.0）」段，**待真实卷宗校准**。
+
+#### 与 `--backend` 的优先级
+
+- `--backend auto`（默认）+ `--text-layer auto`（默认）：先文本层、不达标再 OCR，最优路径。
+- `--backend paddle|mineru`：视为用户显式想要 OCR，跳过文本层分支；除非同时设 `--text-layer always` 强制覆盖。
+- `--text-layer never`：完全禁用文本层，回到旧版纯 OCR 行为。
+- `--text-layer always`：强制文本层，PDF 没有可用文本层时直接报错退出（exit=2），便于排障。
+
+#### 实现要点
+
+- 新增 `scripts/text_layer.py`：探测 + 抽取 + 阈值加载，独立可测。
+- `scripts/convert.py` 提取 `run_postprocess_pipeline` / `finalize_conversion` 两个共享函数；
+  OCR 分支与文本层分支共用同一套 post-process + archive，输出风格保持一致。
+- 文本层结果以合成的 `BackendResult(backend='text_layer', mode='native_pdf_text', provider='pypdfium2')`
+  形式进入既有 archive 流水线；`metadata.json` 多出 `text_layer` 字段，记录 probe 全量指标，
+  方便复盘为什么走了文本层 / 为什么没走。
+- 借鉴 DataInfra 思路（文本密度判定），**未引入任何 DataInfra 代码**（注意 AGPL / 非商用许可隔离）。
+
+#### 自造样本烟测
+
+造两份本地样本验证分流正确（详见 PR 描述）：
+
+| 样本 | 期望 | 实际 |
+|------|------|------|
+| `clean_text_layer.pdf`（reportlab + STHeiti，3 页中文判决片段） | `--text-layer auto` 直读，后端=`text_layer` | ✅ coverage=1.0、cjk/page=112、garbled=0、走文本层 |
+| `scanned_no_text_layer.pdf`（PIL 渲染图片转 PDF，1 页） | `--text-layer auto` 回退到 OCR 后端 | ✅ reason=`no_text_layer`、回退 MinerU light |
+| `scanned_no_text_layer.pdf` + `--text-layer always` | 直接失败、exit=2 | ✅ 报错文案清晰、exit=2 |
+| `clean_text_layer.pdf` + `--text-layer never` | 强制走 OCR | ✅ 跳过文本层、回退 MinerU light |
+
+### 文档完善
+
+- `SKILL.md` 新增「PDF 文本层双路径」章节、参数表加 `--text-layer`、版本号 → 1.5.0。
+- 新增 `references/text-layer-detection.md`：探测算法、字符分类、阈值理由、失败模式。
+- `.env.example` 顶部加 `LEGAL_OCR_TEXT_LAYER*` 配置块。
+
+### 关联
+
+- 任务源：legal-ocr TASKS.md「PDF 文本层双路径」条目（local-only，不在 PR diff 内）。
+- 调研缘由：260707 DataInfra-RedactionEverything 调研 Part B §一。
+- 决策记录：DECISIONS.md「文本层质量阈值（v1.5.0）」段（local-only）。
+
 ## [1.4.3] - 2026-06-14
 
 ### 🔥 真修:`httpx.Client(..., trust_env=False)` 全 5 处加固 — cron 死循环 root cause 治本

--- a/skills/legal-ocr/SKILL.md
+++ b/skills/legal-ocr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: legal-ocr
 description: 本技能应在用户需要 OCR、扫描识别、图片文字识别、文档识别，或将 PDF、图片、Office 文档、URL 转换为 Markdown 时使用。检测到法律材料时可进行保守的法律术语与文书结构优化。不要用于法律事实判断、补写缺失内容、语义改写、印章深度识别或图表实体分析。
-version: "1.4.3"
+version: "1.5.0"
 license: MIT
 author: 杨卫薪律师（微信ywxlaw）
 homepage: https://github.com/cat-xierluo/legal-skills
@@ -10,6 +10,7 @@ homepage: https://github.com/cat-xierluo/legal-skills
 
 本技能用于 OCR、扫描识别、图片文字识别、文档识别，以及把 PDF、图片、Office 文档和 URL 转换为可继续编辑、分析和归档的 Markdown。它首先是通用 OCR 入口；当结果被识别为法律材料时，再自动启用保守型法律后处理。默认使用配置优先的自动路由：
 
+- 本地 PDF 默认先探测原生文本层：法院电子送达判决书、电子合同、政府公文等带可靠文本层的 PDF 直读比 OCR 更准、更快、更省额度。质量达标直接抽文字转 Markdown；不达标才落回 OCR。详见「PDF 文本层双路径」。
 - 只配置 PaddleOCR：PaddleOCR 支持的 PDF / 图片优先走 PaddleOCR；超出能力边界时再提示或改走 MinerU 支持链路。
 - 只配置 MinerU Token：所有 MinerU 支持的输入统一走 MinerU，包含 PDF、图片、Office、远程文档 URL 和网页 URL。
 - 同时配置两套 API：本地 PDF / 图片优先 PaddleOCR，Office / 网页 URL 优先 MinerU；首选后端出现额度、频率、鉴权、网络或服务失败时自动尝试候选后端。
@@ -99,6 +100,7 @@ uv run scripts/convert.py checktoken
 | 参数 | 说明 |
 |------|------|
 | `--backend auto|paddle|mineru` | 指定后端；默认读取 `LEGAL_OCR_BACKEND`，未配置时为 `auto` |
+| `--text-layer auto|never|always` | PDF 原生文本层分支；默认 `auto`，达标则直读跳过 OCR；`never` 强制走 OCR；`always` 强制文本层，不可用即失败 |
 | `--output <path>` | 输出 Markdown 路径或目录 |
 | `--pages <spec>` | 页码范围，如 `1-20`、`1-5,8,10-12` |
 | `--archive-name <name>` | 自定义 archive 目录名 |
@@ -113,6 +115,47 @@ uv run scripts/convert.py checktoken
 | `--paddle-api-extra-json <path>` | 合并额外 PaddleOCR optionalPayload |
 
 PaddleOCR 同步接口会校验后端实际返回页数。若返回页数少于本地 PDF 批次页数，转换会失败并提示降低 `PADDLEOCR_BATCH_PAGES` 或使用 `--pages` 重跑，避免缺页结果被误当作成功。
+
+## PDF 文本层双路径
+
+本地 PDF 进入 OCR 后端之前，会先探测是否带可用的原生文本层（v1.5.0+）。这是法律场景里的高频优化：法院电子送达判决书、电子合同、政府公文等 PDF 通常已带可靠文本层，直读比 OCR 更准、更快、不耗 API 额度。
+
+### 工作流
+
+1. 仅本地 `.pdf` 触发；图片、Office、URL 不参与。
+2. 用 `pypdfium2` 逐页抽取文字，计算 4 个指标：文本页覆盖率、平均 CJK / 页、乱码比例（PUA + 替换字符 + 非常见字符）、总字符数。
+3. 全部阈值达标 → 直接转 Markdown，复用既有 post-process（法律术语 → 硬换行整理 → 基础清理）。
+4. 任一不达标 → 落回原有 OCR 候选（PaddleOCR → MinerU），完全兼容旧工作流。
+
+### 模式（CLI `--text-layer` 或 env `LEGAL_OCR_TEXT_LAYER`）
+
+| 模式 | 行为 |
+|------|------|
+| `auto`（默认） | 探测后达标走文本层，不达标回退 OCR |
+| `never` | 完全禁用文本层，回到旧版纯 OCR 行为 |
+| `always` | 强制走文本层；不可用时直接 exit=2 失败，便于排障 |
+
+### 与 `--backend` 的优先级
+
+- `--backend auto` + `--text-layer auto`：最优路径，先文本层、不达标再 OCR。
+- `--backend paddle|mineru`：视为用户显式想要 OCR，跳过文本层分支（除非同时设 `--text-layer always` 强制覆盖）。
+
+### 阈值（保守默认，理想值待真实卷宗校准）
+
+| env | 默认 | 含义 |
+|-----|------|------|
+| `LEGAL_OCR_TEXT_LAYER_MIN_COVERAGE` | `0.8` | 文本页占探测页比例下限 |
+| `LEGAL_OCR_TEXT_LAYER_MIN_CHARS_PER_PAGE` | `50` | 文本页平均 CJK 字符下限 |
+| `LEGAL_OCR_TEXT_LAYER_MAX_GARBLE_RATIO` | `0.05` | PUA + 替换字符 + 非常见字符占比上限 |
+| `LEGAL_OCR_TEXT_LAYER_MIN_TOTAL_CHARS` | `100` | 非空白字符总数下限 |
+
+阈值默认值的理由见 `references/text-layer-detection.md` 与 `DECISIONS.md`。如果你拿到一批真实卷宗发现误判（例如应该走 OCR 的 PDF 走了文本层，或反之），把指标和样本反馈给维护者，再调阈值或加新规则。
+
+### archive 记录
+
+无论是否走文本层，PDF 输入都会在 `metadata.json` 留下 `text_layer` 字段：
+- 走了文本层：`enabled=true` + `probe` 全量指标（页数、coverage、garbled_ratio、阈值快照）。
+- 没走文本层：`enabled=false` + `probe.reason`（如 `no_text_layer` / `high_garbled_ratio`），便于复盘为什么回退到 OCR。
 
 ## 自动分流
 

--- a/skills/legal-ocr/config/.env.example
+++ b/skills/legal-ocr/config/.env.example
@@ -11,6 +11,22 @@ LEGAL_OCR_RETRY_ATTEMPTS=3
 LEGAL_OCR_RETRY_BASE_DELAY=1.0
 LEGAL_OCR_RETRY_MAX_DELAY=30.0
 
+# ===== PDF 原生文本层分支（v1.5.0+）=====
+# 本地 PDF 进入 OCR 后端前，先探测是否已有可用的原生文本层：
+#   auto   = 达标则直读跳过 OCR（默认，原生文本比 OCR 更准、更快、不耗 API 额度）
+#   never  = 始终走 OCR（与旧版行为一致，用于强制重新识别）
+#   always = 强制走文本层；不可用时直接失败，便于排障
+LEGAL_OCR_TEXT_LAYER=auto
+# 文本层质量阈值（保守默认，理想值待真实卷宗校准，详见 DECISIONS.md）
+# 文本页覆盖率下限（pages_with_text / pages_probed）
+LEGAL_OCR_TEXT_LAYER_MIN_COVERAGE=0.8
+# 每个有文本页的平均 CJK 字符下限；纯英文 PDF 由其它阈值兜底
+LEGAL_OCR_TEXT_LAYER_MIN_CHARS_PER_PAGE=50
+# 乱码字符占比上限（PUA + 替换字符 + 非常见字符 / 非空白字符总数）
+LEGAL_OCR_TEXT_LAYER_MAX_GARBLE_RATIO=0.05
+# 非空白字符总数下限，避免 1 页短文档误判
+LEGAL_OCR_TEXT_LAYER_MIN_TOTAL_CHARS=100
+
 # ===== PaddleOCR 后端 =====
 # 从 https://www.paddleocr.com 对应模型 API 页面复制完整 layout-parsing 端点和 Access Token。
 PADDLEOCR_DOC_PARSING_API_URL=https://your-endpoint.example.com/layout-parsing

--- a/skills/legal-ocr/references/text-layer-detection.md
+++ b/skills/legal-ocr/references/text-layer-detection.md
@@ -1,0 +1,159 @@
+# PDF 文本层双路径探测算法
+
+> v1.5.0 引入。对应代码：`scripts/text_layer.py`。本文档解释探测逻辑、字符分类、阈值理由和已知失败模式，便于排查「为什么走了 / 没走文本层」。
+
+## 为什么需要文本层探测
+
+法律场景里很多 PDF 本就带可用的原生文本层：
+
+- 法院电子送达的判决书 / 裁定书 / 调解书（带法院电子签章，但底层是文本而非扫描图像）。
+- 政府公文系统导出的 PDF。
+- 电子合同平台（如 e签宝、法大大）的签署件。
+- Word / WPS 导出的 PDF。
+
+这些 PDF 直读文本层比 OCR 更优：
+
+| 维度 | 文本层直读 | OCR |
+|------|------------|-----|
+| 准确率 | 100%（就是作者写的字） | 受识别模型限制，常见 95-99% |
+| 速度 | <1s（本地解码） | 数秒到数分钟（含网络往返） |
+| API 额度 | 0 | PaddleOCR / MinerU 都按页计费 |
+| 网络依赖 | 无 | 必须 |
+
+但「带文本层」不等于「文本层可用」。典型坑：
+
+- 扫描件被套了一层「假文本层」（OCR 软件预生成，但识别质量差）。
+- 用了 CID / 自定义字体的 PDF，文本层抽出来全是 PUA 私用区字符（看上去有内容，实则乱码）。
+- 只有封面页有文本、正文是图片。
+- 解码错误导致大量 `U+FFFD` 替换字符。
+
+所以需要一个质量判定，不能「有就信」。
+
+## 探测算法
+
+### 1. 抽取
+
+```python
+doc = pypdfium2.PdfDocument(str(pdf_path))
+for idx in page_indices:
+    page = doc.get_page(idx)
+    textpage = page.get_textpage()
+    raw_text = textpage.get_text_range() or ""
+    # 标准化换行
+```
+
+只取纯文本，不做版面分析。后续 post-process 会处理段落 / 标题。
+
+### 2. 字符分类
+
+逐字符统计 5 类：
+
+| 类别 | 字符范围 | 计入 |
+|------|----------|------|
+| 空白 | `str.isspace() == True` | 跳过 |
+| 替换字符 | `U+FFFD` | `replacement++` |
+| 私用区（PUA） | `U+E000–U+F8FF` 及补充私用区 | `pua++` |
+| CJK | `U+4E00–U+9FFF`（CJK Unified Ideographs） | `cjk++`，`good++` |
+| ASCII 字母数字 | `0-9 A-Z a-z` | `good++` |
+| 常见标点 | CJK 符号、半全角形式、通用标点、ASCII 标点 | `good++` |
+| 其他 | 不在上述类别 | 既不计入 good，也不计入 pua/replacement，归入「不明字符」 |
+
+### 3. 指标计算
+
+```
+total_chars        = 非空白字符总数
+garbled_ratio      = (total_chars - good_chars) / total_chars
+text_coverage      = pages_with_text / pages_probed
+avg_cjk_per_text_page = cjk_chars / pages_with_text
+```
+
+`garbled_ratio` 把 PUA、替换字符、不明字符一起算坏。这三种字符在正常法律 PDF 里都极少出现，>5% 就足以怀疑字体 / 编码有问题。
+
+### 4. 决策
+
+按顺序检查，第一条命中即拒绝（reason 字段写进 archive 便于复盘）：
+
+1. `pages_with_text == 0` → `no_text_layer`（纯扫描件，最常见）
+2. `text_coverage < min_coverage` → `low_coverage`（封面 + 扫描正文混排）
+3. `total_chars < min_total_chars` → `too_few_chars`（1 页短文档兜底）
+4. `avg_cjk < min_chars_per_text_page AND cjk < total_chars` → `low_cjk_density`（零星标题 / 图注）
+5. `garbled_ratio > max_garbled_ratio` → `high_garbled_ratio`（CID 字体陷阱）
+6. 否则 → `text_layer_ok`（usable=True，进入文本层分支）
+
+`avg_cjk` 判据加了 `AND cjk < total_chars` 是为了**不误判纯英文 PDF**：英文合同每页可能只有几十个 CJK 字符（甚至 0），但 `good_chars` 包含 ASCII 字母数字，garbled_ratio 仍低，所以走兜底路径通过。
+
+## 阈值默认值与理由
+
+| 阈值 | 默认 | 理由 |
+|------|------|------|
+| `min_coverage` | 0.8 | 允许 20% 页面是空白 / 封面 / 印章页，剩余 80% 必须有文本。太严会误杀多页判决书（首尾常是空白）；太松会让封面 + 图片混排件蒙混过关。 |
+| `min_chars_per_text_page` | 50 | 一份正常 A4 判决书每页约 600-1500 CJK 字符；50 已经是非常宽松的下限，避免短标题 / 图注页面被当成「有文本」。 |
+| `max_garbled_ratio` | 0.05 | 正常 PDF 抽出来几乎没有 PUA / 替换字符；超过 5% 就足以怀疑字体映射坏了。这个值是直觉默认，**待真实卷宗校准**。 |
+| `min_total_chars` | 100 | 1 页短文档（如单张传票）容易被随机字符误判，加一道绝对下限兜底。 |
+
+**这些默认是保守的、直觉驱动的，没有用真实卷宗校准过。** 理想做法是收集 50-100 份真实法律 PDF，人工标注「该走文本层 / 该走 OCR」，跑探测脚本，看 ROC 曲线找最优阈值。在拿到真实样本前，宁可漏走文本层（fallback 到 OCR 也只是慢一点），也不要错走文本层（输出乱码、用户没察觉）。
+
+## 已知失败模式
+
+### 1. 误判为可用（false positive）
+
+- **CID 字体但 ToUnicode CMap 正确**：抽出来是正常 Unicode，但部分字形 / 标点位置错乱。garbled_ratio 抓不到，需要语义层判定。**目前没解**，依赖人工复核。
+- **OCR 预生成的「假文本层」**：扫描件套了一层 OCR 文本，识别质量 80-95%。文本层指标全过，但实际质量不如重新 OCR。**目前没解**；如果你看到结果质量差，用 `--text-layer never` 强制重跑。
+- **多栏排版**：文本层抽取按 PDF 内部对象顺序，可能左右栏交错。`linebreaks.py` 后处理部分缓解，但不完美。
+
+### 2. 误判为不可用（false negative）
+
+- **CJK 占比很低但 ASCII 多的纯英文合同**：已通过 `cjk < total_chars` 条件兜底；如果你遇到仍被拒绝，调低 `LEGAL_OCR_TEXT_LAYER_MIN_CHARS_PER_PAGE`。
+- **印章 / 水印占字符比例高**：水印字符也算 good，理论上不影响。但极端情况可能 garbled_ratio 升高。
+- **少量页是图片**：低于 20% 图片页可以容忍（coverage 阈值 0.8）；超过就回退 OCR。
+
+### 3. 已知不处理
+
+- **远端 URL 的 PDF**：不会下载到本地再探测；直接走 OCR。
+- **加密 PDF**：pypdfium2 抽不出文本，自动回退 OCR。
+- **`--pages` 截取后的探测**：只看选定页的指标；如果你只选了图片页，会回退 OCR，即使其它页有文本。
+
+## 调试技巧
+
+### 查看 probe 指标
+
+任何 PDF 转换后看 archive 的 `metadata.json`：
+
+```bash
+jq '.text_layer' archive/<latest>/metadata.json
+jq '.backend_metadata.processing.text_layer.metrics' archive/<latest>/metadata.json
+```
+
+### 强制对比文本层 vs OCR
+
+```bash
+# 先跑文本层版本
+uv run scripts/convert.py input.pdf --output with_tl.md
+# 再强制 OCR 版本
+uv run scripts/convert.py input.pdf --output with_ocr.md --text-layer never
+# diff
+diff with_tl.md with_ocr.md
+```
+
+如果 OCR 版本明显更好（少错字 / 段落更整齐），说明文本层 false positive，把样本反馈给维护者调阈值。
+
+### 单独跑探测（不进 OCR）
+
+```python
+import sys
+sys.path.insert(0, "skills/legal-ocr/scripts")
+from text_layer import probe_and_extract, load_thresholds, resolve_page_indices
+from pathlib import Path
+
+pdf = Path("input.pdf")
+indices, total = resolve_page_indices(pdf, None)
+probe = probe_and_extract(pdf, page_indices=indices, thresholds=load_thresholds({}))
+print(probe.to_payload())
+```
+
+## 关联
+
+- 实现：`scripts/text_layer.py`
+- 主入口集成：`scripts/convert.py` 的 `maybe_probe_text_layer` 函数
+- 决策记录：`DECISIONS.md`「文本层质量阈值（v1.5.0）」段
+- 调研缘由：260707 DataInfra-RedactionEverything 调研 Part B §一

--- a/skills/legal-ocr/scripts/convert.py
+++ b/skills/legal-ocr/scripts/convert.py
@@ -45,6 +45,12 @@ from basic_postprocess import run_basic_postprocess  # noqa: E402
 from legal_terms import detect_legal_context, run_legal_terms_postprocess  # noqa: E402
 from linebreaks import run_linebreak_postprocess  # noqa: E402
 from router import RouteDecision, choose_backend  # noqa: E402
+from text_layer import (  # noqa: E402
+    load_thresholds,
+    probe_and_extract,
+    resolve_page_indices,
+    resolve_text_layer_mode,
+)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -53,6 +59,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("input", help='本地文件、远程 URL，或 "checktoken"')
     parser.add_argument("--backend", choices=["auto", "paddle", "mineru"], default=None)
+    parser.add_argument(
+        "--text-layer",
+        choices=["auto", "never", "always"],
+        default=None,
+        help=(
+            "PDF 原生文本层分支：auto=达标则直读跳过 OCR（默认），"
+            "never=始终走 OCR，always=强制文本层（不可用时直接失败）"
+        ),
+    )
     parser.add_argument("--output", help="输出 Markdown 路径；如果不是 .md，则按目录处理")
     parser.add_argument("--pages", help='页码范围，例如 "1-20" 或 "1-5,8,10-12"')
     parser.add_argument("--archive-name", help="自定义 archive 目录名后缀，默认使用输入文件名")
@@ -335,6 +350,235 @@ def convert_once(
     return backend.convert(source, options, work_dir, assets_dir), assets_dir
 
 
+def run_postprocess_pipeline(
+    raw_markdown: str,
+    *,
+    source: SourceInfo,
+    env: dict[str, str],
+    no_line_merge: bool,
+    postprocess_enabled: bool,
+    configured_legal_terms_mode: str,
+) -> tuple[str, list[dict[str, str]], dict[str, Any]]:
+    """统一的后处理链：法律术语 → 硬换行整理 → 基础 Markdown 清理。
+
+    文本层直读分支与 OCR 分支共享此函数，保证两条路径输出风格一致。
+    返回 (final_markdown, postprocess_log, legal_context)。
+    """
+    if not postprocess_enabled:
+        return raw_markdown, [], {
+            "mode": "disabled",
+            "enabled": False,
+            "detection": None,
+        }
+
+    working_markdown = raw_markdown
+    postprocess_log: list[dict[str, str]] = []
+    mode = configured_legal_terms_mode
+    legal_context: dict[str, Any] = {
+        "mode": mode,
+        "enabled": False,
+        "detection": None,
+    }
+    if mode == "auto":
+        detection = detect_legal_context(working_markdown, source_name=source.file_name)
+        legal_context["detection"] = detection
+        legal_context["enabled"] = bool(detection["is_legal"])
+        if not detection["is_legal"]:
+            postprocess_log.append(
+                {
+                    "action": "legal_terms_skip",
+                    "category": "legal_context_auto",
+                    "description": "未检测到足够法律文书信号，跳过法律术语优化",
+                    "score": str(detection["score"]),
+                }
+            )
+    elif mode == "always":
+        legal_context["enabled"] = True
+
+    if legal_context["enabled"]:
+        legal_terms_result = run_legal_terms_postprocess(
+            working_markdown,
+            custom_terms_path=env.get("LEGAL_OCR_CUSTOM_TERMS_PATH"),
+        )
+        working_markdown = legal_terms_result.text
+        postprocess_log.extend(legal_terms_result.log)
+
+    if should_line_merge(env, no_line_merge):
+        linebreak_result = run_linebreak_postprocess(working_markdown)
+        working_markdown = linebreak_result.text
+        postprocess_log.extend(linebreak_result.log)
+
+    postprocessed = run_basic_postprocess(working_markdown)
+    final_markdown = postprocessed.text
+    postprocess_log.extend(postprocessed.log)
+    return final_markdown, postprocess_log, legal_context
+
+
+def finalize_conversion(
+    *,
+    source: SourceInfo,
+    backend_result: BackendResult,
+    route: RouteDecision,
+    attempts: list[dict[str, str]],
+    attempt_assets_dir: Path | None,
+    output_md_path: Path,
+    output_images_dir: Path,
+    archive_name: str,
+    args: argparse.Namespace,
+    env: dict[str, str],
+    postprocess_enabled: bool,
+    configured_legal_terms_mode: str,
+    no_archive: bool,
+    extra_metadata: dict[str, Any] | None = None,
+) -> int:
+    """共享的转换收尾：后处理 → 写 Markdown → 复制图片 → archive → 打印。
+
+    文本层分支与 OCR 分支共用，避免两份相同的 post-process + archive 拷贝。
+    """
+    raw_markdown = backend_result.markdown.strip()
+    final_markdown, postprocess_log, legal_context = run_postprocess_pipeline(
+        raw_markdown,
+        source=source,
+        env=env,
+        no_line_merge=args.no_line_merge,
+        postprocess_enabled=postprocess_enabled,
+        configured_legal_terms_mode=configured_legal_terms_mode,
+    )
+
+    write_text(output_md_path, final_markdown)
+    if attempt_assets_dir is not None:
+        if copy_attempt_assets(attempt_assets_dir, output_images_dir):
+            update_image_paths(backend_result.images, output_images_dir)
+
+    result_json = build_result_payload(
+        source=source,
+        backend_result=backend_result,
+        route=route,
+        attempts=attempts,
+        raw_markdown=raw_markdown,
+        final_markdown=final_markdown,
+        postprocess_log=postprocess_log,
+        postprocess_enabled=postprocess_enabled,
+        legal_context=legal_context,
+    )
+    metadata: dict[str, Any] = {
+        "created_at": datetime.now().isoformat(timespec="seconds"),
+        "source": source_json(source),
+        "backend": result_json["backend"],
+        "route": result_json["route"],
+        "output_markdown": str(output_md_path),
+        "image_output_dir": str(output_images_dir) if output_images_dir.exists() else None,
+        "postprocess_enabled": postprocess_enabled,
+        "legal_context": result_json["postprocess"]["legal_context"],
+        "postprocess_log": postprocess_log,
+        "backend_metadata": backend_result.metadata,
+    }
+    if extra_metadata:
+        metadata.update(extra_metadata)
+
+    archive_path: Path | None = None
+    if not no_archive:
+        archive_path = build_archive(
+            source=source,
+            archive_name=archive_name,
+            output_md_path=output_md_path,
+            output_images_dir=output_images_dir,
+            raw_markdown=raw_markdown,
+            result_json=result_json,
+            metadata=metadata,
+            backend_result_dir=backend_result.backend_result_dir,
+        )
+
+    print("转换完成")
+    print(f"Markdown: {output_md_path}")
+    if output_images_dir.exists():
+        print(f"图片目录: {output_images_dir}")
+    if archive_path:
+        print(f"Archive: {archive_path}")
+    print(f"后端: {backend_result.backend} ({backend_result.mode})")
+    _model = (backend_result.metadata or {}).get("config", {}).get("model")
+    if _model:
+        print(f"OCR_MODEL: {_model}")
+    return 0
+
+
+def maybe_probe_text_layer(
+    *,
+    source: SourceInfo,
+    env: dict[str, str],
+    args: argparse.Namespace,
+    options: ConvertOptions,
+) -> tuple[BackendResult | None, dict[str, Any]]:
+    """PDF 文本层直读分支。
+
+    返回 (BackendResult | None, decision_log)：
+    - 当且仅当文本层分支应当接管时，返回合成的 BackendResult；
+    - 否则返回 None，调用方继续走 OCR 路径。
+    decision_log 记录为什么启用 / 禁用，便于 archive 与诊断。
+    """
+    # 仅本地 PDF 走文本层；远程 / 图片 / Office 不参与
+    if source.is_url or source.suffix != ".pdf" or source.path is None:
+        return None, {"enabled": False, "reason": "not_local_pdf"}
+
+    try:
+        mode = resolve_text_layer_mode(env, args.text_layer)
+    except ValueError as error:
+        return None, {"enabled": False, "reason": "invalid_mode", "error": str(error)}
+
+    if mode == "never":
+        return None, {"enabled": False, "reason": "mode_never"}
+
+    # 显式指定 --backend paddle|mineru 时，用户想要 OCR；文本层分支让位。
+    configured_backend = (args.backend or env.get("LEGAL_OCR_BACKEND", "auto")).lower()
+    if configured_backend in {"paddle", "mineru"} and mode != "always":
+        return None, {"enabled": False, "reason": "explicit_ocr_backend"}
+
+    thresholds = load_thresholds(env)
+    try:
+        page_indices, total_pages = resolve_page_indices(source.path, options.pages)
+    except ValueError as error:
+        if mode == "always":
+            raise
+        return None, {"enabled": False, "reason": "invalid_pages", "error": str(error)}
+
+    probe = probe_and_extract(
+        source.path,
+        page_indices=page_indices,
+        thresholds=thresholds,
+    )
+
+    decision: dict[str, Any] = {
+        "enabled": probe.usable,
+        "mode": mode,
+        "probe": probe.to_payload(),
+    }
+
+    if not probe.usable:
+        if mode == "always":
+            raise ValueError(
+                f"--text-layer always 但 PDF 文本层不可用：reason={probe.reason}；"
+                f"如需走 OCR 请改用 --text-layer auto 或 --text-layer never"
+            )
+        return None, decision
+
+    metadata_payload = {
+        "processing": {
+            "text_layer": probe.to_payload(),
+        },
+    }
+    backend_result = BackendResult(
+        backend="text_layer",
+        mode="native_pdf_text",
+        provider="pypdfium2",
+        markdown=probe.text,
+        images=[],
+        batches=[],
+        metadata=metadata_payload,
+        backend_result_dir=None,
+    )
+    return backend_result, decision
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     env = load_env()
@@ -372,6 +616,48 @@ def main(argv: list[str] | None = None) -> int:
     temp_root = Path(tempfile.mkdtemp(prefix="legal_ocr_"))
     attempts: list[dict[str, str]] = []
     try:
+        # ----- 文本层直读分支（先于 OCR 后端） -----
+        # 仅本地 PDF：先看 PDF 是否带可用的原生文本层，达标则直接抽文字、跳过 OCR。
+        # 不达标或被关闭时继续走下方 OCR 后端循环。
+        try:
+            text_layer_result, text_layer_decision = maybe_probe_text_layer(
+                source=source,
+                env=env,
+                args=args,
+                options=options,
+            )
+        except ValueError as error:
+            print(error, file=sys.stderr)
+            return 2
+
+        if text_layer_result is not None:
+            attempts.append({"backend": "text_layer", "status": "success"})
+            # 文本层分支没有 backend_result_dir；用 route 的 notes 留痕便于 archive。
+            text_layer_route = RouteDecision(
+                preferred="text_layer",
+                candidates=["text_layer"],
+                reason="PDF 原生文本层质量达标，直接抽取文字跳过 OCR",
+                fallback_allowed=False,
+                notes=[f"text_layer probe reason={text_layer_decision.get('probe', {}).get('reason')}"],
+            )
+            return finalize_conversion(
+                source=source,
+                backend_result=text_layer_result,
+                route=text_layer_route,
+                attempts=attempts,
+                attempt_assets_dir=None,
+                output_md_path=output_md_path,
+                output_images_dir=output_images_dir,
+                archive_name=archive_name,
+                args=args,
+                env=env,
+                postprocess_enabled=postprocess_enabled,
+                configured_legal_terms_mode=configured_legal_terms_mode,
+                no_archive=args.no_archive,
+                extra_metadata={"text_layer": text_layer_decision},
+            )
+
+        # ----- OCR 后端分支（PaddleOCR / MinerU） -----
         last_error: Exception | None = None
         for attempt_index, backend_name in enumerate(route.candidates):
             try:
@@ -383,110 +669,29 @@ def main(argv: list[str] | None = None) -> int:
                     temp_root=temp_root,
                 )
                 attempts.append({"backend": backend_name, "status": "success"})
-                raw_markdown = backend_result.markdown.strip()
-                if postprocess_enabled:
-                    working_markdown = raw_markdown
-                    postprocess_log: list[dict[str, str]] = []
-                    mode = configured_legal_terms_mode
-                    legal_context = {
-                        "mode": mode,
-                        "enabled": False,
-                        "detection": None,
-                    }
-                    if mode == "auto":
-                        detection = detect_legal_context(working_markdown, source_name=source.file_name)
-                        legal_context["detection"] = detection
-                        legal_context["enabled"] = bool(detection["is_legal"])
-                        if not detection["is_legal"]:
-                            postprocess_log.append(
-                                {
-                                    "action": "legal_terms_skip",
-                                    "category": "legal_context_auto",
-                                    "description": "未检测到足够法律文书信号，跳过法律术语优化",
-                                    "score": str(detection["score"]),
-                                }
-                            )
-                    elif mode == "always":
-                        legal_context["enabled"] = True
 
-                    if legal_context["enabled"]:
-                        legal_terms_result = run_legal_terms_postprocess(
-                            working_markdown,
-                            custom_terms_path=env.get("LEGAL_OCR_CUSTOM_TERMS_PATH"),
-                        )
-                        working_markdown = legal_terms_result.text
-                        postprocess_log.extend(legal_terms_result.log)
+                # 若 PDF 文本层分支被探测但放弃（mode=auto 且质量不达标），
+                # 把诊断写进 metadata，方便后续复盘为什么走了 OCR。
+                text_layer_meta: dict[str, Any] | None = None
+                if source.suffix == ".pdf" and not source.is_url:
+                    text_layer_meta = {"text_layer": text_layer_decision}
 
-                    if should_line_merge(env, args.no_line_merge):
-                        linebreak_result = run_linebreak_postprocess(working_markdown)
-                        working_markdown = linebreak_result.text
-                        postprocess_log.extend(linebreak_result.log)
-
-                    postprocessed = run_basic_postprocess(working_markdown)
-                    final_markdown = postprocessed.text
-                    postprocess_log.extend(postprocessed.log)
-                else:
-                    final_markdown = raw_markdown
-                    postprocess_log = []
-                    legal_context = {
-                        "mode": "disabled",
-                        "enabled": False,
-                        "detection": None,
-                    }
-
-                write_text(output_md_path, final_markdown)
-                if copy_attempt_assets(attempt_assets_dir, output_images_dir):
-                    update_image_paths(backend_result.images, output_images_dir)
-
-                result_json = build_result_payload(
+                return finalize_conversion(
                     source=source,
                     backend_result=backend_result,
                     route=route,
                     attempts=attempts,
-                    raw_markdown=raw_markdown,
-                    final_markdown=final_markdown,
-                    postprocess_log=postprocess_log,
+                    attempt_assets_dir=attempt_assets_dir,
+                    output_md_path=output_md_path,
+                    output_images_dir=output_images_dir,
+                    archive_name=archive_name,
+                    args=args,
+                    env=env,
                     postprocess_enabled=postprocess_enabled,
-                    legal_context=legal_context,
+                    configured_legal_terms_mode=configured_legal_terms_mode,
+                    no_archive=args.no_archive,
+                    extra_metadata=text_layer_meta,
                 )
-                metadata = {
-                    "created_at": datetime.now().isoformat(timespec="seconds"),
-                    "source": source_json(source),
-                    "backend": result_json["backend"],
-                    "route": result_json["route"],
-                    "output_markdown": str(output_md_path),
-                    "image_output_dir": str(output_images_dir) if output_images_dir.exists() else None,
-                    "postprocess_enabled": postprocess_enabled,
-                    "legal_context": result_json["postprocess"]["legal_context"],
-                    "postprocess_log": postprocess_log,
-                    "backend_metadata": backend_result.metadata,
-                }
-
-                archive_path: Path | None = None
-                if not args.no_archive:
-                    archive_path = build_archive(
-                        source=source,
-                        archive_name=archive_name,
-                        output_md_path=output_md_path,
-                        output_images_dir=output_images_dir,
-                        raw_markdown=raw_markdown,
-                        result_json=result_json,
-                        metadata=metadata,
-                        backend_result_dir=backend_result.backend_result_dir,
-                    )
-
-                print("转换完成")
-                print(f"Markdown: {output_md_path}")
-                if output_images_dir.exists():
-                    print(f"图片目录: {output_images_dir}")
-                if archive_path:
-                    print(f"Archive: {archive_path}")
-                print(f"后端: {backend_result.backend} ({backend_result.mode})")
-                # 输出实际使用的模型名，供上游 run_ocr.py 解析
-                _model = (backend_result.metadata or {}).get("config", {}).get("model")
-                if _model:
-                    print(f"OCR_MODEL: {_model}")
-                return 0
             except Exception as error:  # noqa: BLE001
                 category = classify_backend_error(error)
                 has_next_backend = attempt_index < len(route.candidates) - 1

--- a/skills/legal-ocr/scripts/text_layer.py
+++ b/skills/legal-ocr/scripts/text_layer.py
@@ -1,0 +1,385 @@
+"""PDF 原生文本层探测与抽取。
+
+legal-ocr 进入 OCR 后端（PaddleOCR / MinerU）之前，先用本模块判断 PDF 是否已带
+可用的原生文本层。文本层质量达标时直接抽取文字、复用既有 post-process 转 Markdown，
+跳过 OCR；质量差或无文本层才走 OCR。
+
+设计动机见 `references/text-layer-detection.md` 与 DECISIONS.md「文本层质量阈值」段。
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:
+    import pypdfium2 as pdfium
+except ImportError as error:  # pragma: no cover - pypdfium2 is required by pdf_tools
+    print("缺少依赖: pypdfium2", flush=True)
+    print("请使用: uv run scripts/convert.py <input>", flush=True)
+    raise SystemExit(1) from error
+
+from common import (  # noqa: E402
+    first_non_empty,
+    parse_positive_float,
+    parse_positive_int,
+)
+from pdf_tools import parse_pages_spec  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# 字符分类
+# ---------------------------------------------------------------------------
+
+CJK_RE = re.compile(r"[一-鿿]")  # CJK Unified Ideographs（中文主体）
+PUA_RE = re.compile(
+    # 私用区字符：自定义字体（CID 字体）常把字形映射到 PUA，
+    # 抽出来的文本对人类不可读，是「文本层看似有实则烂」的典型信号。
+    r"[-"
+    r"\U000f0000-\U000ffffd"
+    r"\U00100000-\U0010fffd]"
+)
+# 常见合法标点 / 空白（中英文）。注意 PUA 不在内。
+COMMON_PUNCT_RE = re.compile(
+    r"["
+    r"　-〿"  # CJK Symbols and Punctuation（。、「」、【】…）
+    r"＀-￯"  # Halfwidth and Fullwidth Forms（！，：；？）
+    r" -⁯"  # General Punctuation（—…""）
+    r"!-/:-@\[-`{-~"  # ASCII 标点
+    r"\s]"
+)
+REPLACEMENT_CHAR = "�"  # Unicode 替换字符，解码失败时出现
+
+
+@dataclass(frozen=True)
+class CharStats:
+    total_non_space: int
+    cjk: int
+    good: int  # CJK + ASCII 字母数字 + 常见标点
+    pua: int
+    replacement: int
+
+
+@dataclass(frozen=True)
+class TextLayerMetrics:
+    page_count: int  # PDF 总页数
+    pages_probed: int  # 实际探测页数（按 --pages 截取后）
+    pages_with_text: int  # 抽出非空文本的页数
+    total_chars: int  # 非空白字符总数（text_layer 视角）
+    total_cjk: int  # CJK 字符总数
+    good_chars: int
+    pua_chars: int
+    replacement_chars: int
+    avg_cjk_per_text_page: float  # 文本页的平均 CJK 字符数
+    text_coverage: float  # pages_with_text / pages_probed
+    garbled_ratio: float  # (total - good) / total，越高越脏
+
+
+@dataclass
+class TextLayerThresholds:
+    min_coverage: float
+    min_chars_per_text_page: float  # 文本页 CJK 平均下限
+    max_garbled_ratio: float
+    min_total_chars: int
+
+    def as_dict(self) -> dict[str, float | int]:
+        return {
+            "min_coverage": self.min_coverage,
+            "min_chars_per_text_page": self.min_chars_per_text_page,
+            "max_garbled_ratio": self.max_garbled_ratio,
+            "min_total_chars": self.min_total_chars,
+        }
+
+
+@dataclass
+class TextLayerProbe:
+    usable: bool
+    reason: str  # 机器可读的简短结果标签（text_layer_ok / no_text / low_coverage / ...）
+    page_indices: list[int] = field(default_factory=list)
+    metrics: TextLayerMetrics | None = None
+    thresholds: TextLayerThresholds | None = None
+    text: str = ""  # 抽取并按页拼接的全文（仅 usable=True 时填）
+
+    def to_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "usable": self.usable,
+            "reason": self.reason,
+            "page_indices": self.page_indices,
+        }
+        if self.metrics is not None:
+            payload["metrics"] = {
+                "page_count": self.metrics.page_count,
+                "pages_probed": self.metrics.pages_probed,
+                "pages_with_text": self.metrics.pages_with_text,
+                "total_chars": self.metrics.total_chars,
+                "total_cjk": self.metrics.total_cjk,
+                "good_chars": self.metrics.good_chars,
+                "pua_chars": self.metrics.pua_chars,
+                "replacement_chars": self.metrics.replacement_chars,
+                "avg_cjk_per_text_page": round(self.metrics.avg_cjk_per_text_page, 3),
+                "text_coverage": round(self.metrics.text_coverage, 3),
+                "garbled_ratio": round(self.metrics.garbled_ratio, 4),
+            }
+        if self.thresholds is not None:
+            payload["thresholds"] = self.thresholds.as_dict()
+        return payload
+
+
+# ---------------------------------------------------------------------------
+# 阈值加载（env / CLI 共享）
+# ---------------------------------------------------------------------------
+
+
+def load_thresholds(env: dict[str, str]) -> TextLayerThresholds:
+    """从 env 读阈值；缺失走保守默认。
+
+    默认值依据见 DECISIONS.md「文本层质量阈值（v1.5.0）」。简要：
+    - 覆盖率 0.8：允许 20% 页面是封面 / 空白页 / 印章页，剩余 80% 必须有文本。
+    - 每文本页平均 CJK ≥ 50：低于此多为零星标题或图注，不算可用的正文文本层。
+    - 乱码比例 ≤ 0.05：CID/PUA 字体抽出来字符超过 5% 就不可信。
+    - 总字符 ≥ 100：1 页以下短文档容易误判，加一道兜底。
+    """
+    return TextLayerThresholds(
+        min_coverage=_parse_ratio(
+            env, "LEGAL_OCR_TEXT_LAYER_MIN_COVERAGE", default=0.8
+        ),
+        min_chars_per_text_page=_parse_ratio(
+            env, "LEGAL_OCR_TEXT_LAYER_MIN_CHARS_PER_PAGE", default=50.0
+        ),
+        max_garbled_ratio=_parse_ratio(
+            env, "LEGAL_OCR_TEXT_LAYER_MAX_GARBLE_RATIO", default=0.05
+        ),
+        min_total_chars=parse_positive_int(
+            env.get("LEGAL_OCR_TEXT_LAYER_MIN_TOTAL_CHARS"), default=100
+        ),
+    )
+
+
+def _parse_ratio(env: dict[str, str], key: str, default: float) -> float:
+    raw = first_non_empty(env, key)
+    if not raw:
+        return default
+    try:
+        value = float(raw.strip())
+    except ValueError as error:
+        raise ValueError(f"{key} 必须是数字：{raw!r}") from error
+    if value < 0:
+        raise ValueError(f"{key} 不能为负：{value}")
+    return value
+
+
+# ---------------------------------------------------------------------------
+# 字符分类实现
+# ---------------------------------------------------------------------------
+
+
+def classify_chars(text: str) -> CharStats:
+    """逐字符统计合法 / CJK / PUA / 替换字符 / 其他。
+
+    PUA 与替换字符在「合法字符」之外单独计数，便于诊断 CID 字体问题。
+    其他（既非 CJK、ASCII 字母数字、也非常见标点）算「不明」，归入 garbled。
+    """
+    total = 0
+    cjk = 0
+    good = 0
+    pua = 0
+    replacement = 0
+    for ch in text:
+        if ch.isspace():
+            continue
+        total += 1
+        if ch == REPLACEMENT_CHAR:
+            replacement += 1
+            continue
+        if PUA_RE.match(ch):
+            pua += 1
+            continue
+        if CJK_RE.match(ch):
+            cjk += 1
+            good += 1
+            continue
+        code = ord(ch)
+        if (48 <= code <= 57) or (65 <= code <= 90) or (97 <= code <= 122):
+            # ASCII 数字 / 大小写字母
+            good += 1
+            continue
+        if COMMON_PUNCT_RE.match(ch):
+            good += 1
+            continue
+        # 既非 CJK / ASCII / 常见标点，也不在 PUA / 替换字符——算 garbled
+    return CharStats(
+        total_non_space=total,
+        cjk=cjk,
+        good=good,
+        pua=pua,
+        replacement=replacement,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 页码解析
+# ---------------------------------------------------------------------------
+
+
+def resolve_page_indices(
+    pdf_path: Path, pages_spec: str | None
+) -> tuple[list[int], int]:
+    """返回 (要探测的 0-based 页索引, PDF 总页数)。
+
+    pages_spec 为空时返回所有页。pages_spec 非法时抛 ValueError（由调用方处理）。
+    """
+    doc = pdfium.PdfDocument(str(pdf_path))
+    try:
+        total_pages = len(doc)
+    finally:
+        doc.close()
+    if not pages_spec:
+        return list(range(total_pages)), total_pages
+    indices = parse_pages_spec(pages_spec, total_pages)
+    return indices, total_pages
+
+
+# ---------------------------------------------------------------------------
+# 探测 + 抽取
+# ---------------------------------------------------------------------------
+
+
+def probe_and_extract(
+    pdf_path: Path,
+    *,
+    page_indices: list[int] | None,
+    thresholds: TextLayerThresholds,
+) -> TextLayerProbe:
+    """探测 PDF 文本层质量并抽取文本。
+
+    - 先按 page_indices 逐页 `page.get_textpage().get_text_range()` 取文本；
+    - 计算 coverage / garbled_ratio / avg_cjk_per_text_page；
+    - 达标时把按页拼接的全文填入 `probe.text`，`usable=True`；
+    - 不达标时 `usable=False`，`reason` 解释卡在哪条阈值，便于 archive 与日志诊断。
+    """
+    if not page_indices:
+        return TextLayerProbe(
+            usable=False,
+            reason="no_pages_to_probe",
+            thresholds=thresholds,
+        )
+
+    doc = pdfium.PdfDocument(str(pdf_path))
+    try:
+        total_pages = len(doc)
+        valid_indices = [i for i in page_indices if 0 <= i < total_pages]
+        if not valid_indices:
+            return TextLayerProbe(
+                usable=False,
+                reason="no_valid_pages",
+                thresholds=thresholds,
+            )
+        text_parts: list[str] = []
+        pages_with_text = 0
+        for idx in valid_indices:
+            page = doc.get_page(idx)
+            try:
+                textpage = page.get_textpage()
+                try:
+                    raw_text = textpage.get_text_range() or ""
+                finally:
+                    textpage.close()
+            finally:
+                page.close()
+            normalized = raw_text.replace("\r\n", "\n").replace("\r", "\n").strip()
+            if normalized:
+                pages_with_text += 1
+                text_parts.append(normalized)
+    finally:
+        doc.close()
+
+    joined = "\n\n".join(text_parts)
+    stats = classify_chars(joined)
+    pages_probed = len(valid_indices)
+    avg_cjk = (stats.cjk / pages_with_text) if pages_with_text else 0.0
+    coverage = pages_with_text / pages_probed if pages_probed else 0.0
+    garbled = (
+        1.0 - (stats.good / stats.total_non_space)
+        if stats.total_non_space
+        else 1.0
+    )
+    metrics = TextLayerMetrics(
+        page_count=total_pages,
+        pages_probed=pages_probed,
+        pages_with_text=pages_with_text,
+        total_chars=stats.total_non_space,
+        total_cjk=stats.cjk,
+        good_chars=stats.good,
+        pua_chars=stats.pua,
+        replacement_chars=stats.replacement,
+        avg_cjk_per_text_page=avg_cjk,
+        text_coverage=coverage,
+        garbled_ratio=garbled,
+    )
+
+    if pages_with_text == 0:
+        reason = "no_text_layer"
+    elif coverage < thresholds.min_coverage:
+        reason = "low_coverage"
+    elif stats.total_non_space < thresholds.min_total_chars:
+        reason = "too_few_chars"
+    elif avg_cjk < thresholds.min_chars_per_text_page and stats.cjk < stats.total_non_space:
+        # 当 CJK 占比本身就低（纯英文 PDF），用 avg_cjk 卡会误判；
+        # 加 `and stats.cjk < stats.total_non_space` 让纯 ASCII 文档走 good_chars 路径
+        reason = "low_cjk_density"
+    elif garbled > thresholds.max_garbled_ratio:
+        reason = "high_garbled_ratio"
+    else:
+        reason = "text_layer_ok"
+
+    usable = reason == "text_layer_ok"
+    return TextLayerProbe(
+        usable=usable,
+        reason=reason,
+        page_indices=valid_indices,
+        metrics=metrics,
+        thresholds=thresholds,
+        text=joined if usable else "",
+    )
+
+
+# ---------------------------------------------------------------------------
+# 决策（CLI + env 合并）
+# ---------------------------------------------------------------------------
+
+
+TEXT_LAYER_MODES = ("auto", "never", "always")
+
+
+def resolve_text_layer_mode(
+    env: dict[str, str],
+    cli_value: str | None,
+) -> str:
+    """合并 CLI / env 决定文本层分支模式。
+
+    - 优先级：CLI `--text-layer` > env `LEGAL_OCR_TEXT_LAYER` > 默认 `auto`。
+    - 接受 auto / never / always 以及 0/1/true/false 等布尔别名（兼容老配置）。
+    """
+    raw = (cli_value or first_non_empty(env, "LEGAL_OCR_TEXT_LAYER") or "auto").strip().lower()
+    aliases = {
+        "auto": "auto",
+        "always": "always",
+        "force": "always",
+        "1": "always",
+        "true": "always",
+        "yes": "always",
+        "on": "always",
+        "never": "never",
+        "off": "never",
+        "0": "never",
+        "false": "never",
+        "no": "never",
+    }
+    if raw not in aliases:
+        raise ValueError(
+            "LEGAL_OCR_TEXT_LAYER 仅支持 auto / never / always，"
+            f"或命令行 --text-layer auto|never|always；收到：{raw!r}"
+        )
+    return aliases[raw]


### PR DESCRIPTION
## 是什么

legal-ocr 新增 PDF 原生文本层双路径分支。进入 OCR 后端（PaddleOCR / MinerU）之前，先探测 PDF 是否已带可用的原生文本层；达标直接抽取文字转 Markdown，复用既有 post-process；不达标透明回退到 OCR 候选链。

## 为什么

法律场景里法院电子送达判决书、电子合同、政府公文等相当一部分 PDF 本就带可靠文本层。直读比 OCR 更准（原生文本 100% vs OCR 95-99%）、更快（秒级 vs 分钟级）、更省（不耗 API 额度）。

借鉴 DataInfra-RedactionEverything 调研 Part B §一的文本密度判定思路，**不引入 DataInfra 任何代码**（AGPL 许可证隔离），实现从零写。

## 怎么用

### 默认行为（无需改命令）

```bash
uv run scripts/convert.py judgment.pdf
# 如果 PDF 带可用文本层 → 后端: text_layer (native_pdf_text)
# 否则 → 后端: paddle / mineru（旧行为）
```

### 新参数

| 参数 / env | 默认 | 含义 |
|------------|------|------|
| `--text-layer auto\|never\|always` / `LEGAL_OCR_TEXT_LAYER` | `auto` | `auto`=达标走 / 不达标回退；`never`=强制 OCR；`always`=强制文本层，不可用即 exit=2 |
| `LEGAL_OCR_TEXT_LAYER_MIN_COVERAGE` | `0.8` | 文本页覆盖率下限 |
| `LEGAL_OCR_TEXT_LAYER_MIN_CHARS_PER_PAGE` | `50` | 文本页平均 CJK 字符下限 |
| `LEGAL_OCR_TEXT_LAYER_MAX_GARBLE_RATIO` | `0.05` | PUA + 替换字符 + 非常见字符占比上限 |
| `LEGAL_OCR_TEXT_LAYER_MIN_TOTAL_CHARS` | `100` | 非空白字符总数下限 |

### 与 `--backend` 的优先级

- `--backend auto` + `--text-layer auto`（双默认）：最优路径。
- `--backend paddle|mineru`：视为用户显式想要 OCR，跳过文本层（除非同时设 `--text-layer always` 强制覆盖）。

## 自造样本烟测

造两份本地样本验证分流：

| 样本 | 命令 | 期望 | 实际 |
|------|------|------|------|
| `clean_text_layer.pdf`（reportlab + STHeiti，3 页中文判决片段） | 默认 | 走文本层 | ✅ coverage=1.0、cjk/page=112、garbled=0、后端=text_layer |
| `scanned_no_text_layer.pdf`（PIL image-only PDF） | 默认 | 回退 OCR | ✅ reason=no_text_layer、后端=mineru (light) |
| `scanned + --text-layer always` | 强制文本层 | exit=2 + 清晰报错 | ✅ 报错文案清晰 |
| `clean + --text-layer never` | 强制 OCR | 跳过文本层 | ✅ 后端=mineru (light) |

archive 的 `metadata.json` 多出 `text_layer` 字段，记录 probe 全量指标（page_count / coverage / garbled_ratio / thresholds / reason），无论是否走文本层都写，便于复盘。

## 改动清单

| 文件 | 类型 | 行数 |
|------|------|------|
| `skills/legal-ocr/scripts/text_layer.py` | 新增 | 385 行 |
| `skills/legal-ocr/scripts/convert.py` | 修改 | +258 / -89 |
| `skills/legal-ocr/references/text-layer-detection.md` | 新增 | 159 行 |
| `skills/legal-ocr/CHANGELOG.md` | 修改 | +69 行（v1.5.0 段） |
| `skills/legal-ocr/SKILL.md` | 修改 | +40 / -3（版本 → 1.5.0、新章节、参数表） |
| `skills/legal-ocr/config/.env.example` | 修改 | +16 行（顶部加 `LEGAL_OCR_TEXT_LAYER*` 配置块） |

## 实现要点

- **共享 post-process**：文本层分支与 OCR 分支共用 `run_postprocess_pipeline` + `finalize_conversion`，输出风格完全一致。
- **合成 BackendResult**：文本层结果以 `BackendResult(backend='text_layer', mode='native_pdf_text', provider='pypdfium2')` 形式进入既有 archive 流水线，无新代码路径。
- **字符分类**：5 类（CJK / PUA / 替换字符 / 常见标点 / 不明字符）→ `garbled_ratio` 抓 CID 字体陷阱。
- **5 条拒绝规则**（按顺序检查，第一条命中即拒绝）：`no_text_layer` / `low_coverage` / `too_few_chars` / `low_cjk_density`（带 ASCII 兜底防误杀纯英文 PDF）/ `high_garbled_ratio`。

## 不在 diff 里

- `skills/legal-ocr/TASKS.md` / `DECISIONS.md`：仓库策略（commit 6582daf）gitignored，本地维护。
- `.claude/`：session-local 协议文件与权限配置。
- `archive/`：gitignored。

## 阈值默认值的保守性

阈值是直觉驱动的保守默认，**未经真实卷宗校准**。设计原则是「宁可漏走文本层（fallback 到 OCR 也只是慢一点），也不要错走文本层（输出乱码、用户没察觉）」。理想校准做法（收集 50-100 份真实法律 PDF、人工标注、跑 ROC）写进了 TASKS.md / DECISIONS.md / references/text-layer-detection.md 的「待校准」段。

如果用户拿到真实卷宗发现误判（应该走 OCR 的走了文本层，或反之），反馈指标和样本，再调阈值或加新规则。

## 兼容性

- **完全向后兼容**：默认行为升级，不可达情况自动回退 OCR。
- **强制旧行为**：`--text-layer never` 完全等价 v1.4.3。
- **archive 结构兼容**：仅多出 `metadata.json.text_layer` 字段。

## 关联

- 任务源：legal-ocr TASKS.md「PDF 文本层双路径」（local-only）
- 调研缘由：260707 DataInfra-RedactionEverything 调研 Part B §一
- 决策记录：legal-ocr DECISIONS.md「文本层质量阈值（v1.5.0）」段（local-only）
- Worker session：`.claude/agent-sessions/w1-legal-ocr-textlayer/`（RESULT.md + PATCH_SUMMARY.md）