### PR TITLE
fix(svg-book-illustrator): constrain container overlap metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@
 
 | 日期       | 类型     | Skill                                             | 版本   | 更新要点                                                                                           |
 | :--------- | :------- | :------------------------------------------------ | :----- | :------------------------------------------------------------------------------------------------- |
+| 2026-07-16 | 更新     | [svg-book-illustrator](skills/svg-book-illustrator/) | v1.8.10（待发布） | 对齐 writing-reviewer v0.16+ shape containment：容器只允许 `container + 单图唯一 id + 明示承载关系的 note + 非透明 hex/rgb/hsl fill`，producer 拒绝 namespace/继承色/paint server/泛化说明/任意 role；实际包含仍由真实浏览器 render gate 留证 |
 | 2026-07-15 | 新上传   | [apple-smart-schedule](skills/apple-smart-schedule/) | v0.1.0 | 苹果智能日程提醒：自然语言(机票/高铁/开庭/会议/截止等)或票据截图自动建苹果日历事件 + 按事件类型智能提前提醒；仅 macOS，经 iCloud 同步 iPhone/iPad |
-| 2026-07-14 | 更新     | [svg-book-illustrator](skills/svg-book-illustrator/) | v1.8.9（待发布） | 修复生成器/模板与源契约冲突，新增稳定图身份、单一外部字体 CSS、双渲染器接线及 PR/main source contract；PR #51 已合并且 `main` source contract 已通过，待发布资产可用后完成 |
 | 2026-07-06 | 更新     | [skill-manager](skills/skill-manager/) | v1.6.0 | 新增 QoderWork 支持：自动识别 `~/.qoderworkcn/skills/` 为安装目标，`~/.qoderworkcn` 及其子目录调用时自动检测；`target.sh` 和 `install.sh` 统一扩展 `.qoderworkcn` |
 | 2026-06-23 | 更新     | [de-ai-polish](skills/de-ai-polish/) | v2.0.1 | Voice Calibration 补齐样本使用边界与匹配门禁：仅使用用户确认样本，禁止冒充作者身份、复制样本原句或引入样本事实；评分门禁新增 profile 偏离、反例复现、样本复刻、事实污染回炉规则 |
 | 2026-06-22 | 新上传   | [invoice-organizer](skills/invoice-organizer/) | v0.1.1 | 发票/票据 PDF 整理与报销清单：pdftotext 提取文本，按购买方抬头匹配所属案件项目，向上回溯读取项目上下文自动填补事由/案号/日期/路线，复制归档（原件不动）并出具报销清单（可切换消费清单/对账流水）；含 Hard Fail 验收标准 |
@@ -449,8 +449,8 @@
 <td>工具·配图</td>
 <td style="word-break:break-word">书籍/文章 SVG 配图生成工具，专注于架构图、流程图、层次图等专业技术配图，针对印刷出版场景优化，字号间距按物理尺寸反推</td>
 <td style="text-align:center">MIT</td>
-<td style="text-align:center">v1.8.9</td>
-<td style="text-align:center"><a href="https://github.com/cat-xierluo/legal-skills/releases/download/v2026.07.20/svg-book-illustrator-1.8.9.zip">下载</a></td>
+<td style="text-align:center">v1.8.10（候选）</td>
+<td style="text-align:center">待发布（v1.8.10 zip）</td>
 <td></td>
 </tr>
 <tr>

--- a/skills/svg-book-illustrator/CHANGELOG.md
+++ b/skills/svg-book-illustrator/CHANGELOG.md
@@ -1,5 +1,30 @@
 # CHANGELOG
 
+## [v1.8.10] - 2026-07-16
+
+> **发布状态：候选。** 本地 producer contract 已通过，待 PR / `main` source check 与 release asset；不得据此宣称已发布。
+
+### 新增
+
+- 对齐 writing-reviewer v0.16+ 的 shape containment 语义：只有确属承载内层 shape 的外层 area shape 才能声明 `data-overlap-role="container"`，且必须同时绑定单图唯一的安全原生 `id`、明示承载关系的 `data-overlap-note` 与可静态证明非透明的 hex/rgb/hsl `fill`。
+- 在生成与审查文档中明确职责边界：producer 只静态检查声明是否可审计；实际几何是否形成合法包含，由 writing-reviewer 的真实浏览器 render gate 判定并记录 outer / inner / reason。
+
+### 修复
+
+- 修复 producer contract 对 `data-overlap-role` 完全 fail-open 的问题；旧检查器会放过缺/重复/namespaced id、缺失/空白/加前缀泛化/孤立/namespaced note、透明色/继承色/零 opacity 容器、`decoration`、自造 role，以及把声明写在非 shape 元素上的候选。
+- 禁止用 `data-overlap-role="decoration"`、`data-allow-overlap` 或任意 role 掩盖意外重叠；意外重叠仍须改坐标、尺寸或层级。
+
+### 技术优化
+
+- 扩展 `scripts/tests/test_svg_producer_contract.py` 的统一断言，使 5 个生成器产物、10 个模板 SVG 块和已知坏样本共同受容器元数据契约约束。
+- 新增 1 个容器语义回归测试，覆盖 1 个 canonical 合法声明 + 3 个合法 fill 变体，以及 28 类坏样本：缺/不安全/带首尾空白/重复/namespaced id，缺失/空白/短或加前缀泛化/孤立/namespaced note，decoration/任意 role、用装饰语义 note 伪装 container，通用 overlap 逃生口，非 area shape，以及 `none`/零 alpha/继承/paint server/未知或非法 rgb/hsl fill、零 opacity/fill-opacity。
+
+### 验证
+
+- TDD RED：首轮与四次独立契约复核累计暴露 28 类 fail-open；后续每一类均先落最小坏样本，再收紧统一 producer contract。
+- TDD GREEN：目标测试通过；`python3 -m unittest discover -s scripts/tests -p 'test_*.py' -v` → 5 tests passed，全部现有生成器与模板回归保持绿色。
+- 本版未新增另一个几何计算器，也未把静态通过写成视觉通过；writing-reviewer render gate 仍是 shape 包含的最终几何证据源。
+
 ## [v1.8.9] - 2026-07-14
 
 > **发布状态：候选。** PR #51 已于 2026-07-14 squash merge，`main` 上 source producer contract 已通过；v1.8.9 release zip 当前仍不可用，因此 T001 保持未完成。

--- a/skills/svg-book-illustrator/DECISIONS.md
+++ b/skills/svg-book-illustrator/DECISIONS.md
@@ -1,5 +1,37 @@
 # DECISIONS
 
+## DEC-022：shape 包含只允许可审计的 container 窄声明
+
+- 日期：2026-07-16
+- 状态：已采纳
+- 关联任务：T002
+
+### 背景
+
+writing-reviewer v0.16+ 不再把“一个 shape 完全包含另一个 shape”自动猜成合法容器，因为同一几何现象也可能来自坐标写错、遮挡或装饰底纹压住信息卡。与此同时，书籍配图确有“外层面板承载内层卡片”的正常构图；若一律阻断，会制造无法表达的误报。现有 producer contract 对所有 `data-overlap-role` 属性完全不检查，候选可用 `decoration` 或任意 role 自发隐藏问题，也可声明 `container` 却不提供稳定身份与理由，导致 producer 与 reviewer 契约断裂。
+
+### 决策
+
+1. 默认把 shape/shape 包含或重叠视为待修布局问题；先改坐标、尺寸或层级，不给候选 SVG 通用重叠逃生口。
+2. 唯一允许写入候选源的 role 是 `data-overlap-role="container"`。禁止 `decoration`、`background` 等自造 role，也禁止候选自发 `data-allow-overlap`。
+3. container 只标在 writing-reviewer 实际审计的外层 area shape（`rect` / `circle` / `ellipse` / `polygon` / `path`），并同时绑定：
+   - 单张 SVG 内唯一、无 namespace 的安全稳定 `id`；
+   - 无 namespace、至少六字、包含“承载/包含/容纳”等关系词且不能只是“这里允许重叠/覆盖”的具体 `data-overlap-note`；
+   - 可静态证明非透明的 hex/rgb/hsl `fill`；禁止 `none/transparent`、零 alpha、命名色、继承/全局关键字和无法在 producer 侧证明的 paint server，且 opacity/fill-opacity 必须大于 0。
+4. producer contract 对声明做静态 fail-closed：缺失/不安全/重复/namespaced id，缺失/空白/泛化/孤立/namespaced note，透明/继承/零 opacity、非法 role、非 area shape 声明一律失败；生成器产物、模板 SVG 块与坏样本共用同一断言。
+5. 静态元数据只证明意图可审计，不证明几何合法。最终必须由 writing-reviewer v0.16+ render gate 在真实浏览器中判断 outer 是否实际包含 inner，并把 outer / inner / reason 写入 candidate-bound evidence。
+6. 不在 producer 中复制一套浏览器几何计算器。两个几何实现会随 transform、path、字体和 renderer 演进而漂移；producer 负责生成期契约，writing-reviewer 负责 canonical source/render 验收。
+
+### 取舍
+
+- “完全禁止任何 shape 包含”最简单，但会误伤卡片嵌套等真实版式。
+- “允许 decoration / 任意 role”最灵活，却把 finding 的裁量权交回候选源，重现本次治理要解决的假绿。
+- 采用单一 container 窄声明，把意图写进源文件、把实际命中写进 evidence，同时保留真实几何门禁。
+
+### 兼容性
+
+现有 5 个生成器和 10 个模板 SVG 块均未使用 `data-overlap-role`，因此节点、坐标、渲染像素和既有产物不变。只有未来新增的容器声明受新静态契约约束；历史书稿是否补声明由各项目决定，不在本 Skill 版本中批量迁移。
+
 ## DEC-021：生产规则必须由生成产物回归测试闭环
 
 - 日期：2026-07-14

--- a/skills/svg-book-illustrator/SKILL.md
+++ b/skills/svg-book-illustrator/SKILL.md
@@ -2,7 +2,7 @@
 name: svg-book-illustrator
 homepage: https://github.com/cat-xierluo/legal-skills
 author: 杨卫薪律师（微信ywxlaw）
-version: "1.8.9"
+version: "1.8.10"
 license: MIT
 description: 书籍/文章 SVG 配图生成工具，专注于架构图、流程图、层次图等专业技术配图。当用户需要为书籍章节或正式文章生成配图、创建架构图/流程图/层次图，或提到"章节配图"、"书籍插图"、"架构图"、"流程图"时使用此技能。
 ---
@@ -69,11 +69,13 @@ python scripts/extract_svgs.py path/to/chapter.md --output output/figures/
 
 **② 图-正文论点一致性审查**：每张图回溯所在小节，核对节点数 / 层级名 / 流程方向 / 对比维度 与正文表述一致；替换 mermaid / ASCII 图时原信息（节点、关系、标注）不丢失；图注准确概括图内容，不夸大不遗漏。
 
-**③ 字宽/坐标硬算自检（v1.8.5+，先于视觉目检）**：生成器产出后，按 **CJK≈Fpx/字、Latin≈0.55Fpx/字** 估算文字宽度 ≤ 容器宽，相邻元素 y 差 ≥ 20px，viewBox H 足够——**计算闸**，防视觉目检对"轻微溢出/贴近"漏检（v1.8.5 radar 图例重叠、three-col 子卡片溢出两例均靠此抓出）。详见 `review-checklist.md` §③。
+**③ 字宽/坐标硬算自检（v1.8.5+，先于视觉目检）**：生成器产出后，按 **CJK≈Fpx/字、Latin≈0.55Fpx/字** 估算文字宽度 ≤ 容器宽，相邻元素 y 差 ≥ 20px，viewBox H 足够——**计算闸**，防视觉目检对"轻微溢出/贴近"漏检（v1.8.5 radar 图例重叠、three-col 子卡片溢出两例均靠此抓出）。详见 `references/review-checklist.md` §③。
 
 **④ 视觉目检（多模态渲染后眼检）**：SVG 用受控字体渲染为 PNG（快速预览运行 `python3 scripts/render_svg.py input.svg output.png`；高 DPI 运行 `node scripts/svg2png.js input.svg output.png 300`）后，用多模态模型逐张查——文字不溢出容器、框不重叠（间距 ≥24px）、箭头落位方向正确、字号可读（节点≥16px 副≥12px）、黑白可辨、整体美观留白合理。发现问题回改 SVG 坐标，复检直到目检通过。
 
 > **多模态生产提示**：若环境支持图像理解，④ 必须真正"看"渲染图，不能只靠 xmllint / rsvg 无警告间接验证——语法通过 ≠ 布局美观，溢出/重叠/箭头错位只有肉眼（或多模态模型）能发现。但视觉目检对"轻微溢出/贴近"易判 OK，故须先过 ③ 字宽硬算自检。
+
+**形状包含窄语义（v1.8.10+）**：默认把 shape/shape 包含或重叠当作待修布局问题，先改坐标，不得用 `data-overlap-role="decoration"`、`data-allow-overlap` 或任意自造 role 掩盖。只有外层 area shape 确实承担“面板承载内层信息卡”等容器语义时，才在外层写单图唯一的安全原生 `id`、`data-overlap-role="container"`、明示承载关系的 `data-overlap-note` 与可静态证明非透明的 hex/rgb/hsl `fill`；namespaced 假属性、透明/继承/paint server/零 opacity 容器和孤立 note 都无效。该声明只是让意图可审计，不证明几何正确；最终必须由 writing-reviewer v0.16+ render gate 以真实浏览器几何复核，并在 evidence 中记录实际命中的 outer / inner / reason。详见 `references/style-guide.md` §六与 `references/review-checklist.md` §⓪/④。
 
 **生产器契约回归（v1.8.9+）**：修改 `scripts/gen-*.py` 或 `references/layout-templates.md` 后，必须运行：
 
@@ -81,7 +83,7 @@ python scripts/extract_svgs.py path/to/chapter.md --output output/figures/
 python3 -m unittest discover -s scripts/tests -p 'test_*.py' -v
 ```
 
-只有退出码为 0 才能进入合并候选。该测试实际执行全部生成器，并检查模板文档中的全部 SVG 代码块；viewBox 必须严格为 `0 0 720 H`，根 `width` 必须为 720、`height` 必须等于 H；`data-figure-id` 必须存在、格式安全且在同一批产物中不重复；XML、`<style>`、元素 `style=`、任一元素的 `font-family`、class/CSS 变量和背景矩形任一不合规都会失败。
+只有退出码为 0 才能进入合并候选。该测试实际执行全部生成器，并检查模板文档中的全部 SVG 代码块；viewBox 必须严格为 `0 0 720 H`，根 `width` 必须为 720、`height` 必须等于 H；`data-figure-id` 必须存在、格式安全且在同一批产物中不重复；XML、`<style>`、元素 `style=`、任一元素的 `font-family`、class/CSS 变量和背景矩形任一不合规都会失败。任何 `data-overlap-role` 也必须严格满足上面的 `container + 单图唯一原生 id + 明示承载关系的 note + 外层 area shape + 非透明 hex/rgb/hsl fill` 窄契约；namespaced 属性、孤立 note、继承/透明/paint server fill、`decoration` 与自造 role 直接失败。
 
 **生产身份契约（v1.8.9+）**：下游 review / render inventory 以 SVG 根的 `data-figure-id` 绑定跨轮 finding 与渲染证据，不能再依赖“第几张图”或文件遍历顺序。5 个生成器默认从输出文件 stem 取稳定 ID，也支持显式指定：
 
@@ -139,11 +141,12 @@ python3 scripts/verify_render_font_equivalence.py
 - **画布**：**宽 720px 固定（16开 115mm 通栏物理尺寸），高度按内容裁剪**（v1.7.1）——viewBox="0 0 720 H"，H = 内容底边最大 y + 40px；**不再固定 400**（固定 400 会让内容少的图底部留白过大、SVG 下边缘离图注间距忽大忽小）。**透明背景（硬约束）**——不画背景矩形、不设底色；左右 + 顶部安全边距 40px，底部 = H − 内容底（即 40px）。底色由书页/排版提供。
 - **风格**：简洁、专业、静态（无动画、无渐变、无滤镜、无 emoji）
 - **颜色（v1.5.0 透明背景 + 内部模块多色版）**：新生成图**透明底**，配色用于 **SVG 内部不同模块 / 分支 / 方向 / 层级之间的多色柔和区分**——颜色尽量多样（一图 4-6 种甚至更多柔和模块色）。从 8 组预定义调色板（P1 雾蓝系 / P2 浅青系 / P3 嫩绿系 / P4 暖米系 / P5 浅紫系 / P6 浅粉系 / P7 暖灰系 / P8 混合柔和系）选 1 组，组内 5-6 个柔和模块色按"模块 1 取色 1、模块 2 取色 2…"依次分配，相邻模块不同色。文字色统一深灰 `#2D3436`/`#636E72` 保证可读。打印友好约束（文字 vs 所在模块填充色对比 ≥4.5:1 WCAG AA、相邻模块区分度 ≥10%、模块色明度 L*≥80、禁高饱和荧光、CMYK 不偏色、灰度差≥10%）。**仅新生成图用新配色，main 上既有 34 张白底单色 SVG 保持稳定不回改**。
-- **颜色语法硬约束**：颜色只用 `fill`/`stroke` 属性内联——**禁 `<style>` 块定义颜色、禁 `<svg>` 开标签写 font-family、禁 CSS 变量/class、禁画背景矩形**（已验证的 Obsidian 渲染 + 透明背景硬约束，详见 style-guide.md §5.4）。
-- **可视友好化配色与渲染禁忌（v1.8.7 硬约束，详见 style-guide.md §5.5）**：① **深底浅字**——深色填充（L* ≤ 50，如 `#2C5282`/`#1A202C`/G4 深档/项目 canonical 强调色）的模块内 `<text>` 必须用 `#FFFFFF`/`#EDF2F7`，**禁深底深字**；② **字色对比度**——文字 fill 与所在模块 fill 对比 ≥ 4.5:1（AA，大文本 ≥ 3:1）；③ **箭头落点**——marker 单 `id="arrow"` + `markerUnits=userSpaceOnUse` + `orient=auto`，落点 `x2 = 目标框边 − 4px`、方向指向目标节点；④ **文字完整性**——每个有标题语义的节点框都有非空 `<text>`、文字坐标在框内、fill 与模块不同色。源 T134 review 实测：图 7-6 箭头错位 / 图 11-8 字色不可辨 / 图 11-9 深蓝底深字 / 图 7-13/8-3/6-7 框内文字缺失。
-- **蓝色焦点 + 文字二档（v1.8.8 通用规则，DEC-020，详见 style-guide.md §5.0/§5.1）**：① **文字色统一深灰二档**——图内所有文字仅允许 `#2D3436`（主）/`#636E72`（次），深底走 `#FFFFFF`/`#EDF2F7`；**不再用 `#1A202C`/`#4A5568`**（收敛二档消除四档混用）。② **项目 canonical 主色（如 `#2C5282`/`#1A365D` 蓝）只用于焦点节点填充/描边，禁作文字 fill**——以色块承载强调，文字强调改用字重/字号；这是通用纪律，非项目指针（任何项目锁定主色为视觉标识时都适用）。③ **每张结构/流程图 ≥1 焦点节点**——layer/tree/flow/hub/cycle/matrix 应至少有 1 个焦点节点（canonical 主色或更深一档填充/描边）承载层次，反对纯灰平铺；纯并列清单无自然焦点时用灰阶递进 + 边框粗细区分。源法律 AI Skill 实战 DEC-114 方案 A 定调（图 1-6 灰阶 + 唯一蓝色焦点 = 层次标杆、零蓝字）。
+- **颜色语法硬约束**：颜色只用 `fill`/`stroke` 属性内联——**禁 `<style>` 块定义颜色、禁 `<svg>` 开标签写 font-family、禁 CSS 变量/class、禁画背景矩形**（已验证的 Obsidian 渲染 + 透明背景硬约束，详见 `references/style-guide.md` §5.4）。
+- **可视友好化配色与渲染禁忌（v1.8.7 硬约束，详见 `references/style-guide.md` §5.5）**：① **深底浅字**——深色填充（L* ≤ 50，如 `#2C5282`/`#1A202C`/G4 深档/项目 canonical 强调色）的模块内 `<text>` 必须用 `#FFFFFF`/`#EDF2F7`，**禁深底深字**；② **字色对比度**——文字 fill 与所在模块 fill 对比 ≥ 4.5:1（AA，大文本 ≥ 3:1）；③ **箭头落点**——marker 单 `id="arrow"` + `markerUnits=userSpaceOnUse` + `orient=auto`，落点 `x2 = 目标框边 − 4px`、方向指向目标节点；④ **文字完整性**——每个有标题语义的节点框都有非空 `<text>`、文字坐标在框内、fill 与模块不同色。源 T134 review 实测：图 7-6 箭头错位 / 图 11-8 字色不可辨 / 图 11-9 深蓝底深字 / 图 7-13/8-3/6-7 框内文字缺失。
+- **蓝色焦点 + 文字二档（v1.8.8 通用规则，DEC-020，详见 `references/style-guide.md` §5.0/§5.1）**：① **文字色统一深灰二档**——图内所有文字仅允许 `#2D3436`（主）/`#636E72`（次），深底走 `#FFFFFF`/`#EDF2F7`；**不再用 `#1A202C`/`#4A5568`**（收敛二档消除四档混用）。② **项目 canonical 主色（如 `#2C5282`/`#1A365D` 蓝）只用于焦点节点填充/描边，禁作文字 fill**——以色块承载强调，文字强调改用字重/字号；这是通用纪律，非项目指针（任何项目锁定主色为视觉标识时都适用）。③ **每张结构/流程图 ≥1 焦点节点**——layer/tree/flow/hub/cycle/matrix 应至少有 1 个焦点节点（canonical 主色或更深一档填充/描边）承载层次，反对纯灰平铺；纯并列清单无自然焦点时用灰阶递进 + 边框粗细区分。源法律 AI Skill 实战 DEC-114 方案 A 定调（图 1-6 灰阶 + 唯一蓝色焦点 = 层次标杆、零蓝字）。
 - **文字**：继承渲染环境默认无衬线字体（PingFang SC / Microsoft YaHei 落在系统层），节点标签 18px 起（16开 115mm 通栏下物理 2.88mm = 8.2pt）
 - **形状**：圆角矩形（rx="6"）、简洁箭头、最小 24px 间距
+- **形状包含**：默认修复意外重叠；只有真实承载子 shape 的外层 area shape 才声明 `data-overlap-role="container"`，并同时写单图唯一原生 `id`、明示承载关系的 `data-overlap-note` 与非透明 hex/rgb/hsl `fill`。静态契约只审声明，实际几何由 writing-reviewer render gate 审计
 - **印刷**：黑白可辨，颜色不是唯一区分手段（黑白降级仍可辨是硬约束）
 
 ---
@@ -187,7 +190,7 @@ find figures/ -name "*.svg" -exec node scripts/svg2png.js {} \;
 - 图注格式统一：**图 N-X：标题**
 - **配图密度达标**：图/节 ≥ 0.7、图/万字 ≥ 0.8
 - **图-正文一致**：节点/层级/方向/维度与正文论点吻合，替换 mermaid/ASCII 图信息无损
-- **视觉目检通过**：渲染后无溢出/重叠/箭头错位，字号可读、黑白可辨、美观
+- **视觉目检通过**：渲染后无溢出/意外重叠/箭头错位，字号可读、黑白可辨、美观；有意的 shape 包含仅走可审计 `container` 窄声明并由 writing-reviewer render gate 留证
 - 印刷友好：16开 115mm 通栏下文字 ≥8pt 清晰可读，黑白打印可辨，文字对比度 ≥4.5:1（WCAG AA），CMYK 转换不偏色
 - 配色合规（v1.5.0）：新生成图**透明背景**（无画布底色矩形）；从调色板 8 组选 1 组，组内模块色用于内部模块多色柔和区分（一图 4-6 色）、相邻模块不同色；文字色统一深灰；颜色只用 `fill`/`stroke` 属性内联；既有 34 张白底单色图保持稳定不回改
 - 可视友好化（v1.8.7）：深底（L* ≤ 50）模块内文字走浅色 `#FFFFFF`/`#EDF2F7`（禁深底深字）；文字 vs 所在模块对比 ≥ 4.5:1；箭头落点 `x2 = 目标框边 − 4px`、方向指向目标；每个有标题语义的节点框都有非空 `<text>`、坐标在框内、fill 与模块不同色（详见 style-guide §5.5）

--- a/skills/svg-book-illustrator/TASKS.md
+++ b/skills/svg-book-illustrator/TASKS.md
@@ -2,7 +2,15 @@
 
 ## 当前任务
 
-- [ ] T001：消除 SVG 生产器与 Skill 硬规则冲突（VERIFIED，PR #51 已合并且 `main` source check 已通过，待 v1.8.9 发布）
+- [ ] T002：让 SVG producer 与 writing-reviewer v0.16+ 的 shape containment 语义一致（本地 VERIFIED，待 PR / `main` source check / v1.8.10 发布）
+  - 任何候选源中的 `data-overlap-role` 只允许 `container`；禁止 `decoration`、任意自造 role 与候选自发 `data-allow-overlap`。
+  - 只有真实承载内层 shape 的外层 area shape 才能声明 container，并同时绑定单图唯一的安全原生 `id`、明示承载关系的 `data-overlap-note` 与可静态证明非透明的 hex/rgb/hsl `fill`；意外重叠必须修坐标、尺寸或层级。
+  - producer contract 必须拒绝缺失/不安全/重复/namespaced id，缺失/空白/短或加前缀泛化/孤立/namespaced note，透明/继承/paint server/零 opacity 容器、非法 role 和非 area shape 声明；生成器产物与模板 SVG 块共用同一断言。
+  - 静态声明通过不等于几何通过；最终由 writing-reviewer v0.16+ render gate 以真实浏览器几何判定，并在 evidence 中记录实际命中的 outer / inner / reason。
+  - 当前本地证据：TDD RED 累计 28 类坏样本被旧断言漏过；TDD GREEN 后目标测试通过，全量 producer contract 为 5 tests passed。
+  - 完成条件：① 分支 PR 合并；② `main` 上 `Source producer contract` 绿色；③ v1.8.10 release zip 可访问；④ writing-reviewer v0.16+ 已合并可用，且至少一组合法 container / 装饰语义绕过对照已由真实 render gate 生成 candidate-bound 跨 Skill 证据。未满足前保持未勾选。
+
+- [ ] T001：消除 SVG 生产器与 Skill 硬规则冲突（VERIFIED，PR #51 已合并且 `main` source check 已通过，待 v1.8.9 或后续版本发布）
   - 5 个生成器的最小有效输出必须是可解析 XML，并带完整 `viewBox`、`width`、`height` 和稳定 `data-figure-id`；支持默认 output stem 与显式 `--figure-id`，非法值写文件前失败。
   - 画布必须严格为 `viewBox="0 0 720 H"`、`width="720"`、`height="H"`；生成产物及全部模板 SVG 块不得包含 `<style>`、`style=`、内嵌 `font-family`、`class`、CSS 变量或画布背景矩形。
   - librsvg 与浏览器导出必须共同读取 `assets/render-fonts.css`，字体栈不得复制；受控 librsvg 与旧内嵌 style 基线 5/5 `pixel AE = 0`。
@@ -11,6 +19,6 @@
   - PR 与 `main` 推送必须由 GitHub Actions 自动运行 source producer contract；没有明确绿色 check 时保持不可合并。该 check 不替代视觉门禁。
   - 当前证据：原始 RED 暴露 15 项样式/尺寸冲突及 3 个 fail-open；身份契约 RED 再暴露 15 个 producer/template 缺 ID；4 个测试全绿（5 生成器 / 10 模板 / 16 坏样本 / ID 默认-显式-非法与批内唯一 / 双渲染器接线）；`scripts/verify_render_font_equivalence.py` 可重复证明字体交付方式与身份元数据两组对照均为 5/5 `AE = 0`。
   - 合并证据：PR #51 已于 2026-07-14 squash merge（`e32a73a6`）；`main` 上 `SVG Book Source Producer Contract` run `29323054523` 结论为 `SUCCESS`。
-  - 完成条件：① PR #51 合并✅；② `main` 上 source check 通过✅；③ v1.8.9 release zip 可访问⏳。目前发布资产仍为 `PENDING`（下载链接 404），因此不得勾选完成。
+  - 完成条件：① PR #51 合并✅；② `main` 上 source check 通过✅；③ v1.8.9 或包含相同能力的后续 release zip 可访问⏳。目前发布资产仍为 `PENDING`，因此不得勾选完成。
 
 > 本文件自 v1.8.9 建立。更早版本的任务演进保留在 `CHANGELOG.md`，不在此追补或改写历史。

--- a/skills/svg-book-illustrator/references/review-checklist.md
+++ b/skills/svg-book-illustrator/references/review-checklist.md
@@ -13,6 +13,10 @@
 - [ ] 当前项目 canonical scope 内 ID 全局唯一；推荐 `fig-chNN-sN-NN`，不能以文件遍历顺序或“第几张图”代替
 - [ ] `fig-template-*` 已在落稿前替换，生成器调用已显式传入 `--figure-id fig-chNN-sN-NN`
 - [ ] review finding、渲染截图/清单与修订复检均以同一 ID 绑定；缺失或重复时 fail-closed，不进入后续四道审查
+- [ ] 默认不存在用属性“解释掉”的 shape 重叠；意外重叠已回改坐标，而不是添加 `data-allow-overlap`、`data-overlap-role="decoration"` 或任意自造 role
+- [ ] 确有“外层 shape 承载内层 shape”语义时，只在外层 area shape 写 `data-overlap-role="container"`，并同时写单图唯一原生 `id`、至少六字且明示承载关系的 `data-overlap-note` 与非透明 hex/rgb/hsl `fill`
+- [ ] producer contract 已静态通过容器声明；这只证明元数据合规，不证明几何合法
+- [ ] writing-reviewer v0.16+ render gate 已以真实浏览器几何复核，并在 evidence 中记录实际命中的 outer / inner / reason；未命中的声明不得拿来替代修图
 
 本门禁只约束新产物；是否为历史书稿补 ID 由项目另行决定，不在本 Skill 升级中强制迁移。
 
@@ -98,7 +102,7 @@ node scripts/svg2png.js in.svg out.png 300
 **多模态模型逐张查**（看渲染 PNG，**不看 SVG 源码**）：
 
 - [ ] **文字不溢出**：所有文字落在所属容器 / 框内，不被边缘截断
-- [ ] **无重叠**：框 / 节点 / 文字互不遮挡，间距 ≥ 24px
+- [ ] **无意外重叠**：框 / 节点 / 文字互不遮挡，间距 ≥ 24px；确有容器包含语义时只走 `container + 单图唯一原生 id + 明示承载关系的 note + 非透明 hex/rgb/hsl fill` 窄声明，并核对 writing-reviewer render evidence，不把 decoration / 任意 role 当豁免
 - [ ] **箭头正确**：箭头起止落在节点边缘，方向正确，marker 不偏移
 - [ ] **箭头硬约束（v1.6.0 新增）**：SVG 源码 `grep '<marker'` 只允许**单个** `<marker id="arrow" ... markerUnits="userSpaceOnUse" orient="auto">` 定义；**禁止**多方向自造 marker（`arrV`/`arrF`/`arrG`/`arrT`/`arrR`/`arrL` 等），**禁止**为垂直 / 斜向箭头硬编码不同 `refX`/`refY`/`orient`——一个 marker 配 `orient="auto"` 通吃所有方向。所有 `marker-end` 必须引用规范 `id="arrow"`，禁止 inline `marker-end="url(#arr...)"` 自创 id。详见 style-guide §六 / DEC-011。
 - [ ] **连线清晰**：连线不穿越文字，交叉处可辨
@@ -122,7 +126,7 @@ node scripts/svg2png.js in.svg out.png 300
 ```
 这是一张书籍配图（720×H SVG 的 PNG 渲染，宽 720 固定 / 高 H 按内容裁剪，v1.7.1 透明背景 + 内部模块多色/灰度梯度）。请逐项检查，只报问题：
 1. 是否有文字溢出容器 / 被截断？
-2. 是否有框、节点、文字重叠（间距应 ≥24px）？
+2. 是否有框、节点、文字意外重叠（间距应 ≥24px）？若是容器包含，是否确有承载语义且已由 writing-reviewer render evidence 记录 outer / inner / reason？
 3. 箭头是否落位正确、方向无误？
 4. 字号是否可读（节点≥16px）？
 5. 黑白打印能否分辨层级（颜色不是唯一区分手段）？
@@ -145,4 +149,4 @@ node scripts/svg2png.js in.svg out.png 300
 4. **视觉目检**（多模态逐图）→ 不美则改坐标
 5. 四道全过 → **验收通过**；任一未过 → 回改 + 复检
 
-> 与写作审稿（writing-reviewer）的边界：本清单审**配图本身**（密度 / 一致性 / 视觉）；writing-reviewer 审**正文文字**（口吻 / 去 AI 化 / 术语）。图注若需审贴切性 / 口吻，可补跑 writing-reviewer。
+> 与 writing-reviewer 的边界：本 Skill 负责生成期规则、producer 静态契约与人工/多模态配图审查；writing-reviewer v0.16+ 还负责 canonical Markdown 中 SVG inventory、静态规则与真实浏览器几何/render evidence。`container` 声明由本 Skill 约束写法，是否真的形成合法 shape 包含由 writing-reviewer render gate 最终判定；正文口吻、术语与图注贴切性仍由 writing-reviewer 审稿维度处理。

--- a/skills/svg-book-illustrator/references/style-guide.md
+++ b/skills/svg-book-illustrator/references/style-guide.md
@@ -368,6 +368,27 @@ convert out.png -colorspace Gray gray.png
 - 线宽 `2px` 在 16开下物理 0.32mm，印刷可见
 - 相邻模块同色组取不同色，避免色块连成一片
 
+### 容器包含语义（v1.8.10+，与 writing-reviewer v0.16+ 对齐）
+
+shape 完全包含另一 shape 既可能是“面板承载信息卡”的正常构图，也可能是坐标写错造成的遮挡。不要靠几何猜意图：**默认先把包含/重叠当作布局缺陷修坐标**；只有外层 shape 确实承担容器语义时，才使用唯一的 candidate-bound 窄声明。
+
+```svg
+<!-- 合法：外层卡片真实承载内层信息卡，意图与身份均可审计 -->
+<rect id="outer-card" x="40" y="40" width="220" height="160" rx="6"
+  fill="#EDF2F7" stroke="#2D3436" stroke-width="2"
+  data-overlap-role="container"
+  data-overlap-note="外层卡片承载内层信息卡"/>
+<rect x="60" y="70" width="180" height="90" rx="6"
+  fill="#D6E4F0" stroke="#2D3436" stroke-width="2"/>
+```
+
+- `data-overlap-role` **只允许**精确值 `container`；禁止 `decoration`、`background` 或任意自造 role，禁止用 `data-allow-overlap` 给候选 SVG 自发放行。
+- 声明只能放在 writing-reviewer 可测量的外层 area shape：`rect` / `circle` / `ellipse` / `polygon` / `path`；不要标在 `g`、`text`、连线或根 `svg` 上。
+- 外层必须同时有：①单张 SVG 内唯一、无 namespace 的稳定安全 `id`（1–128 位字母、数字、点、下划线或连字符，首位为字母或数字）；②无 namespace、至少六字且含“承载/包含/容纳”等关系词的具体 `data-overlap-note`，说明“外层承载什么”，不能只写“这里允许重叠/覆盖”；③可静态证明非透明的 hex/rgb/hsl `fill`。`none/transparent`、零 alpha、命名色、`inherit/currentColor/var()/url()` 等继承或无法在 producer 侧证明的值均不合格，`opacity/fill-opacity` 必须大于 0。
+- `data-overlap-note` 不能脱离 `container` role 单独存在；`x:id`、`x:data-overlap-note` 等 namespaced 假属性不会被浏览器 `getAttribute("id")` 识别，producer contract 直接拒绝。
+- 这组属性只表达候选源中的设计意图，**不构成几何通过证据**。producer contract 负责静态拒绝缺 id / 缺 note / 非法 role；writing-reviewer v0.16+ render gate 用真实浏览器几何判断是否实际包含，并把命中的 outer / inner / reason 写入 evidence。
+- 装饰底纹若压住信息 shape，仍应改尺寸、层级或坐标；不得把装饰标成容器来消除 finding。容器声明长期未命中也不等于合规，应删除无效声明。
+
 ### 箭头
 
 **单个 marker 通吃所有方向**（水平/垂直/斜向都用同一个 `id="arrow"`，靠 `orient="auto"` 自动旋转，**不要**为每个方向另造 marker 如 `arrV`/`arrF`/`arrG`）：

--- a/skills/svg-book-illustrator/scripts/tests/test_svg_producer_contract.py
+++ b/skills/svg-book-illustrator/scripts/tests/test_svg_producer_contract.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import math
 import re
 import subprocess
 import sys
@@ -21,6 +22,46 @@ RSVG_WRAPPER = SCRIPTS_DIR / "render_svg.py"
 RENDER_EQUIVALENCE_CHECK = SCRIPTS_DIR / "verify_render_font_equivalence.py"
 BROWSER_RENDERER = SCRIPTS_DIR / "svg2png.js"
 FIGURE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+OVERLAP_CONTAINER_TAGS = frozenset({"rect", "circle", "ellipse", "polygon", "path"})
+OVERLAP_CONTRACT_ATTRIBUTES = frozenset({
+    "id",
+    "data-overlap-role",
+    "data-overlap-note",
+    "data-allow-overlap",
+    "data-allow-overlap-note",
+})
+GENERIC_CONTAINER_NOTES = frozenset({
+    "允许重叠",
+    "允许覆盖",
+    "容器",
+    "container",
+    "overlap",
+    "allow overlap",
+})
+CONTAINER_RELATION_TERMS = (
+    "承载",
+    "容纳",
+    "包含",
+    "包裹",
+    "收纳",
+    "承托",
+    "contains",
+    "hosts",
+    "encloses",
+    "wraps",
+)
+NON_LITERAL_OR_INVISIBLE_FILLS = frozenset({
+    "none",
+    "transparent",
+    "inherit",
+    "initial",
+    "unset",
+    "revert",
+    "revert-layer",
+    "currentcolor",
+    "context-fill",
+    "context-stroke",
+})
 
 
 def local_name(name: str) -> str:
@@ -32,6 +73,114 @@ def parse_number(value: str) -> float:
     if normalized.endswith("px"):
         normalized = normalized[:-2]
     return float(normalized)
+
+
+def parse_css_alpha(value: str) -> float:
+    normalized = value.strip()
+    if normalized.endswith("%"):
+        alpha = float(normalized[:-1]) / 100
+    else:
+        alpha = float(normalized)
+    if not math.isfinite(alpha) or not 0 <= alpha <= 1:
+        raise ValueError("alpha must be finite and between 0 and 1")
+    return alpha
+
+
+def parse_css_channel(value: str, maximum: float) -> float:
+    normalized = value.strip()
+    if normalized.endswith("%"):
+        channel = float(normalized[:-1])
+        if not math.isfinite(channel) or not 0 <= channel <= 100:
+            raise ValueError("percentage channel must be between 0 and 100")
+        return channel
+    channel = float(normalized)
+    if not math.isfinite(channel) or not 0 <= channel <= maximum:
+        raise ValueError(f"channel must be between 0 and {maximum}")
+    return channel
+
+
+def parse_css_hue(value: str) -> float:
+    normalized = value.strip()
+    match = re.fullmatch(
+        r"([-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)(deg|grad|rad|turn)?",
+        normalized,
+    )
+    if not match:
+        raise ValueError("invalid hue")
+    hue = float(match.group(1))
+    if not math.isfinite(hue):
+        raise ValueError("hue must be finite")
+    return hue
+
+
+def parse_css_color_function(function_name: str, body: str) -> float:
+    if body.count("/") > 1:
+        raise ValueError("multiple alpha separators")
+    if "/" in body:
+        channels_text, alpha_text = body.rsplit("/", 1)
+        if "," in channels_text:
+            raise ValueError("slash alpha syntax requires space-separated channels")
+        alpha = parse_css_alpha(alpha_text)
+    else:
+        channels_text = body
+        alpha = 1.0
+
+    if "," in channels_text:
+        channels = [part.strip() for part in channels_text.split(",")]
+    else:
+        channels = channels_text.split()
+    if any(not channel for channel in channels):
+        raise ValueError("empty color channel")
+
+    if "/" not in body and function_name in {"rgba", "hsla"}:
+        if "," not in channels_text:
+            raise ValueError("legacy alpha syntax requires comma-separated channels")
+        if len(channels) != 4:
+            raise ValueError("legacy alpha function requires four comma channels")
+        alpha = parse_css_alpha(channels.pop())
+    if len(channels) != 3:
+        raise ValueError("color function requires exactly three channels")
+
+    if function_name in {"rgb", "rgba"}:
+        for channel in channels:
+            parse_css_channel(channel, 255)
+    else:
+        parse_css_hue(channels[0])
+        for channel in channels[1:]:
+            if not channel.strip().endswith("%"):
+                raise ValueError("hsl saturation and lightness must be percentages")
+            parse_css_channel(channel, 100)
+    return alpha
+
+
+def has_statically_visible_fill(value: str) -> bool:
+    fill = value.strip().casefold()
+    if not fill or fill in NON_LITERAL_OR_INVISIBLE_FILLS:
+        return False
+
+    if fill.startswith("#"):
+        if not re.fullmatch(r"#[0-9a-f]+", fill):
+            return False
+        if len(fill) in {4, 7}:
+            return True
+        if len(fill) == 5:
+            return int(fill[-1], 16) > 0
+        if len(fill) == 9:
+            return int(fill[-2:], 16) > 0
+        return False
+
+    color_function = re.fullmatch(r"(rgb|rgba|hsl|hsla)\(([^()]*)\)", fill)
+    if color_function:
+        function_name, body = color_function.groups()
+        try:
+            return parse_css_color_function(function_name, body) > 0
+        except ValueError:
+            return False
+
+    # Restrict container fills to auditable hex/rgb/hsl literals. Named colors,
+    # paint servers, variables and inheritance would require a CSS renderer to
+    # distinguish a visible value from an invalid or transparent one.
+    return False
 
 
 class SvgContractMixin:
@@ -79,11 +228,94 @@ class SvgContractMixin:
             self.assertNotIn("background", key.lower(), f"{source}: SVG 根不得设置背景属性")
             self.assertNotIn("background", value.lower(), f"{source}: SVG 根不得设置背景样式")
 
+        element_ids: set[str] = set()
         for element in root.iter():
             tag = local_name(element.tag)
             self.assertNotEqual(tag, "style", f"{source}: 不得包含 <style> 块")
 
             attributes = {local_name(key): value for key, value in element.attrib.items()}
+            for raw_name in element.attrib:
+                name = local_name(raw_name)
+                if name in OVERLAP_CONTRACT_ATTRIBUTES:
+                    self.assertEqual(
+                        raw_name,
+                        name,
+                        f"{source}: {name} 必须是无 namespace 的原生 SVG 属性",
+                    )
+            element_id = element.attrib.get("id")
+            if element_id is not None:
+                self.assertNotIn(
+                    element_id,
+                    element_ids,
+                    f"{source}: 元素 id 必须在单张 SVG 内唯一：{element_id}",
+                )
+                element_ids.add(element_id)
+            self.assertNotIn(
+                "data-allow-overlap",
+                attributes,
+                f"{source}: 候选 SVG 不得自发声明通用重叠豁免",
+            )
+            self.assertNotIn(
+                "data-allow-overlap-note",
+                attributes,
+                f"{source}: 候选 SVG 不得保留通用重叠豁免说明",
+            )
+            overlap_role = element.attrib.get("data-overlap-role")
+            overlap_note_attribute = element.attrib.get("data-overlap-note")
+            if overlap_role is None:
+                self.assertIsNone(
+                    overlap_note_attribute,
+                    f"{source}: data-overlap-note 不能脱离 container role 单独存在",
+                )
+            if overlap_role is not None:
+                self.assertEqual(
+                    overlap_role,
+                    "container",
+                    f"{source}: data-overlap-role 只允许窄语义 container，不能声明装饰或任意豁免",
+                )
+                self.assertIn(
+                    tag,
+                    OVERLAP_CONTAINER_TAGS,
+                    f"{source}: container 只能标在 writing-reviewer 可审计的外层 area shape",
+                )
+                container_id = element.attrib.get("id", "")
+                self.assertRegex(
+                    container_id,
+                    FIGURE_ID_PATTERN,
+                    f"{source}: container 必须绑定非空安全稳定 id",
+                )
+                overlap_note = (overlap_note_attribute or "").strip()
+                normalized_note = " ".join(overlap_note.casefold().split())
+                self.assertGreaterEqual(
+                    len(overlap_note),
+                    6,
+                    f"{source}: container note 必须具体说明外层承载对象",
+                )
+                self.assertNotIn(
+                    normalized_note,
+                    GENERIC_CONTAINER_NOTES,
+                    f"{source}: container note 不能只写通用“允许重叠/覆盖”",
+                )
+                self.assertTrue(
+                    any(term in normalized_note for term in CONTAINER_RELATION_TERMS),
+                    f"{source}: container note 必须明确说明外层与内层的承载关系",
+                )
+                fill = element.attrib.get("fill", "")
+                self.assertTrue(
+                    has_statically_visible_fill(fill),
+                    f"{source}: container 必须用可静态证明非透明的显式 fill",
+                )
+                for opacity_name in ("opacity", "fill-opacity"):
+                    opacity = element.attrib.get(opacity_name, "1").strip()
+                    try:
+                        opacity_value = float(opacity)
+                    except ValueError:
+                        self.fail(f"{source}: container {opacity_name} 必须是数值")
+                    self.assertGreater(
+                        opacity_value,
+                        0,
+                        f"{source}: container {opacity_name} 必须大于 0",
+                    )
             self.assertNotIn("class", attributes, f"{source}: 不得用 class 引用样式")
             self.assertNotIn("style", attributes, f"{source}: 不得使用 style 属性")
             self.assertNotIn("font-family", attributes, f"{source}: 字体只能来自受控外部 CSS")
@@ -226,6 +458,257 @@ class TemplateContractTests(SvgContractMixin, unittest.TestCase):
 
 
 class ContractRuleTests(SvgContractMixin, unittest.TestCase):
+    def test_shape_container_declarations_are_narrow_and_auditable(self) -> None:
+        valid_root = (
+            '<svg viewBox="0 0 720 400" width="720" height="400" '
+            'data-figure-id="fig-test">'
+        )
+        valid = (
+            valid_root
+            + '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+            'fill="#EDF2F7" data-overlap-role="container" '
+            'data-overlap-note="外层卡片承载内层信息卡"/>'
+            '<rect x="60" y="70" width="180" height="90" fill="#D6E4F0"/>'
+            '</svg>'
+        )
+        self.assertEqual(self.assert_svg_contract(valid, "valid container"), "fig-test")
+        for label, fill in (
+            ("valid rgba container", "rgba(237,242,247,0.2)"),
+            ("valid hsl container", "hsl(210 22% 95% / 20%)"),
+            ("valid alpha hex container", "#EDF2F701"),
+        ):
+            with self.subTest(fill=fill):
+                variant = (
+                    valid_root
+                    + '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+                    f'fill="{fill}" data-overlap-role="container" '
+                    'data-overlap-note="外层卡片承载内层信息卡"/>'
+                    '</svg>'
+                )
+                self.assertEqual(self.assert_svg_contract(variant, label), "fig-test")
+
+        for invalid_fill in (
+            "rgba(0,0,0 / 0.5)",
+            "rgba(0 0 0 0.5)",
+            "rgb(256,0,0)",
+            "rgb(NaN,0,0)",
+            "rgba(0,0,0,2)",
+            "rgba(0,0,0,-0.1)",
+            "hsl(0,50,50)",
+            "hsl(0 101% 50%)",
+        ):
+            with self.subTest(invalid_fill=invalid_fill):
+                self.assertFalse(has_statically_visible_fill(invalid_fill))
+
+        bad_svgs = {
+            "container missing id": (
+                valid_root
+                + '<rect x="40" y="40" width="220" height="160" fill="#EDF2F7" '
+                'data-overlap-role="container" data-overlap-note="承载内层卡片"/>'
+                '</svg>'
+            ),
+            "container unsafe id": (
+                valid_root
+                + '<rect id="outer card" x="40" y="40" width="220" height="160" '
+                'fill="#EDF2F7" data-overlap-role="container" '
+                'data-overlap-note="承载内层卡片"/>'
+                '</svg>'
+            ),
+            "container padded id": (
+                valid_root
+                + '<rect id=" outer-card " x="40" y="40" width="220" height="160" '
+                'fill="#EDF2F7" data-overlap-role="container" '
+                'data-overlap-note="承载内层卡片"/>'
+                '</svg>'
+            ),
+            "container missing note": (
+                valid_root
+                + '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+                'fill="#EDF2F7" data-overlap-role="container"/>'
+                '</svg>'
+            ),
+            "container blank note": (
+                valid_root
+                + '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+                'fill="#EDF2F7" data-overlap-role="container" data-overlap-note="   "/>'
+                '</svg>'
+            ),
+            "decoration role": (
+                valid_root
+                + '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+                'fill="#EDF2F7" data-overlap-role="decoration" '
+                'data-overlap-note="装饰底纹"/>'
+                '</svg>'
+            ),
+            "arbitrary role": (
+                valid_root
+                + '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+                'fill="#EDF2F7" data-overlap-role="background" '
+                'data-overlap-note="背景面板"/>'
+                '</svg>'
+            ),
+            "decoration disguised as container": (
+                valid_root
+                + '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+                'fill="#EDF2F7" data-overlap-role="container" '
+                'data-overlap-note="外层作为装饰底纹"/>'
+                '</svg>'
+            ),
+            "generic overlap escape hatch": (
+                valid_root
+                + '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+                'fill="#EDF2F7" data-allow-overlap="true" '
+                'data-allow-overlap-note="允许覆盖"/>'
+                '</svg>'
+            ),
+            "non-shape container": (
+                valid_root
+                + '<g id="outer-card" data-overlap-role="container" '
+                'data-overlap-note="分组承载内层卡片">'
+                '<rect x="40" y="40" width="220" height="160" fill="#EDF2F7"/>'
+                '</g></svg>'
+            ),
+            "duplicate container id": (
+                valid_root
+                + '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+                'fill="#EDF2F7" data-overlap-role="container" '
+                'data-overlap-note="外层卡片承载第一张信息卡"/>'
+                '<rect id="outer-card" x="300" y="40" width="220" height="160" '
+                'fill="#EDF2F7" data-overlap-role="container" '
+                'data-overlap-note="外层卡片承载第二张信息卡"/>'
+                '</svg>'
+            ),
+            "namespaced identity": (
+                '<svg xmlns:x="urn:test" viewBox="0 0 720 400" width="720" height="400" '
+                'data-figure-id="fig-test">'
+                '<rect x:id="outer-card" x="40" y="40" width="220" height="160" '
+                'fill="#EDF2F7" data-overlap-role="container" '
+                'data-overlap-note="外层卡片承载内层信息卡"/>'
+                '</svg>'
+            ),
+            "namespaced note": (
+                '<svg xmlns:x="urn:test" viewBox="0 0 720 400" width="720" height="400" '
+                'data-figure-id="fig-test">'
+                '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+                'fill="#EDF2F7" data-overlap-role="container" '
+                'x:data-overlap-note="外层卡片承载内层信息卡"/>'
+                '</svg>'
+            ),
+            "container rect without visible fill": (
+                valid_root
+                + '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+                'fill="none" stroke="#2D3436" data-overlap-role="container" '
+                'data-overlap-note="外层卡片承载内层信息卡"/>'
+                '</svg>'
+            ),
+            "container open path without visible fill": (
+                valid_root
+                + '<path id="outer-card" d="M40 40 L260 40 L260 200" '
+                'fill="none" stroke="#2D3436" data-overlap-role="container" '
+                'data-overlap-note="外层路径承载内层信息卡"/>'
+                '</svg>'
+            ),
+            "container zero fill opacity": (
+                valid_root
+                + '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+                'fill="#EDF2F7" fill-opacity="0" data-overlap-role="container" '
+                'data-overlap-note="外层卡片承载内层信息卡"/>'
+                '</svg>'
+            ),
+            "container zero opacity": (
+                valid_root
+                + '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+                'fill="#EDF2F7" opacity="0" data-overlap-role="container" '
+                'data-overlap-note="外层卡片承载内层信息卡"/>'
+                '</svg>'
+            ),
+            "container zero alpha hex fill": (
+                valid_root
+                + '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+                'fill="#00000000" data-overlap-role="container" '
+                'data-overlap-note="外层卡片承载内层信息卡"/>'
+                '</svg>'
+            ),
+            "container zero alpha rgba fill": (
+                valid_root
+                + '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+                'fill="rgba(0,0,0,0)" data-overlap-role="container" '
+                'data-overlap-note="外层卡片承载内层信息卡"/>'
+                '</svg>'
+            ),
+            "container inherited fill": (
+                valid_root
+                + '<g fill="none"><rect id="outer-card" x="40" y="40" '
+                'width="220" height="160" fill="inherit" '
+                'data-overlap-role="container" '
+                'data-overlap-note="外层卡片承载内层信息卡"/></g>'
+                '</svg>'
+            ),
+            "container paint server fill": (
+                valid_root
+                + '<defs><linearGradient id="panel-fill">'
+                '<stop offset="0" stop-color="#EDF2F7"/>'
+                '<stop offset="1" stop-color="#D6E4F0"/>'
+                '</linearGradient></defs>'
+                '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+                'fill="url(#panel-fill)" data-overlap-role="container" '
+                'data-overlap-note="外层卡片承载内层信息卡"/>'
+                '</svg>'
+            ),
+            "container unknown named fill": (
+                valid_root
+                + '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+                'fill="notacolor" data-overlap-role="container" '
+                'data-overlap-note="外层卡片承载内层信息卡"/>'
+                '</svg>'
+            ),
+            "container invalid rgb fill": (
+                valid_root
+                + '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+                'fill="rgb(nonsense)" data-overlap-role="container" '
+                'data-overlap-note="外层卡片承载内层信息卡"/>'
+                '</svg>'
+            ),
+            "container empty rgb fill": (
+                valid_root
+                + '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+                'fill="rgb()" data-overlap-role="container" '
+                'data-overlap-note="外层卡片承载内层信息卡"/>'
+                '</svg>'
+            ),
+            "container invalid hsl fill": (
+                valid_root
+                + '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+                'fill="hsl(nonsense)" data-overlap-role="container" '
+                'data-overlap-note="外层卡片承载内层信息卡"/>'
+                '</svg>'
+            ),
+            "generic overlap note": (
+                valid_root
+                + '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+                'fill="#EDF2F7" data-overlap-role="container" '
+                'data-overlap-note="允许重叠"/>'
+                '</svg>'
+            ),
+            "padded generic overlap note": (
+                valid_root
+                + '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+                'fill="#EDF2F7" data-overlap-role="container" '
+                'data-overlap-note="这里允许重叠"/>'
+                '</svg>'
+            ),
+            "orphan overlap note": (
+                valid_root
+                + '<rect id="outer-card" x="40" y="40" width="220" height="160" '
+                'fill="#EDF2F7" data-overlap-note="外层卡片承载内层信息卡"/>'
+                '</svg>'
+            ),
+        }
+        for rule, svg_text in bad_svgs.items():
+            with self.subTest(rule=rule):
+                with self.assertRaises(AssertionError):
+                    self.assert_svg_contract(svg_text, rule)
+
     def test_known_bad_contract_variants_are_rejected(self) -> None:
         valid_root = (
             '<svg viewBox="0 0 720 400" width="720" height="400" '


### PR DESCRIPTION
## Outcome

Aligns svg-book-illustrator v1.8.10 producer rules with writing-reviewer v0.16+ shape-containment evidence. Candidate SVGs can no longer silence shape overlap with decoration/arbitrary roles, a generic overlap escape hatch, or a decoration note disguised as a container.

## Conflict resolution

- rebuilt from current legal-skills main at da58c3c
- the only prior merge conflict was the root README version index
- retained all current-main README/release changes and added the v1.8.10 candidate entry
- final PR is mergeable and CLEAN

## Contract

- only data-overlap-role=container is allowed
- declaration is limited to outer area shapes: rect/circle/ellipse/polygon/path
- stable safe id, non-empty relational note, and statically visible literal fill are mandatory
- candidate data-allow-overlap is rejected
- broad relation term “作为” is rejected; the former “外层作为装饰底纹” bypass is now a regression fixture
- static producer validation records intent only; real geometry remains the responsibility of writing-reviewer Chromium render evidence

## Verification

- producer contract: 5/5 tests passed
- covers one canonical valid declaration, three valid fill variants, and 28 fail-open variants
- former decoration-note bypass independently replayed and rejected
- all five generators and ten published template SVG blocks remain green
- py_compile and git diff --check: PASS
- doc-curator independent audit: hard=0, adaptive=0

T002 remains open until PR merge, main source check, v1.8.10 release asset, writing-reviewer v0.16+ availability, and candidate-bound cross-Skill render evidence are all available.

Agent Attribution: Codex <codex@agents.local>
