### PR TITLE
[fix] md2word v1.1.5 中文撇号+脚注星号 inline 解析

### DIFF
--- a/skills/md2word/CHANGELOG.md
+++ b/skills/md2word/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 本文件记录 md2word 技能的所有重要变更。
 
+## [1.1.5] - 2026-07-11
+
+### 修复
+- **脚注 markdown 星号进 XML（footnote_handler）**：原实现把脚注 text 直接 `_xml_escape` 塞进单个 `<w:t>`，`*需律师现场确认*` 的星号原样进 footnotes.xml，Word 显示字面星号。新增 `_footnote_text_to_runs_xml()`：解析 `**bold**`/`*italic*`/`` `code` `` 转 Word runs（`<w:b/>`/`<w:i/>`/Consolas 等宽），既不显示字面星号、又保留斜体/粗体/代码格式。不处理 `_italic_`（避免下划线变量名误判）、嵌套与 `[link](url)`（留 follow-up）。
+- **中文撇号误判为英文所有格（formatter.py isalpha）**：`convert_quotes_to_chinese` 原用 `prev_c.isalpha() and next_c.isalpha()` 保留英文缩写/所有格撇号（don't/O'Brien），但 `'需'.isalpha()` 在 Python 返回 True（中文属 Unicode Lo），导致「中文'中文」被误判为英文所有格、本该转中文单引号 ‘’ 却保留 ASCII `'`。修：加 `.isascii()` 限定，只 ASCII 字母-撇号-ASCII 字母保留。
+
+### 验证（眼见为实）
+- 单元测试：footnote runs 6 case ALL PASS（`*x*`→`<w:i/>`、`**x**`→`<w:b/>`、无字面星号；code/空/普通文本 OK）；convert_quotes_to_chinese 6 case（中文边界→中文单引号 ‘’；don't/O'Brien/API's→保留 ASCII `'`）。
+- 集成验证：造含中文撇号 + 星号脚注的 md 转 docx（legal preset, footnote 模式）—— document.xml `需律师现场确认`→中文单引号、don't/API's 保留 ASCII；footnotes.xml 无字面 `*`、含 `<w:i/>`/`<w:b/>`、脚注拆 runs。
+
 ## [1.1.4] - 2026-07-09
 
 ### 改进

--- a/skills/md2word/scripts/footnote_handler.py
+++ b/skills/md2word/scripts/footnote_handler.py
@@ -144,6 +144,56 @@ def _xml_escape(t):
     return t.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
 
 
+# 脚注 markdown inline 强调 token（**bold** / *italic* / `code`）；
+# 不处理 _italic_（避免下划线变量名误判），不处理嵌套，不处理 [link](url)（留 follow-up）。
+_FN_INLINE_TOKEN_RE = re.compile(r'(\*\*.+?\*\*|\*.+?\*|`.+?`)')
+
+
+def _footnote_text_to_runs_xml(text):
+    """把脚注 text 的 markdown inline 强调（**bold**/*italic*/`code`）转为 Word runs XML 片段。
+
+    每个 segment 一个 <w:r>，base rPr 含 sz=18（脚注小字）；bold 加 <w:b/>，
+    italic 加 <w:i/>，code 加 Consolas 等宽字体。第一个 run 文本前缀一个空格
+    （对齐原 ' %s' 前导空格，与 footnoteRef 拉开间距）。返回 runs XML（不含 <w:p>）。
+
+    bug fix：原实现把 text 直接 _xml_escape 塞进单个 <w:t>，*需律师现场确认* 的
+    星号原样进 XML，Word 显示字面星号。本函数解析强调标记转 run，既不显示字面
+    星号、又保留斜体/粗体/代码格式。
+    """
+    runs = []
+    first = True
+    for part in _FN_INLINE_TOKEN_RE.split(text):
+        if not part:
+            continue
+        bold = italic = code = False
+        seg = part
+        if len(part) >= 4 and part.startswith('**') and part.endswith('**'):
+            bold = True
+            seg = part[2:-2]
+        elif len(part) >= 2 and part.startswith('*') and part.endswith('*'):
+            italic = True
+            seg = part[1:-1]
+        elif len(part) >= 2 and part.startswith('`') and part.endswith('`'):
+            code = True
+            seg = part[1:-1]
+        rpr_parts = ['<w:sz w:val="18"/>']
+        if bold:
+            rpr_parts.append('<w:b/>')
+        if italic:
+            rpr_parts.append('<w:i/>')
+        if code:
+            rpr_parts.append('<w:rFonts w:ascii="Consolas" w:hAnsi="Consolas"/>')
+        rpr = '<w:rPr>' + ''.join(rpr_parts) + '</w:rPr>'
+        prefix = ' ' if first else ''
+        first = False
+        runs.append('<w:r>%s<w:t xml:space="preserve">%s%s</w:t></w:r>'
+                    % (rpr, prefix, _xml_escape(seg)))
+    if not runs:
+        runs.append('<w:r><w:rPr><w:sz w:val="18"/></w:rPr>'
+                    '<w:t xml:space="preserve"> </w:t></w:r>')
+    return ''.join(runs)
+
+
 def _inject_footnotes_into_docx(docx_path, refs):
     """post-process：把脚注 part 注入已保存的 docx（纯 zip 操作，不依赖 python-docx part API）。
 
@@ -169,8 +219,8 @@ def _inject_footnotes_into_docx(docx_path, refs):
         fn_items.append(
             '<w:footnote w:id="%d"><w:p>'
             '<w:r><w:rPr><w:vertAlign w:val="superscript"/><w:sz w:val="18"/></w:rPr><w:footnoteRef/></w:r>'
-            '<w:r><w:rPr><w:sz w:val="18"/></w:rPr><w:t xml:space="preserve"> %s</w:t></w:r>'
-            '</w:p></w:footnote>' % (seq, _xml_escape(text))
+            '%s'
+            '</w:p></w:footnote>' % (seq, _footnote_text_to_runs_xml(text))
         )
     footnotes_xml = (
         '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'

--- a/skills/md2word/scripts/formatter.py
+++ b/skills/md2word/scripts/formatter.py
@@ -75,7 +75,10 @@ def convert_quotes_to_chinese(text):
             # 保留英文缩写/所有格中的撇号：字母-撇号-字母
             prev_c = text[i - 1] if i > 0 else ''
             next_c = text[i + 1] if i + 1 < len(text) else ''
-            if prev_c.isalpha() and next_c.isalpha():
+            # 只对 ASCII 字母保留撇号（英文缩写/所有格 don't/it's/O'Brien）。
+            # 中文 isalpha() 也返回 True，必须 isascii() 限定，否则「中文'中文」
+            # 被误判为英文所有格、本该转中文单引号却保留 ASCII 撇号（bug fix）。
+            if prev_c.isascii() and prev_c.isalpha() and next_c.isascii() and next_c.isalpha():
                 result.append("'")
                 i += 1
                 continue


### PR DESCRIPTION
formatter isascii（中文 isalpha True 致误判英文所有格）+ footnote _footnote_text_to_runs_xml（星号原样进 XML）。单元+集成 docx 验证 PASS。clean branch（弃含混入 mao 的 fix/md2word-isalpha-footnote）。