### PR TITLE
fix(md2word): 脚注 inline 解析抽共享 parser + 补回归测试

### DIFF
--- a/skills/md2word/CHANGELOG.md
+++ b/skills/md2word/CHANGELOG.md
@@ -32,12 +32,12 @@
 ## [1.1.5] - 2026-07-11
 
 ### 修复
-- **脚注 markdown 星号进 XML（footnote_handler）**：原实现把脚注 text 直接 `_xml_escape` 塞进单个 `<w:t>`，`*需律师现场确认*` 的星号原样进 footnotes.xml，Word 显示字面星号。新增 `_footnote_text_to_runs_xml()`：解析 `**bold**`/`*italic*`/`` `code` `` 转 Word runs（`<w:b/>`/`<w:i/>`/Consolas 等宽），既不显示字面星号、又保留斜体/粗体/代码格式。不处理 `_italic_`（避免下划线变量名误判）、嵌套与 `[link](url)`（留 follow-up）。
+- **脚注 markdown 星号进 XML（footnote_handler）**：原实现把脚注 text 直接 `_xml_escape` 塞进单个 `<w:t>`，`*需律师现场确认*` 的星号原样进 footnotes.xml，Word 显示字面星号。新增共享 inline parser：`footnote` 转 `<w:b/>`/`<w:i/>`/Consolas runs，`endnote` 同样拆成 python-docx runs；两条路径都不再显示字面星号/反引号。不处理 `_italic_`（避免下划线变量名误判）、嵌套与 `[link](url)`（留 follow-up）。
 - **中文撇号误判为英文所有格（formatter.py isalpha）**：`convert_quotes_to_chinese` 原用 `prev_c.isalpha() and next_c.isalpha()` 保留英文缩写/所有格撇号（don't/O'Brien），但 `'需'.isalpha()` 在 Python 返回 True（中文属 Unicode Lo），导致「中文'中文」被误判为英文所有格、本该转中文单引号 ‘’ 却保留 ASCII `'`。修：加 `.isascii()` 限定，只 ASCII 字母-撇号-ASCII 字母保留。
 
 ### 验证（眼见为实）
-- 单元测试：footnote runs 6 case ALL PASS（`*x*`→`<w:i/>`、`**x**`→`<w:b/>`、无字面星号；code/空/普通文本 OK）；convert_quotes_to_chinese 6 case（中文边界→中文单引号 ‘’；don't/O'Brien/API's→保留 ASCII `'`）。
-- 集成验证：造含中文撇号 + 星号脚注的 md 转 docx（legal preset, footnote 模式）—— document.xml `需律师现场确认`→中文单引号、don't/API's 保留 ASCII；footnotes.xml 无字面 `*`、含 `<w:i/>`/`<w:b/>`、脚注拆 runs。
+- 正式回归文件：`scripts/test_regressions.py` 覆盖中文引号与英文撇号、footnote OOXML 注入、bold/italic/code runs、endnote 路径无字面 Markdown。
+- 集成验证：构造含中文撇号 + 星号脚注的 docx，确认 document/footnotes XML 中中文单引号正确、don't/API's 保留 ASCII、footnotes.xml 无字面 `*` 且含 `<w:i/>`/`<w:b/>`。
 
 ## [1.1.4] - 2026-07-09
 

--- a/skills/md2word/scripts/footnote_handler.py
+++ b/skills/md2word/scripts/footnote_handler.py
@@ -109,8 +109,7 @@ class FootnoteManager:
             idx = p.add_run('[%d] ' % seq)
             idx.font.size = Pt(9)
             idx.bold = True
-            body = p.add_run(text)
-            body.font.size = Pt(9)
+            _append_note_runs(p, text)
 
     def finalize_footnotes_part(self, output_path):
         """footnote 模式：doc.save 后 post-process，注入 footnotes.xml + rels + Content_Types。"""
@@ -149,6 +148,39 @@ def _xml_escape(t):
 _FN_INLINE_TOKEN_RE = re.compile(r'(\*\*.+?\*\*|\*.+?\*|`.+?`)')
 
 
+def _parse_footnote_inline(text):
+    """返回 (text, bold, italic, code) 片段，供 footnote/endnote 两条路径共用。"""
+    segments = []
+    for part in _FN_INLINE_TOKEN_RE.split(text):
+        if not part:
+            continue
+        bold = italic = code = False
+        segment = part
+        if len(part) >= 4 and part.startswith('**') and part.endswith('**'):
+            bold = True
+            segment = part[2:-2]
+        elif len(part) >= 2 and part.startswith('*') and part.endswith('*'):
+            italic = True
+            segment = part[1:-1]
+        elif len(part) >= 2 and part.startswith('`') and part.endswith('`'):
+            code = True
+            segment = part[1:-1]
+        segments.append((segment, bold, italic, code))
+    return segments
+
+
+def _append_note_runs(paragraph, text):
+    """在 python-docx 段落中写入已解析的 endnote runs，不显示 Markdown 标记。"""
+    for segment, bold, italic, code in _parse_footnote_inline(text):
+        run = paragraph.add_run(segment)
+        run.font.size = Pt(9)
+        run.bold = bold
+        run.italic = italic
+        if code:
+            run.font.name = 'Consolas'
+            run._element.get_or_add_rPr().get_or_add_rFonts().set(qn('w:eastAsia'), '等线')
+
+
 def _footnote_text_to_runs_xml(text):
     """把脚注 text 的 markdown inline 强调（**bold**/*italic*/`code`）转为 Word runs XML 片段。
 
@@ -162,20 +194,7 @@ def _footnote_text_to_runs_xml(text):
     """
     runs = []
     first = True
-    for part in _FN_INLINE_TOKEN_RE.split(text):
-        if not part:
-            continue
-        bold = italic = code = False
-        seg = part
-        if len(part) >= 4 and part.startswith('**') and part.endswith('**'):
-            bold = True
-            seg = part[2:-2]
-        elif len(part) >= 2 and part.startswith('*') and part.endswith('*'):
-            italic = True
-            seg = part[1:-1]
-        elif len(part) >= 2 and part.startswith('`') and part.endswith('`'):
-            code = True
-            seg = part[1:-1]
+    for seg, bold, italic, code in _parse_footnote_inline(text):
         rpr_parts = ['<w:sz w:val="18"/>']
         if bold:
             rpr_parts.append('<w:b/>')

--- a/skills/md2word/scripts/test_regressions.py
+++ b/skills/md2word/scripts/test_regressions.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""md2word 已知出版逃逸的回归测试。"""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import sys
+import unittest
+import zipfile
+
+from docx import Document
+
+
+HERE = Path(__file__).resolve().parent
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+from formatter import convert_quotes_to_chinese  # noqa: E402
+from footnote_handler import (  # noqa: E402
+    FootnoteManager,
+    _footnote_text_to_runs_xml,
+    _inject_footnotes_into_docx,
+)
+
+
+class Md2WordRegressionTest(unittest.TestCase):
+    def test_cjk_ascii_quotes_convert_but_english_apostrophes_survive(self):
+        converted = convert_quotes_to_chinese("标注'需律师现场确认'，don't、O'Brien 与 API's 保留。")
+        self.assertIn("‘需律师现场确认’", converted)
+        self.assertIn("don't", converted)
+        self.assertIn("O'Brien", converted)
+        self.assertIn("API's", converted)
+
+    def test_footnote_inline_markers_become_word_properties(self):
+        xml = _footnote_text_to_runs_xml("*模型概览* 与 **重点**，命令 `book-gate verify`")
+        self.assertNotIn("*模型概览*", xml)
+        self.assertNotIn("**重点**", xml)
+        self.assertNotIn("`book-gate verify`", xml)
+        self.assertIn("<w:i/>", xml)
+        self.assertIn("<w:b/>", xml)
+        self.assertIn('w:ascii="Consolas"', xml)
+
+    def test_injected_footnotes_xml_has_no_literal_markdown(self):
+        with TemporaryDirectory() as temp:
+            docx_path = Path(temp) / "footnotes.docx"
+            Document().save(docx_path)
+            _inject_footnotes_into_docx(
+                str(docx_path),
+                [(1, "*模型概览*"), (2, "**需律师确认**"), (3, "`Skill`")],
+            )
+            with zipfile.ZipFile(docx_path) as archive:
+                xml = archive.read("word/footnotes.xml").decode("utf-8")
+            self.assertNotIn("*模型概览*", xml)
+            self.assertNotIn("**需律师确认**", xml)
+            self.assertNotIn("`Skill`", xml)
+            self.assertIn("<w:i/>", xml)
+            self.assertIn("<w:b/>", xml)
+
+    def test_endnotes_path_also_removes_markdown_markers(self):
+        document = Document()
+        manager = FootnoteManager(mode="endnote")
+        manager.refs = [(1, "*模型概览* 与 **重点**，命令 `Skill`")]
+        manager.append_endnotes_section(document)
+        text = "\n".join(paragraph.text for paragraph in document.paragraphs)
+        self.assertIn("模型概览 与 重点，命令 Skill", text)
+        self.assertNotIn("*", text)
+        self.assertNotIn("`", text)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+


### PR DESCRIPTION
## 摘要
脚注 inline 强调解析（`**bold**`/`*italic*`/``code``）原只在 footnote 的 XML 路径实现；抽出 `_parse_footnote_inline()` 共享给 footnote（XML）与 endnote（python-docx runs）两条路径，新增 `scripts/test_regressions.py` 正式回归覆盖。

## 改动
- `footnote_handler.py`：抽 `_parse_footnote_inline()` + `_append_note_runs()`；endnote 路径不再显示字面 Markdown 标记。
- `test_regressions.py`（新）：中文引号转换、英文撇号保留、footnote OOXML 无字面 Markdown、endnote 路径无字面标记。
- `CHANGELOG.md`：[1.1.5] 验证段更新为引用正式回归文件。

## 测试
- [x] `test_regressions.py` 4/4 PASS（含 endnote 路径）
- [x] `py_compile` 通过

## 背景
原与 book-gate 同分支开发；book-gate 已迁入 private-skills 不公开发布，本 md2word 改进属于已公开 skill 的独立修复，单独开 PR。从原分支 cherry-pick（commit 8b039d8 → 9dafbaa）。

> 不自合并，review 后 squash merge。