### PR TITLE
feat(yuandian-law-search): v1.8.4 validate-query-filters.py 硬门禁

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
     {
       "name": "yuandian-law-search",
       "description": "元典法条与案例检索，通过元典 API 或官方 MCP 获取法条、案例、法规与企业信息，并自动归档；支持将多次检索汇总为 7 节结论先行法律检索报告",
-      "version": "1.8.3",
+      "version": "1.8.4",
       "author": {
         "name": "杨卫薪律师（微信ywxlaw）"
       },

--- a/skills/yuandian-law-search/CHANGELOG.md
+++ b/skills/yuandian-law-search/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 新增
 
-- **`scripts/validate-query-filters.py`**：把 `references/07` §9.1「字段归属接口速查表」从软约束（worker 自觉读）升级为硬门禁（脚本校验）。校验 research-plan / 单条 query 的 filter×interface 合法性（如 `--wenshu-type` 挂 `case` 关键词会被拦截，并提示正确归属 `case-semantic`）。退出码 0 合法 / 1 有违规，可接 CI / pre-commit / hook。字段表以 `yd_search.py` 各 subparser 为权威，覆盖 8 个接口。源自 Round 3 worker 执行方差发现（12/67 filter 误挂）的工程闭环。
+- **`scripts/validate-query-filters.py`**：把 `references/07` §9.1「字段归属接口速查表」从软约束（worker 自觉读）升级为硬门禁（脚本校验）。校验 research-plan / 单条 query 的 filter×interface 合法性（如 `--wenshu-type` 挂 `case` 关键词会被拦截，并提示正确归属 `case-semantic`）。退出码 0 合法 / 1 有违规，可接 CI / pre-commit / hook。字段表**动态自省**自 `yd_search.py` 的 `build_parser()`（零漂移，自动覆盖全部子命令含双别名/store_false，自省失败时回退硬编码）；覆盖 21 个子命令。源自 Round 3 worker 执行方差发现（12/67 filter 误挂）的工程闭环。
 
 ## [1.8.3] - 2026-08-02
 

--- a/skills/yuandian-law-search/CHANGELOG.md
+++ b/skills/yuandian-law-search/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 变更日志
 
+## [1.8.4] - 2026-08-02
+
+### 新增
+
+- **`scripts/validate-query-filters.py`**：把 `references/07` §9.1「字段归属接口速查表」从软约束（worker 自觉读）升级为硬门禁（脚本校验）。校验 research-plan / 单条 query 的 filter×interface 合法性（如 `--wenshu-type` 挂 `case` 关键词会被拦截，并提示正确归属 `case-semantic`）。退出码 0 合法 / 1 有违规，可接 CI / pre-commit / hook。字段表以 `yd_search.py` 各 subparser 为权威，覆盖 8 个接口。源自 Round 3 worker 执行方差发现（12/67 filter 误挂）的工程闭环。
+
 ## [1.8.3] - 2026-08-02
 
 ### 移除

--- a/skills/yuandian-law-search/SKILL.md
+++ b/skills/yuandian-law-search/SKILL.md
@@ -2,7 +2,7 @@
 name: yuandian-law-search
 homepage: https://github.com/cat-xierluo/legal-skills
 author: 杨卫薪律师（微信ywxlaw）
-version: "1.8.3"
+version: "1.8.4"
 license: MIT
 description: 元典法条与案例检索。本技能应在需要查询中国法律法规条文、检索相关案例、为法律分析提供数据支撑时使用。
 ---

--- a/skills/yuandian-law-search/references/07-research-middleware.md
+++ b/skills/yuandian-law-search/references/07-research-middleware.md
@@ -177,6 +177,8 @@ filter 必须挂在**真正支持它**的接口上，否则会被忽略或报错
 - **`--jarq-start/end` 两个案例接口都支持**（源码确认），可放心用于日期范围。
 - 法条接口（`search`/`keyword`）的 `--sxx`/`--effect1` 不得挪到案例接口。
 
+**硬校验**：用 `scripts/validate-query-filters.py <research-plan.json>` 自动校验 filter×interface 合法性（退出码 0 合法 / 1 有违规，可接 CI 或 pre-commit hook）。单条 query 可用 `--query '{"interface":"case","filters":{...}}'`。字段表与本节一致，以 `yd_search.py` 各 subparser 为权威。
+
 ## 10. 策略与法律检索解耦（[DEC-006] pt 6）
 
 `economical` / `balanced` / `aggressive` 只控制**调用预算与深度**（试几条 query、是否自动跑语义+关键词双检索、是否自动拉 case-detail），**不得**改变：

--- a/skills/yuandian-law-search/scripts/validate-query-filters.py
+++ b/skills/yuandian-law-search/scripts/validate-query-filters.py
@@ -16,29 +16,59 @@ subparser 的 add_argument 为权威；改字段时同步更新 §9.1 与本表�
 import argparse, json, sys
 from pathlib import Path
 
-# 各 interface 支持的 filter 字段 (去掉前导 --)。源自 yd_search.py 各 subparser。
-# search: add_parser("search")  | keyword: add_parser("keyword")
-# case: add_parser("case")      | case-semantic: add_parser("case-semantic")
-# detail / case-detail / regulation / regulation-detail 同。
-VALID_FILTERS = {
-    "search": {"sxx", "effect1", "fgmc", "keep-industry", "return-num",
-               "rewrite-flag", "no-rewrite", "fbrq-start", "fbrq-end",
-               "ssrq-start", "ssrq-end", "law-start", "law-end"},
-    "keyword": {"sxx", "effect1", "fgmc", "keep-industry", "expand",
-                "search-mode", "top-k"},
-    "case": {"ah", "title", "ay", "jbdw", "ajlb", "xzqh-p", "province",
-             "wszl", "jarq-start", "jarq-end", "fxgc", "yyft",
-             "ft-search-mode", "authority-only", "expand", "search-mode", "top-k"},
-    "case-semantic": {"authority-only", "xzqh-p", "province", "fayuan",
-                      "wenshu-type", "wszl", "cj", "rewrite-flag",
-                      "return-num", "jarq-start", "jarq-end"},
+# 硬编码 fallback：仅当动态自省 yd_search.build_parser() 失败时使用。
+# 已按 yd_search.py 源码（含 _add_law_filters helper、双别名、store_false）校准。
+# 维护时以动态自省结果为准（见 VALID_FILTERS_LOAD_SOURCE），勿手改本表。
+_HARDCODED = {
+    "search": {"effect1", "sxx", "keep-industry", "rewrite-flag", "no-rewrite",
+               "return-num", "law-start", "law-end"},
+    "keyword": {"expand", "fgmc", "effect1", "sxx", "keep-industry", "search-mode",
+                "fbrq-start", "fbrq-end", "ssrq-start", "ssrq-end", "top-k"},
+    "case": {"ah", "title", "ay", "jbdw", "ajlb", "xzqh-p", "province", "wszl",
+             "jarq-start", "jarq-end", "fxgc", "yyft", "ft-search-mode",
+             "authority-only", "expand", "search-mode", "top-k"},
+    "case-semantic": {"authority-only", "xzqh-p", "province", "fayuan", "wenshu-type",
+                      "wszl", "cj", "rewrite-flag", "no-rewrite", "return-num",
+                      "jarq-start", "jarq-end"},
     "detail": {"ft-name", "reference-date"},
     "case-detail": {"type", "id", "ah"},
-    "regulation": {"effect1", "sxx", "fgmc", "keep-industry", "expand",
-                   "search-mode", "top-k", "fbrq-start", "fbrq-end",
-                   "ssrq-start", "ssrq-end"},
+    "regulation": {"expand", "search-mode", "fgmc", "effect1", "sxx", "keep-industry",
+                   "fbrq-start", "fbrq-end", "ssrq-start", "ssrq-end", "top-k"},
     "regulation-detail": {"name", "fgid", "reference-date"},
 }
+
+
+def _load_valid_filters():
+    """优先从同目录 yd_search.py 的 build_parser() 动态自省（零漂移）；
+    失败回退 _HARDCODED。返回 (filters_dict, source_str)。"""
+    try:
+        import importlib.util
+        yd = Path(__file__).resolve().parent / "yd_search.py"
+        if not yd.exists():
+            return {k: set(v) for k, v in _HARDCODED.items()}, "fallback(yd_search.py 缺失)"
+        spec = importlib.util.spec_from_file_location("yd_search_for_validator", yd)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        parser = mod.build_parser()
+        valid = {}
+        for act in parser._actions:
+            if isinstance(act, argparse._SubParsersAction):
+                for name, sub in act.choices.items():
+                    fields = set()
+                    for a in sub._actions:
+                        for opt in a.option_strings:
+                            if opt in ("-h", "--help"):
+                                continue
+                            fields.add(opt.lstrip("-"))
+                    valid[name] = fields
+        if not valid:
+            return {k: set(v) for k, v in _HARDCODED.items()}, "fallback(自省为空)"
+        return valid, "dynamic(yd_search.build_parser)"
+    except Exception as e:
+        return {k: set(v) for k, v in _HARDCODED.items()}, f"fallback({type(e).__name__}: {e})"
+
+
+VALID_FILTERS, VALID_FILTERS_LOAD_SOURCE = _load_valid_filters()
 
 # 反查: 某字段通常属于哪些 interface (用于给违规信息提示"它属于谁")
 FIELD_OWNERS = {}
@@ -129,6 +159,8 @@ def main():
 
     if not v:
         print(f"✓ 合法：{n} 条 query 的 filter×interface 全部匹配 §9.1 字段表。")
+        if VALID_FILTERS_LOAD_SOURCE.startswith("fallback"):
+            print(f"⚠ 字段表为 {VALID_FILTERS_LOAD_SOURCE}（非动态自省），结果可能不准，请检查 yd_search.py。")
         return 0
 
     cases_hit = sorted({x["case_id"] for x in v})
@@ -139,6 +171,8 @@ def main():
         else:
             print(f"  [{x['case_id']}] Q{x['query_id']} interface={x['interface']}: {x['msg']}")
     print(f"\n参考: references/07-research-middleware.md §9.1 字段归属接口速查表。")
+    if VALID_FILTERS_LOAD_SOURCE.startswith("fallback"):
+        print(f"⚠ 字段表为 {VALID_FILTERS_LOAD_SOURCE}（非动态自省），结果可能不准，请检查 yd_search.py。")
     return 1
 
 

--- a/skills/yuandian-law-search/scripts/validate-query-filters.py
+++ b/skills/yuandian-law-search/scripts/validate-query-filters.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""validate-query-filters.py — 校验 research-plan / query 的 filter×interface 合法性。
+
+把 references/07-research-middleware.md §9.1「字段归属接口速查表」从软约束
+(worker 自觉读) 变成硬门禁 (脚本校验)。字段表以 scripts/yd_search.py 各
+subparser 的 add_argument 为权威；改字段时同步更新 §9.1 与本表。
+
+用法:
+  python3 scripts/validate-query-filters.py <research-plan.json>
+  python3 scripts/validate-query-filters.py --query '{"interface":"case","filters":{"wenshu-type":"民事"}}'
+  python3 scripts/validate-query-filters.py <plan.json> --strict   # 未知 interface 也算违规
+
+退出码: 0=全合法, 1=有违规 (可接 CI / pre-commit / hook)。
+"""
+import argparse, json, sys
+from pathlib import Path
+
+# 各 interface 支持的 filter 字段 (去掉前导 --)。源自 yd_search.py 各 subparser。
+# search: add_parser("search")  | keyword: add_parser("keyword")
+# case: add_parser("case")      | case-semantic: add_parser("case-semantic")
+# detail / case-detail / regulation / regulation-detail 同。
+VALID_FILTERS = {
+    "search": {"sxx", "effect1", "fgmc", "keep-industry", "return-num",
+               "rewrite-flag", "no-rewrite", "fbrq-start", "fbrq-end",
+               "ssrq-start", "ssrq-end", "law-start", "law-end"},
+    "keyword": {"sxx", "effect1", "fgmc", "keep-industry", "expand",
+                "search-mode", "top-k"},
+    "case": {"ah", "title", "ay", "jbdw", "ajlb", "xzqh-p", "province",
+             "wszl", "jarq-start", "jarq-end", "fxgc", "yyft",
+             "ft-search-mode", "authority-only", "expand", "search-mode", "top-k"},
+    "case-semantic": {"authority-only", "xzqh-p", "province", "fayuan",
+                      "wenshu-type", "wszl", "cj", "rewrite-flag",
+                      "return-num", "jarq-start", "jarq-end"},
+    "detail": {"ft-name", "reference-date"},
+    "case-detail": {"type", "id", "ah"},
+    "regulation": {"effect1", "sxx", "fgmc", "keep-industry", "expand",
+                   "search-mode", "top-k", "fbrq-start", "fbrq-end",
+                   "ssrq-start", "ssrq-end"},
+    "regulation-detail": {"name", "fgid", "reference-date"},
+}
+
+# 反查: 某字段通常属于哪些 interface (用于给违规信息提示"它属于谁")
+FIELD_OWNERS = {}
+for _iface, _fields in VALID_FILTERS.items():
+    for _f in _fields:
+        FIELD_OWNERS.setdefault(_f, []).append(_iface)
+
+
+def _normalize(key):
+    """filter key 统一去前导 -- / 前导 -。"""
+    k = key.strip()
+    while k.startswith("-"):
+        k = k[1:]
+    return k
+
+
+def validate_queries(queries, case_id="?", strict=False):
+    """对一组 query 校验 filter×interface。返回 violations 列表。"""
+    violations = []
+    for q in queries or []:
+        qid = q.get("id") or "?"
+        iface = (q.get("interface") or "").strip()
+        if iface not in VALID_FILTERS:
+            if strict or not iface:
+                violations.append({
+                    "case_id": case_id, "query_id": qid,
+                    "interface": iface or "(空)",
+                    "field": None,
+                    "msg": "未知/缺失 interface" + (f"，已知: {sorted(VALID_FILTERS)}" if not iface else ""),
+                })
+            continue
+        legal = VALID_FILTERS[iface]
+        for raw_key in (q.get("filters") or {}).keys():
+            k = _normalize(raw_key)
+            if k not in legal:
+                owners = FIELD_OWNERS.get(k, [])
+                hint = f"（属 {owners[0]}）" if len(owners) == 1 else (
+                    f"（属 {owners}）" if owners else "（未知字段）")
+                violations.append({
+                    "case_id": case_id, "query_id": qid,
+                    "interface": iface, "field": raw_key,
+                    "msg": f"--{k} 不被 {iface} 支持{hint}",
+                })
+    return violations
+
+
+def _extract_cases(plan):
+    if isinstance(plan, list):
+        return [(c.get("case_id", f"#{i}"), c) for i, c in enumerate(plan)]
+    if isinstance(plan, dict):
+        cases = plan.get("cases") or plan.get("results") or []
+        out = []
+        for i, c in enumerate(cases):
+            out.append((c.get("case_id", f"#{i}"), c))
+        # 兼容顶层就是单个 case
+        if not cases and "queries" in plan:
+            out.append((plan.get("case_id", "?"), plan))
+        return out
+    return []
+
+
+def validate_plan_file(path, strict=False):
+    plan = json.loads(Path(path).read_text(encoding="utf-8"))
+    all_v = []
+    n_queries = 0
+    for case_id, c in _extract_cases(plan):
+        qs = c.get("queries") or []
+        n_queries += len(qs)
+        all_v += validate_queries(qs, case_id, strict)
+    return all_v, n_queries
+
+
+def main():
+    ap = argparse.ArgumentParser(description="校验 research-plan 的 filter×interface 合法性 (§9.1 硬门禁)")
+    ap.add_argument("plan", nargs="?", help="research-plan.json 路径")
+    ap.add_argument("--query", help="单条 query JSON (如 '{\"interface\":\"case\",\"filters\":{...}}')")
+    ap.add_argument("--strict", action="store_true", help="未知/缺失 interface 也算违规")
+    args = ap.parse_args()
+
+    if args.query:
+        q = json.loads(args.query)
+        v = validate_queries([q], "(单条)", args.strict)
+        n = 1
+    elif args.plan:
+        v, n = validate_plan_file(args.plan, args.strict)
+    else:
+        ap.error("需要 plan 路径或 --query")
+
+    if not v:
+        print(f"✓ 合法：{n} 条 query 的 filter×interface 全部匹配 §9.1 字段表。")
+        return 0
+
+    cases_hit = sorted({x["case_id"] for x in v})
+    print(f"✗ {len(v)} 处 filter 违规（涉及 {len(cases_hit)} 个 case / {n} 条 query）：")
+    for x in v:
+        if x["field"] is None:
+            print(f"  [{x['case_id']}] Q{x['query_id']} interface={x['interface']}: {x['msg']}")
+        else:
+            print(f"  [{x['case_id']}] Q{x['query_id']} interface={x['interface']}: {x['msg']}")
+    print(f"\n参考: references/07-research-middleware.md §9.1 字段归属接口速查表。")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
把 `references/07` §9.1「字段归属接口速查表」从软约束（worker 自觉读）升级为**硬门禁**（脚本校验）。源自 Round 3 发现的 worker 执行方差（12/67 filter 误挂 `--wenshu-type` 到 `case` 关键词）的工程闭环。

## 新增

- `scripts/validate-query-filters.py`：
  - 校验 research-plan.json 或单条 `--query` 的 filter×interface 合法性
  - 违规精确报告：case / query / interface / 字段 + 字段正确归属（如 `--wenshu-type` 属 `case-semantic` 不属 `case`）
  - 退出码 0 合法 / 1 有违规，可接 CI / pre-commit / hook
  - 字段表以 `yd_search.py` 各 subparser 为权威，覆盖 8 个接口（search/keyword/case/case-semantic/detail/case-detail/regulation/regulation-detail）

## 回归验证（Round 3 真实产出）

- `r3a-runA`：0 违规（exit 0）✓
- `r3a-runB`：12 违规 `--wenshu-type on case`（exit 1），与 Round 3 audit 数字一致 ✓

## 其他

- `references/07` §9.1 加硬校验说明（指向该脚本）
- 版本 1.8.3 → 1.8.4（SKILL.md / marketplace.json / CHANGELOG 三处同步）

## 字段表维护

字段表硬编码在本脚本（源自 `yd_search.py` 各 subparser 的 `add_argument`）。未来若 `yd_search.py` 改字段，需同步更新 §9.1 与本脚本 `VALID_FILTERS`。