### PR TITLE
fix(workbuddy-checkin): 兼容 WorkBuddy v5.3.8 新版明文登录态存储 (v1.0.2)

### DIFF
--- a/skills/workbuddy-checkin/CHANGELOG.md
+++ b/skills/workbuddy-checkin/CHANGELOG.md
@@ -1,5 +1,25 @@
 # 变更日志
 
+## [1.0.2] - 2026-08-06
+
+### 修复
+
+- **兼容 WorkBuddy 桌面端 v5.3.8 新版登录态存储**（#68）：v5.3.8 不再把当前登录态写入 `state.vscdb`，改用明文 JSON 文件 `~/Library/Application Support/CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info`（Windows/Linux 同构路径）。旧版（≤1.0.1）只认 `state.vscdb`，导致连续报「获取令牌失败（未知原因）」。
+  - `decrypt-token.js` 改为**新版明文文件优先、旧版 `state.vscdb` 回退**；新版分支纯 Node 读取 `auth.accessToken`，无需 Electron `safeStorage` 解密。
+  - `require("electron")` 包裹 try/catch，脚本可由普通 `node` 直接执行。
+  - 统一 `emitAndExit()`（`process.stdout.write` 后延迟 ~200ms 退出），避免 `console.log` 后立即 `app.exit()` 导致 stdout 未 flush。
+- **macOS 运行时策略改为 Node 优先**（#68）：直接调用 WorkBuddy.app 的 Electron 二进制会启动主应用而非执行脚本；新版明文文件用纯 Node 即可读取，无需依赖应用内 Electron。`checkin.sh`/`checkin.ps1`/`setup.sh`/`setup.ps1` 均改为 Node 优先、Electron 回退，新增 `WB_CHECKIN_NODE=<path>` 环境变量。
+- **`daily-checkin` 的 `code=10001` 识别为已签到**（#68）：v5.3.8 实测 `checkin-status` 的 `today_checked_in` 不可靠（签到成功后仍为 `false`），当日重跑会再次调 `daily-checkin` 并返回 `code=10001`（今天已签到）；旧版将其误报为「签到未成功」，导致幂等分支失效。1.0.2 起正确报告「今日已签到，无需重复领取」。
+
+### 改进
+
+- 文档同步：`SKILL.md` / `references/dependencies.md` 更新原理、平台路径、依赖（Electron 降级为仅旧版可选）、环境变量（新增 `WB_CHECKIN_NODE`）、排错（v5.3.8 专项条目）。
+- `setup.sh`/`setup.ps1`：v5.3.8 用户（仅 Node、无 Electron）不再被误判为「未找到 Electron」而失败。
+
+### 已知限制
+
+- Windows / Linux 的 `CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info` 路径基于 v5.3.8 桌面端约定推导，已在 macOS 实测命中，其他平台待真实环境确认。
+
 ## [1.0.1] - 2026-08-05
 
 ### 改进

--- a/skills/workbuddy-checkin/CHANGELOG.md
+++ b/skills/workbuddy-checkin/CHANGELOG.md
@@ -16,6 +16,16 @@
 - 文档同步：`SKILL.md` / `references/dependencies.md` 更新原理、平台路径、依赖（Electron 降级为仅旧版可选）、环境变量（新增 `WB_CHECKIN_NODE`）、排错（v5.3.8 专项条目）。
 - `setup.sh`/`setup.ps1`：v5.3.8 用户（仅 Node、无 Electron）不再被误判为「未找到 Electron」而失败。
 
+### 合并前代码评审修复
+
+- **`checkin.sh` / `checkin.ps1` Electron 回退条件修正（高）**：原实现仅当 Node 输出为空才回退 Electron；但旧版 `state.vscdb` 账户在装有 Node 的机器上，纯 Node 会输出非空的 `ERR`（无法解 safeStorage），导致 Electron 回退被跳过、误报失败（对 v1.0.1 旧版账户的回归）。改为「空 或 ERR」均回退。
+- **`decrypt-token.js` 部分明文文件不再硬失败**：明文文件存在但缺 `auth.accessToken`（如升级中途 / 写入中）或解析失败时，不再 `exit 5`，而是落入旧版 `state.vscdb` 分支兜底。
+- **`decrypt-token.js` 旧版读取异常可观测**：`readValue` 抛错（如 `node:sqlite` 不可用且未开 python3 回退）时不再裸抛，统一经 `DECRYPT_RESULT:ERR` 带原因输出，避免「未知原因」式失败。
+- **`checkin.sh` `WB_CHECKIN_JITTER=0` / 非数字不再触发除零中止**：改为先 `[ -gt 0 ]` 校验。
+- **`checkin.sh` 缺 `python3` 不再误报「签到未成功」**：结果解析为空时改为提示「请求已提交，缺 python3 无法解析」，避免服务端已成功却被报失败。
+
+### 已知限制
+
 ### 已知限制
 
 - Windows / Linux 的 `CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info` 路径基于 v5.3.8 桌面端约定推导，已在 macOS 实测命中，其他平台待真实环境确认。

--- a/skills/workbuddy-checkin/SKILL.md
+++ b/skills/workbuddy-checkin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workbuddy-checkin
 description: WorkBuddy 每日积分自动签到。自动解密本地登录令牌，调用官方签到 API 完成每日积分领取（100 积分/天，连续第 7 天 1000 积分），并支持配置定时任务。触发词：WorkBuddy 签到、每日积分、check-in、credits。
-version: "1.0.1"
+version: "1.0.2"
 license: MIT
 ---
 
@@ -12,15 +12,20 @@ license: MIT
 
 ## 原理
 
-1. WorkBuddy 桌面端登录后，将 auth session（含 `accessToken`）用 Electron `safeStorage` 加密存于本地 `state.vscdb`。
-2. 用 Electron 运行时执行 `safeStorage.decryptString()` 解密（macOS 命中钥匙串密钥；Windows/Linux 走系统 DPAPI/keyring）。
-3. 调用腾讯官方签到 API：
+1. WorkBuddy 桌面端登录后，会在本地保存登录态。**v5.3.8+ 的新版桌面端**改为明文 JSON 文件：
+   - macOS：`~/Library/Application Support/CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info`
+   - 结构 `{ account, auth: { accessToken, refreshToken, expiresAt, ... }, accounts }`，桌面端临近过期会自动刷新，纯 Node 即可读取 `auth.accessToken`。
+2. **旧版 WorkBuddy/CodeBuddy** 仍把 auth session 用 Electron `safeStorage` 加密存于 `state.vscdb`；新版明文文件缺失时回退到此路径，用 Electron 运行时执行 `safeStorage.decryptString()` 解密（macOS 命中钥匙串；Windows/Linux 走 DPAPI/keyring）。
+3. 运行时策略：**Node 优先**（读新版明文文件，无需 Electron），缺失时回退 Electron（解旧版 `state.vscdb`）。
+4. 调用腾讯官方签到 API：
    - 查状态：`POST https://copilot.tencent.com/billing/meter/checkin-status`
    - 执行签到：`POST https://copilot.tencent.com/billing/meter/daily-checkin`
    - 认证：`Authorization: Bearer <accessToken>`
-4. 脚本幂等：先查状态，今日已签到则跳过。
+5. 脚本幂等：先查状态（命中即跳过）；`daily-checkin` 返回 `code=10001`（今天已签到）同样视为成功，避免重复请求被误报为失败。
 
-兼容旧版应用名 `CodeBuddy`（macOS 需设环境变量 `WB_CHECKIN_APP_NAME=CodeBuddy`）。
+> ⚠️ v5.3.8 实测 `checkin-status` 的 `today_checked_in` 字段不可靠（签到成功后仍可能为 `false`）。因此幂等性主要靠 `daily-checkin` 的 `code=10001` 兜底。
+
+兼容旧版应用名 `CodeBuddy`（仅旧版 `state.vscdb` 分支需要，macOS 需设环境变量 `WB_CHECKIN_APP_NAME=CodeBuddy`）。
 
 ## 文件结构
 
@@ -45,14 +50,18 @@ workbuddy-checkin/
 
 | 依赖 | 用途 | 安装方式 |
 |------|------|----------|
-| WorkBuddy 桌面端（已登录） | 提供本地登录会话 `state.vscdb` | 官网下载，必须登录过至少一次 |
-| Electron 运行时（≥ 30，推荐 37） | 解密令牌 | 运行 `scripts/setup.sh` 或 `setup.ps1` 自动下载，约 100MB |
+| WorkBuddy 桌面端（已登录） | 提供本地登录态（v5.3.8+ 明文文件 / 旧版 `state.vscdb`） | 官网下载，必须登录过至少一次 |
+| Node.js（推荐 20+，v5.3.8+ 主路径必需） | 读取新版明文登录态、解析 JSON | nodejs.org 下载，或系统包管理器 |
 | curl（macOS/Linux 自带）/ curl.exe | 调用签到 API | Windows 10 1803+ 自带 |
+| Electron 运行时（≥ 30，推荐 37） | **仅旧版** `state.vscdb` 分支解密令牌用 | 仅旧版账户需要，运行 `scripts/setup.sh` 或 `setup.ps1` |
+
+> v5.3.8+ 用户：装好 Node.js 并登录桌面端即可直接签到，**无需安装 Electron**。Electron 仅用于尚未迁移到新版明文存储的旧版 WorkBuddy/CodeBuddy 账户。
 
 ### 开箱即用 vs 需安装
 
-- **开箱即用**：已装 WorkBuddy 桌面端并登录 + 系统已有 Electron 二进制 → 直接运行签到脚本。
-- **需安装 Electron**：首次运行提示「未找到 Electron 运行时」时，执行：
+- **开箱即用（v5.3.8+）**：已装 WorkBuddy 桌面端并登录 + 系统已有 Node.js → 直接运行签到脚本。
+- **需安装 Node.js**：提示「未找到 Node」时，到 nodejs.org 安装，或用 `WB_CHECKIN_NODE=<path>` 指定。
+- **旧版账户需 Electron**：使用旧版 WorkBuddy/CodeBuddy（`state.vscdb`）且提示「未找到 Electron」时，执行：
 
   ```bash
   # macOS / Linux
@@ -65,9 +74,10 @@ workbuddy-checkin/
 
 | 依赖 | 缺失时行为 |
 |------|------------|
-| Node.js 内置 `node:sqlite`（Electron 37 / Node 22+ 自带） | 自动回退到 `python3` 读取 sqlite |
+| Electron 运行时 | 仅旧版 `state.vscdb` 账户需要；v5.3.8+ 新版明文路径不需要 |
+| Node.js 内置 `node:sqlite`（Electron 37 / Node 22+ 自带） | 旧版分支自动回退到 `python3` 读取 sqlite |
 | `python3` | sh 版 JSON 解析降级为 `unknown`，签到请求仍会执行 |
-| `npm`（仅 setup 首次安装用） | 手动放置 Electron 后用 `WB_CHECKIN_ELECTRON=<path>`（sh）/ `-ElectronPath <path>`（ps1）指定 |
+| `npm`（仅旧版 setup 首次安装 Electron 用） | 手动放置 Electron 后用 `WB_CHECKIN_ELECTRON=<path>`（sh）/ `-ElectronPath <path>`（ps1）指定 |
 
 完整依赖说明见 `references/dependencies.md`。
 
@@ -75,7 +85,7 @@ workbuddy-checkin/
 
 macOS / Linux：
 ```bash
-bash scripts/setup.sh     # 一键安装（检测/下载 Electron）
+bash scripts/setup.sh     # 检测运行时并验证令牌链路（v5.3.8+ 用 Node，旧版才需 Electron）
 bash scripts/checkin.sh   # 立即签到一次（验证）
 ```
 
@@ -85,7 +95,7 @@ powershell -ExecutionPolicy Bypass -File scripts\setup.ps1
 powershell -ExecutionPolicy Bypass -File scripts\checkin.ps1
 ```
 
-前提：本机已安装并**登录** WorkBuddy 桌面端。
+前提：本机已安装并**登录** WorkBuddy 桌面端；系统已安装 Node.js（v5.3.8+ 主路径）。
 
 ## 设置定时任务
 
@@ -136,32 +146,37 @@ WorkBuddy 环境下可调用自动化任务工具（`automation_update`，recurr
 
 ## 平台说明
 
-| 平台 | 脚本 | 会话库路径（自动探测） |
-|---|---|---|
-| macOS | `checkin.sh` | `~/Library/Application Support/WorkBuddy/User/globalStorage/state.vscdb` |
-| Windows | `checkin.ps1`（或 Git Bash 跑 `checkin.sh`） | `%APPDATA%\WorkBuddy\User\globalStorage\state.vscdb` |
-| Linux | `checkin.sh` | `~/.config/WorkBuddy/User/globalStorage/state.vscdb` |
+新版明文登录态（v5.3.8+，主路径，Node 读取）与旧版 `state.vscdb`（回退路径，Electron 解密）均自动探测。
+
+| 平台 | 脚本 | 新版明文登录态（v5.3.8+，主路径） | 旧版 state.vscdb（回退） |
+|---|---|---|---|
+| macOS | `checkin.sh` | `~/Library/Application Support/CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info` | `~/Library/Application Support/WorkBuddy/User/globalStorage/state.vscdb` |
+| Windows | `checkin.ps1`（或 Git Bash 跑 `checkin.sh`） | `%APPDATA%\CodeBuddyExtension\Data\Public\auth\workbuddy-desktop.info` | `%APPDATA%\WorkBuddy\User\globalStorage\state.vscdb` |
+| Linux | `checkin.sh` | `~/.config/CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info` | `~/.config/WorkBuddy/User/globalStorage/state.vscdb` |
 
 Windows PowerShell 执行策略用 `-ExecutionPolicy Bypass`；需 `curl.exe`（Win10 1803+ 自带）。
-Linux 需桌面会话 + 系统 keyring（GNOME Keyring / KWallet）。
+旧版 `state.vscdb` 分支在 Linux 需桌面会话 + 系统 keyring（GNOME Keyring / KWallet）；新版明文分支无此要求。
 
 ## 环境变量
 
 | 变量 | 作用 |
 |------|------|
-| `WB_CHECKIN_ELECTRON=<path>` | 指定 Electron 二进制路径（sh 版） |
+| `WB_CHECKIN_NODE=<path>` | 指定 Node 二进制路径（v5.3.8+ 主路径用，sh/ps1 通用） |
+| `WB_CHECKIN_ELECTRON=<path>` | 指定 Electron 二进制路径（仅旧版 state.vscdb 回退用，sh 版） |
 | `-ElectronPath <path>` | 同上（ps1 版参数） |
-| `WB_CHECKIN_APP_NAME=CodeBuddy` | 兼容旧版应用名（macOS 钥匙串密钥） |
+| `WB_CHECKIN_APP_NAME=CodeBuddy` | 兼容旧版应用名（仅旧版 state.vscdb 分支的 macOS 钥匙串密钥） |
 | `WB_CHECKIN_JITTER=<秒>` | 启动前随机等待 0~N 秒，避免整点风暴 |
 
 ## 排错
 
-- **解密失败 / 未找到本地会话**：WorkBuddy 桌面端未登录或从未打开过，先登录一次。
-- **401 令牌过期**：打开 WorkBuddy 刷新登录态，脚本每次运行会重新解密获取最新 token，次日自动恢复。
-- **macOS 解密报错但已登录**：旧版迁移应用名仍是 `CodeBuddy`，设 `export WB_CHECKIN_APP_NAME=CodeBuddy` 后重试。
-- **Electron 下载慢/失败**：配置 npm 镜像（见 `references/dependencies.md`）后重跑 setup；或手动放置 Electron 后用环境变量/参数指定。
+- **「获取令牌失败（未知原因）」/ 未找到本地登录态**：先确认 WorkBuddy 桌面端已登录并打开过至少一次。v5.3.8+ 用户检查 Node.js 是否安装（`node -v`），或用 `WB_CHECKIN_NODE` 指定。
+- **v5.3.8 已登录但仍报令牌失败**：本机 skill 版本过旧（< 1.0.2），不识别新版明文存储；升级到 1.0.2+。
+- **当日重跑提示「签到未成功 / code=10001」**：旧版本（< 1.0.2）未把 `code=10001` 识别为「已签到」；1.0.2+ 会正确报告「今日已签到」。
+- **401 令牌过期**：打开 WorkBuddy 刷新登录态，脚本每次运行会重新读取最新 token，次日自动恢复。
+- **macOS 解密报错但已登录（旧版账户）**：旧版迁移应用名仍是 `CodeBuddy`，设 `export WB_CHECKIN_APP_NAME=CodeBuddy` 后重试（仅走 state.vscdb 分支时生效）。
+- **Electron 下载慢/失败（旧版账户）**：配置 npm 镜像（见 `references/dependencies.md`）后重跑 setup；或手动放置 Electron 后用环境变量/参数指定。v5.3.8+ 新版账户无需 Electron。
 - **Windows 提示不是内部或外部命令**：用 `powershell -ExecutionPolicy Bypass -File …` 运行；确认 `curl.exe` 存在。
-- **沙箱里 `require('electron')` 报错**：Agent 沙箱默认设 `ELECTRON_RUN_AS_NODE=1`，脚本已用 `env -u`（sh）/ `Remove-Item Env:`（ps1）处理。
+- **沙箱里 `require('electron')` 报错**：Agent 沙箱默认设 `ELECTRON_RUN_AS_NODE=1`，脚本已用 `env -u`（sh）/ `Remove-Item Env:`（ps1）处理；v5.3.8+ 主路径用纯 Node，不受此影响。
 
 ## 安全说明
 
@@ -177,9 +192,10 @@ Linux 需桌面会话 + 系统 keyring（GNOME Keyring / KWallet）。
 
 本 skill 自述为"每日签到"，但完整链路需以下能力，均为本机运行、无后端，且对完成签到必不可少：
 
-- **解密本地令牌**：WorkBuddy 桌面端把登录态用 Electron `safeStorage` 加密存于本地 `state.vscdb`，必须解密才能调用官方签到接口。这是签到功能的核心，无法绕过。
-- **Electron 运行时**：执行 `safeStorage.decryptString()` 解密令牌（macOS 命中钥匙串、Windows/Linux 走系统 DPAPI/keyring）。推荐手动指定已校验的 Electron（设 `WB_CHECKIN_ELECTRON`），不依赖自动下载。
-- **python3 回退（默认关闭）**：仅当 `node:sqlite` 不可用时，设 `WB_CHECKIN_ALLOW_PY_FALLBACK=1` 才会调用外部 `python3` 读取会话库。默认关闭以缩小信任边界。
+- **读取本地令牌**：WorkBuddy 桌面端登录后把登录态存于本地——v5.3.8+ 为明文 JSON 文件（`workbuddy-desktop.info`，纯 Node 可读），旧版为 Electron `safeStorage` 加密的 `state.vscdb`。必须读到 `accessToken` 才能调用官方签到接口，这是签到功能的核心，无法绕过。
+- **Node.js 运行时**：v5.3.8+ 主路径用 Node 直接读取明文登录态并解析 JSON。推荐手动指定已校验的 Node（设 `WB_CHECKIN_NODE`）。
+- **Electron 运行时（仅旧版账户）**：只有使用旧版 WorkBuddy/CodeBuddy（`state.vscdb`）时才需要，执行 `safeStorage.decryptString()` 解密令牌（macOS 命中钥匙串、Windows/Linux 走系统 DPAPI/keyring）。推荐手动指定已校验的 Electron（设 `WB_CHECKIN_ELECTRON`），不依赖自动下载。
+- **python3 回退（默认关闭）**：仅当旧版分支的 `node:sqlite` 不可用时，设 `WB_CHECKIN_ALLOW_PY_FALLBACK=1` 才会调用外部 `python3` 读取会话库。默认关闭以缩小信任边界。
 - **定时任务（crontab / launchd / 任务计划程序）**：用于多时间点幂等补签，脚本本身不写入系统定时，需你显式配置。
 
 ### 供应链提示
@@ -193,7 +209,7 @@ Linux 需桌面会话 + 系统 keyring（GNOME Keyring / KWallet）。
 | 权限 | 范围 | 说明 |
 |------|------|------|
 | 本地代码执行 | 仅本 skill 的 `checkin.sh/.ps1`、`decrypt-token.js`、`setup.sh/.ps1` | 用户手动或定时触发，非后台常驻 |
-| 本地文件读取 | 仅用户目录下的 WorkBuddy `state.vscdb` 会话库 | 读取加密登录态以解密令牌 |
+| 本地文件读取 | 用户目录下的 WorkBuddy 登录态（v5.3.8+ 明文 `workbuddy-desktop.info` / 旧版 `state.vscdb`） | 读取登录态以获取调用官方接口所需的 accessToken |
 | 网络访问 | 仅 `copilot.tencent.com` 官方签到接口 | 不访问任何其他域名 |
-| 环境变量读取 | `WB_CHECKIN_*`（Electron 路径、应用名、错峰、回退开关） | 均为本机用户显式配置 |
+| 环境变量读取 | `WB_CHECKIN_*`（Node/Electron 路径、应用名、错峰、回退开关） | 均为本机用户显式配置 |
 | 定时任务 | 由用户显式配置 crontab / launchd / 任务计划程序 | skill 不自动写入系统定时 |

--- a/skills/workbuddy-checkin/references/dependencies.md
+++ b/skills/workbuddy-checkin/references/dependencies.md
@@ -1,29 +1,38 @@
 # 依赖清单（Dependencies）
 
-本 skill 运行链路：**解密本地令牌 → 调用官方 API → 写日志**。所需依赖如下。
+本 skill 运行链路：**读取本地令牌 → 调用官方 API → 写日志**。所需依赖如下。
+
+> v5.3.8+ 登录态改版说明：新版 WorkBuddy 桌面端把当前登录态写入明文 JSON 文件（`workbuddy-desktop.info`），不再写入 `state.vscdb`。本 skill v1.0.2+ 优先用 Node 读取该明文文件，旧版 `state.vscdb` 仅作回退。v1.0.0/1.0.1 因只认 `state.vscdb`，在 v5.3.8 桌面端上会报「获取令牌失败（未知原因）」，需升级到 1.0.2+。
 
 ## 核心依赖（必须有）
 
 | 组件 | 作用 | 获取方式 | 说明 |
 |---|---|---|---|
-| WorkBuddy 桌面端（已登录） | 提供本地登录会话（state.vscdb） | 官网下载：https://www.codebuddy.cn/work/ | 必须已登录过至少一次，否则没有可解密的令牌 |
-| Electron 运行时（>= 30，推荐 37） | 执行 `safeStorage.decryptString()` 解密令牌 | `scripts/setup.sh` / `setup.ps1` 自动下载（npm install electron@37），约 100MB | 与 WorkBuddy 桌面端同版本的 Electron 最稳；旧版 CodeBuddy 用户需设 `WB_CHECKIN_APP_NAME=CodeBuddy` |
+| WorkBuddy 桌面端（已登录） | 提供本地登录态（v5.3.8+ 明文文件 / 旧版 `state.vscdb`） | 官网下载：https://www.codebuddy.cn/work/ | 必须已登录过至少一次，否则没有可读的令牌 |
+| Node.js（推荐 20+） | 读取 v5.3.8+ 明文登录态、解析 JSON（主路径） | nodejs.org 下载 LTS；或系统包管理器 | v5.3.8+ 用户必需；可用 `WB_CHECKIN_NODE=<path>` 指定 |
 | curl（sh 版） / curl.exe（ps1 版） | 调用签到 API | macOS/Linux 自带；Windows 10 1803+ 自带 curl.exe | — |
+
+## 仅旧版账户需要的依赖
+
+| 组件 | 作用 | 获取方式 | 说明 |
+|---|---|---|---|
+| Electron 运行时（>= 30，推荐 37） | 仅旧版 `state.vscdb` 分支执行 `safeStorage.decryptString()` 解密令牌 | `scripts/setup.sh` / `setup.ps1`（npm install electron@37，约 100MB） | v5.3.8+ 新版账户**不需要**；旧版 CodeBuddy 用户需设 `WB_CHECKIN_APP_NAME=CodeBuddy` |
 
 ## 可选 / 回退依赖（缺了也能跑，只是走回退路径）
 
 | 组件 | 作用 | 缺失时的行为 |
 |---|---|---|
-| Node.js 内置 `node:sqlite` | 读取 state.vscdb | 解密脚本自动回退到 python3 |
+| Node.js 内置 `node:sqlite` | 仅旧版分支读取 state.vscdb | 旧版分支自动回退到 python3 |
 | python3 | 回退读取 sqlite + 解析 API 响应 JSON（sh 版） | sh 版解析会降级为 unknown，签到仍会执行 |
-| npm | 自动下载 Electron | 手动放置 Electron 后通过环境变量/参数指定路径 |
+| npm | 仅旧版 setup 自动下载 Electron | 手动放置 Electron 后通过环境变量/参数指定路径 |
 
-> 说明：decrypt-token.js 用 Node 内置 `node:sqlite` 读库（Electron 37 内置 Node 22 可用）；
+> 说明：旧版分支的 decrypt-token.js 用 Node 内置 `node:sqlite` 读库（Electron 37 内置 Node 22 可用）；
 > 若所用 Electron 版本较旧不支持 `node:sqlite`，会自动调用 `python3` 读取，无需额外安装 npm 包。
+> 新版明文分支为纯 JSON 文件读取，不涉及 sqlite。
 
 ## 网络要求
 
-- 需可访问 `https://copilot.tencent.com`（签到 API）与 `https://registry.npmjs.org`（首次安装 Electron）。
+- 需可访问 `https://copilot.tencent.com`（签到 API）；仅旧版账户首次安装 Electron 时才需 `https://registry.npmjs.org`。v5.3.8+ 新版账户走 Node 直读，无需下载 Electron。
 - 国内网络下载 Electron 慢时，配置镜像：
   ```bash
   npm config set registry https://registry.npmmirror.com
@@ -33,11 +42,15 @@
 
 ## 平台差异速查
 
-| 平台 | Shell | 会话库路径（自动探测） | Electron 二进制 |
-|---|---|---|---|
-| macOS | `checkin.sh`（bash） | `~/Library/Application Support/WorkBuddy/User/globalStorage/state.vscdb` | `Electron.app/Contents/MacOS/Electron` |
-| Windows | `checkin.ps1`（PowerShell）或 Git Bash 下 `checkin.sh` | `%APPDATA%\WorkBuddy\User\globalStorage\state.vscdb` | `electron.exe` |
-| Linux | `checkin.sh`（bash） | `~/.config/WorkBuddy/User/globalStorage/state.vscdb` | `electron`（无 .app 包裹） |
+新版明文登录态（v5.3.8+，主路径，Node 读取）与旧版 `state.vscdb`（回退，Electron 解密）均自动探测。
+
+| 平台 | Shell | 新版明文登录态（v5.3.8+，主路径） | 旧版 state.vscdb（回退） | Electron 二进制（仅旧版） |
+|---|---|---|---|---|
+| macOS | `checkin.sh`（bash） | `~/Library/Application Support/CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info` | `~/Library/Application Support/WorkBuddy/User/globalStorage/state.vscdb` | `Electron.app/Contents/MacOS/Electron` |
+| Windows | `checkin.ps1`（PowerShell）或 Git Bash 下 `checkin.sh` | `%APPDATA%\CodeBuddyExtension\Data\Public\auth\workbuddy-desktop.info` | `%APPDATA%\WorkBuddy\User\globalStorage\state.vscdb` | `electron.exe` |
+| Linux | `checkin.sh`（bash） | `~/.config/CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info` | `~/.config/WorkBuddy/User/globalStorage/state.vscdb` | `electron`（无 .app 包裹） |
+
+> ⚠️ Windows / Linux 的 `CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info` 路径基于 v5.3.8 桌面端约定推导，已在 macOS 实测命中；其他平台如路径不一致，请以实际安装为准并反馈。
 
 ## 安装后的目录结构（示意）
 
@@ -46,10 +59,10 @@ workbuddy-checkin/
 ├── SKILL.md
 ├── references/dependencies.md
 ├── scripts/
-│   ├── decrypt-token.js      # 跨平台，唯一需要 Electron 执行的脚本
-│   ├── checkin.sh            # macOS / Linux / Git Bash
-│   ├── checkin.ps1           # Windows PowerShell
-│   ├── setup.sh              # macOS / Linux 一键安装
-│   └── setup.ps1             # Windows 一键安装
+│   ├── decrypt-token.js      # 跨平台：新版明文 Node 读取 + 旧版 state.vscdb Electron 解密
+│   ├── checkin.sh            # macOS / Linux / Git Bash（Node 优先，Electron 回退）
+│   ├── checkin.ps1           # Windows PowerShell（Node 优先，Electron 回退）
+│   ├── setup.sh              # macOS / Linux 环境检查（Node 优先，旧版才需 Electron）
+│   └── setup.ps1             # Windows 环境检查
 └── logs/                     # 签到日志（自动创建）
 ```

--- a/skills/workbuddy-checkin/scripts/checkin.ps1
+++ b/skills/workbuddy-checkin/scripts/checkin.ps1
@@ -81,8 +81,8 @@ if ($NodeBin) {
         if ($out) { $Token = (($out | Select-Object -First 1).Line -replace "^DECRYPT_RESULT:", "").Trim() }
     } catch {}
 }
-# Electron 回退
-if (-not $Token) {
+# Electron 回退（Node 未取到有效 token，或 Node 报 ERR —— 如旧版账户无明文文件、纯 Node 无法解密 state.vscdb）
+if (-not $Token -or $Token.StartsWith("ERR")) {
     $Electron = Find-Electron
     if ($Electron) {
         # 关键：若环境存在 ELECTRON_RUN_AS_NODE，必须移除，否则 require('electron') 拿不到 safeStorage

--- a/skills/workbuddy-checkin/scripts/checkin.ps1
+++ b/skills/workbuddy-checkin/scripts/checkin.ps1
@@ -1,14 +1,17 @@
 # ============================================================
 # WorkBuddy 每日积分签到（Windows PowerShell 版，兼容 PS 5.1）
 #
-# 流程：解密本地令牌 → 查询签到状态 → 未签到则领取 → 写日志
+# 流程：读取本地令牌 → 查询签到状态 → 未签到则领取 → 写日志
 # 用法：
 #   powershell -ExecutionPolicy Bypass -File checkin.ps1
-# 或（如果已配置）：
+# 或（显式指定运行时）：
+#   $env:WB_CHECKIN_NODE="C:\path\to\node.exe"
 #   $env:WB_CHECKIN_ELECTRON="C:\path\to\electron.exe"
 #   powershell -ExecutionPolicy Bypass -File checkin.ps1
 # 定时（示例，每天 09:00，管理员或普通用户均可）：
 #   schtasks /Create /TN WorkBuddyDailyCheckin /TR "powershell -ExecutionPolicy Bypass -File C:\path\checkin.ps1" /SC DAILY /ST 09:00 /F
+#
+# 运行时策略：Node 优先（读取 v5.3.8+ 新版明文登录态），缺失时回退到 Electron + safeStorage。
 #
 # ⚠️ 凭据安全提示：
 #   - 本地令牌（accessToken）等同 WorkBuddy 账号密码，仅在本脚本内存中使用，
@@ -41,7 +44,19 @@ if ($env:WB_CHECKIN_JITTER) {
     } catch {}
 }
 
-# ---------- 探测 Electron 运行时 ----------
+# ---------- 探测 Node 运行时（v5.3.8+ 新版明文登录态优先用 Node 直读） ----------
+function Find-Node {
+    if ($env:WB_CHECKIN_NODE -and (Test-Path $env:WB_CHECKIN_NODE)) { return $env:WB_CHECKIN_NODE }
+    $cands = @(
+        (Get-Command node -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source),
+        (Join-Path $env:ProgramFiles "nodejs\node.exe"),
+        (Join-Path ${env:ProgramFiles(x86)} "nodejs\node.exe")
+    )
+    foreach ($c in $cands) { if ($c -and (Test-Path $c)) { return $c } }
+    return ""
+}
+
+# ---------- 探测 Electron 运行时（仅旧版 state.vscdb 回退分支需要） ----------
 function Find-Electron {
     if ($env:WB_CHECKIN_ELECTRON -and (Test-Path $env:WB_CHECKIN_ELECTRON)) {
         return $env:WB_CHECKIN_ELECTRON
@@ -52,30 +67,40 @@ function Find-Electron {
         (Join-Path $SkillRoot ".runtime\electron\electron.exe"),
         (Join-Path $ScriptDir "..\node_modules\electron\dist\electron.exe")
     )
-    foreach ($c in $cands) {
-        if ($c -and (Test-Path $c)) { return $c }
-    }
+    foreach ($c in $cands) { if ($c -and (Test-Path $c)) { return $c } }
     return ""
 }
 
-$Electron = Find-Electron
-if (-not $Electron) {
-    Write-Log "❌ 未找到 Electron 运行时。请先运行 setup.ps1，或设置 WB_CHECKIN_ELECTRON 指向 electron.exe。"
+# ---------- 1. 读取令牌：Node 优先，Electron 回退 ----------
+$Token = ""
+# Node 优先
+$NodeBin = Find-Node
+if ($NodeBin) {
+    try {
+        $out = & $NodeBin $DecryptJs 2>$null | Select-String "^DECRYPT_RESULT:"
+        if ($out) { $Token = (($out | Select-Object -First 1).Line -replace "^DECRYPT_RESULT:", "").Trim() }
+    } catch {}
+}
+# Electron 回退
+if (-not $Token) {
+    $Electron = Find-Electron
+    if ($Electron) {
+        # 关键：若环境存在 ELECTRON_RUN_AS_NODE，必须移除，否则 require('electron') 拿不到 safeStorage
+        Remove-Item Env:ELECTRON_RUN_AS_NODE -ErrorAction SilentlyContinue
+        try {
+            $out = & $Electron $DecryptJs 2>$null | Select-String "^DECRYPT_RESULT:"
+            if ($out) { $Token = (($out | Select-Object -First 1).Line -replace "^DECRYPT_RESULT:", "").Trim() }
+        } catch {
+            Write-Log "❌ 调用 Electron 解密脚本出错：$($_.Exception.Message)"
+        }
+    }
+}
+
+if (-not $Token) {
+    Write-Log "❌ 未找到 Node 或 Electron 运行时，或运行时未能产出令牌。请安装 Node.js，或设置 WB_CHECKIN_NODE / WB_CHECKIN_ELECTRON。"
     exit 1
 }
-
-# ---------- 1. 解密令牌 ----------
-# 关键：若环境存在 ELECTRON_RUN_AS_NODE，必须移除，否则 require('electron') 拿不到 safeStorage
-Remove-Item Env:ELECTRON_RUN_AS_NODE -ErrorAction SilentlyContinue
-$Token = ""
-try {
-    $out = & $Electron $DecryptJs 2>$null | Select-String "^DECRYPT_RESULT:"
-    if ($out) { $Token = (($out | Select-Object -First 1).Line -replace "^DECRYPT_RESULT:", "").Trim() }
-} catch {
-    Write-Log "❌ 调用解密脚本出错：$($_.Exception.Message)"
-}
-
-if (-not $Token -or $Token.StartsWith("ERR")) {
+if ($Token.StartsWith("ERR")) {
     Write-Log "❌ 获取令牌失败（$Token）。请确认已安装并登录 WorkBuddy 桌面端。"
     exit 1
 }
@@ -92,6 +117,8 @@ try {
 if (-not $Status) { Write-Log "❌ 查询签到状态失败（网络异常）"; exit 1 }
 if ($Status -match "401|unauthorized") { Write-Log "❌ 令牌已过期（401），请打开 WorkBuddy 桌面端刷新登录态后重试"; exit 1 }
 
+# 注意：today_checked_in 字段在 v5.3.8 实测不可靠（签到成功后仍可能为 false）。
+# 此处仅用于快速短路与 401 探测；真正的幂等兜底在下方 daily-checkin 的 code=10001 处理。
 $Checked = $false
 try { $Checked = [bool]($Status | ConvertFrom-Json).data.today_checked_in } catch {}
 if ($Checked) { Write-Log "✅ 今日已签到，无需重复领取"; exit 0 }
@@ -109,8 +136,10 @@ $Credit = ""
 try {
     $d = $Result | ConvertFrom-Json
     if ($d.code -eq 0) { $Credit = "OK credit=$($d.data.credit) streak_days=$($d.data.streak_days)" }
+    elseif ($d.code -eq 10001) { $Credit = "ALREADY today" }   # 当日已签到：接口幂等拒绝，视为成功
     else { $Credit = "FAIL code=$($d.code) msg=$($d.msg)" }
 } catch { $Credit = "PARSE_ERR" }
 
 if ($Credit -like "OK*") { Write-Log "🎉 签到成功！领取 $Credit" }
+elseif ($Credit -like "ALREADY*") { Write-Log "✅ 今日已签到，无需重复领取（接口返回已签到）" }
 else { Write-Log "⚠️ 签到未成功：$Credit" }

--- a/skills/workbuddy-checkin/scripts/checkin.sh
+++ b/skills/workbuddy-checkin/scripts/checkin.sh
@@ -2,13 +2,18 @@
 # ============================================================
 # WorkBuddy 每日积分签到（通用版，可分发）
 #
-# 流程：解密本地令牌 → 查询签到状态 → 未签到则领取 → 写日志
+# 流程：读取本地令牌 → 查询签到状态 → 未签到则领取 → 写日志
 # 用法：
-#   ./checkin.sh                      # 自动探测 Electron 运行时
+#   ./checkin.sh                      # 自动探测运行时（Node 优先，Electron 回退）
+#   WB_CHECKIN_NODE=<path> ./checkin.sh
 #   WB_CHECKIN_ELECTRON=<path> ./checkin.sh
 # 定时（示例，每天 09:00）：
 #   crontab -e
 #   0 9 * * * /path/to/checkin.sh >> /path/to/logs/checkin.log 2>&1
+#
+# 运行时策略：
+#   - 优先用 Node 读取 v5.3.8+ 的新版明文登录态（无需 Electron）。
+#   - 新版明文文件缺失时，回退到 Electron + safeStorage 解密旧版 state.vscdb。
 #
 # ⚠️ 凭据安全提示：
 #   - 本地令牌（accessToken）等同 WorkBuddy 账号密码，仅在本脚本内存中使用，
@@ -24,7 +29,27 @@ LOG_DIR="$SCRIPT_DIR/../logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/checkin.log"
 
-# ---------- 探测 Electron 运行时 ----------
+# ---------- 探测 Node 运行时（v5.3.8+ 新版明文登录态优先用 Node 直读） ----------
+find_node() {
+  # 1) 显式指定
+  if [ -n "${WB_CHECKIN_NODE:-}" ] && [ -x "$WB_CHECKIN_NODE" ]; then
+    echo "$WB_CHECKIN_NODE"; return
+  fi
+  # 2) PATH 上的 node + 常见绝对路径（cron/launchd 的 PATH 可能很精简）
+  local cands=(
+    "$(command -v node 2>/dev/null)"
+    "$HOME/.local/bin/node"
+    "/opt/homebrew/bin/node"
+    "/usr/local/bin/node"
+    "$HOME/.nvm/versions/node"/*/bin/node
+  )
+  for c in "${cands[@]}"; do
+    if [ -n "$c" ] && [ -x "$c" ]; then echo "$c"; return; fi
+  done
+  echo ""
+}
+
+# ---------- 探测 Electron 运行时（仅旧版 state.vscdb 回退分支需要） ----------
 find_electron() {
   # 1) 显式指定
   if [ -n "${WB_CHECKIN_ELECTRON:-}" ] && [ -x "$WB_CHECKIN_ELECTRON" ]; then
@@ -46,6 +71,23 @@ find_electron() {
   echo ""
 }
 
+# ---------- 读取令牌：Node 优先，Electron 回退 ----------
+read_token() {
+  local out="" node_bin electron_bin
+  node_bin="$(find_node)"
+  if [ -n "$node_bin" ]; then
+    out=$("$node_bin" "$DECRYPT_JS" 2>/dev/null | grep "^DECRYPT_RESULT:" | sed 's/^DECRYPT_RESULT://')
+  fi
+  if [ -z "$out" ]; then
+    electron_bin="$(find_electron)"
+    if [ -n "$electron_bin" ]; then
+      out=$(env -u ELECTRON_RUN_AS_NODE "$electron_bin" "$DECRYPT_JS" 2>/dev/null \
+        | grep "^DECRYPT_RESULT:" | sed 's/^DECRYPT_RESULT://')
+    fi
+  fi
+  echo "$out"
+}
+
 log() {
   local ts
   ts=$(date '+%Y-%m-%d %H:%M:%S')
@@ -59,18 +101,15 @@ if [ -n "${WB_CHECKIN_JITTER:-}" ]; then
   [ "$jitter" -gt 0 ] && sleep "$jitter"
 fi
 
-ELECTRON="$(find_electron)"
-if [ -z "$ELECTRON" ]; then
-  log "❌ 未找到 Electron 运行时。请先运行 setup.sh 安装，或设置 WB_CHECKIN_ELECTRON 指向 Electron 二进制。"
+# ---------- 1. 读取令牌 ----------
+TOKEN="$(read_token)"
+
+if [ -z "$TOKEN" ]; then
+  log "❌ 未找到 Node 或 Electron 运行时，或运行时未能产出令牌。请安装 Node.js，或设置 WB_CHECKIN_NODE / WB_CHECKIN_ELECTRON 指向可用运行时。"
   exit 1
 fi
-
-# ---------- 1. 解密令牌 ----------
-TOKEN=$(env -u ELECTRON_RUN_AS_NODE "$ELECTRON" "$DECRYPT_JS" 2>/dev/null \
-  | grep "^DECRYPT_RESULT:" | sed 's/^DECRYPT_RESULT://')
-
-if [ -z "$TOKEN" ] || [[ "$TOKEN" == ERR* ]]; then
-  log "❌ 获取令牌失败（${TOKEN:-未知原因}）。请确认已安装并登录 WorkBuddy 桌面端。"
+if [[ "$TOKEN" == ERR* ]]; then
+  log "❌ 获取令牌失败（${TOKEN}）。请确认已安装并登录 WorkBuddy 桌面端。"
   exit 1
 fi
 
@@ -90,6 +129,9 @@ if echo "$STATUS" | grep -qi "401\|unauthorized"; then
   exit 1
 fi
 
+# 注意：today_checked_in 字段在 v5.3.8 实测不可靠（签到成功后仍可能为 false）。
+# 此处仅用于「能省一次签到请求就省」的快速短路与 401 探测；真正的幂等兜底
+# 放在下方 daily-checkin 的 code=10001 处理。
 CHECKED=$(echo "$STATUS" | python3 -c "
 import sys, json
 try:
@@ -121,6 +163,9 @@ try:
     if d.get('code') == 0:
         data = d.get('data', {})
         print(f\"OK credit={data.get('credit')} streak_days={data.get('streak_days')}\")
+    elif d.get('code') == 10001:
+        # 当日已签到：接口幂等拒绝，视为成功
+        print('ALREADY today')
     else:
         print(f\"FAIL code={d.get('code')} msg={d.get('msg')}\")
 except Exception:
@@ -129,6 +174,8 @@ except Exception:
 
 if [[ "$CREDIT" == OK* ]]; then
   log "🎉 签到成功！领取 $CREDIT"
+elif [[ "$CREDIT" == ALREADY* ]]; then
+  log "✅ 今日已签到，无需重复领取（接口返回已签到）"
 else
   log "⚠️ 签到未成功：$CREDIT"
 fi

--- a/skills/workbuddy-checkin/scripts/checkin.sh
+++ b/skills/workbuddy-checkin/scripts/checkin.sh
@@ -78,7 +78,9 @@ read_token() {
   if [ -n "$node_bin" ]; then
     out=$("$node_bin" "$DECRYPT_JS" 2>/dev/null | grep "^DECRYPT_RESULT:" | sed 's/^DECRYPT_RESULT://')
   fi
-  if [ -z "$out" ]; then
+  if [ -z "$out" ] || [[ "$out" == ERR* ]]; then
+    # Node 未产出 token（未装 Node / 崩溃），或 Node 报 ERR（如旧版账户无明文文件、
+    # 纯 Node 无法解密 state.vscdb）→ 回退到 Electron 解旧版库
     electron_bin="$(find_electron)"
     if [ -n "$electron_bin" ]; then
       out=$(env -u ELECTRON_RUN_AS_NODE "$electron_bin" "$DECRYPT_JS" 2>/dev/null \
@@ -95,8 +97,9 @@ log() {
 }
 
 # ---------- 可选：随机错峰（避免整点风暴） ----------
-# 设置 WB_CHECKIN_JITTER=<秒> 时，脚本在开始前随机等待 0~N 秒
-if [ -n "${WB_CHECKIN_JITTER:-}" ]; then
+# 设置 WB_CHECKIN_JITTER=<正整数秒> 时，脚本在开始前随机等待 0~N 秒
+# 须 > 0：RANDOM % 0 会触发除零异常；非数字也会被 `[ -gt 0 ]` 拒绝（静默跳过）
+if [ "${WB_CHECKIN_JITTER:-0}" -gt 0 ] 2>/dev/null; then
   jitter=$((RANDOM % WB_CHECKIN_JITTER))
   [ "$jitter" -gt 0 ] && sleep "$jitter"
 fi
@@ -176,6 +179,9 @@ if [[ "$CREDIT" == OK* ]]; then
   log "🎉 签到成功！领取 $CREDIT"
 elif [[ "$CREDIT" == ALREADY* ]]; then
   log "✅ 今日已签到，无需重复领取（接口返回已签到）"
+elif [ -z "$CREDIT" ]; then
+  # 多为缺 python3 导致结果无法解析：服务端可能已成功，不能误报失败
+  log "⚠️ 签到请求已提交，但缺少 python3 无法解析结果（请打开 WorkBuddy 确认；安装 python3 可恢复明细）"
 else
   log "⚠️ 签到未成功：$CREDIT"
 fi

--- a/skills/workbuddy-checkin/scripts/decrypt-token.js
+++ b/skills/workbuddy-checkin/scripts/decrypt-token.js
@@ -144,7 +144,9 @@ function toBuffer(parsed) {
 // 主流程：新版明文文件优先，旧版 state.vscdb 回退
 // ============================================================
 
-// ---------- 1. 新版明文认证文件（WorkBuddy v5.3.8+，纯 Node 读取）----------
+// ---------- 1. 新版明文认证文件（WorkBuddy v5.3.8+，纯 Node 读取，优先）----------
+// 命中且含 accessToken 即输出；文件缺失 / 无 token / 解析失败均不硬失败，
+// 统一落入下方旧版 state.vscdb 分支兜底（覆盖升级中途、文件写入中等场景）。
 for (const f of desktopAuthFileCandidates()) {
   if (!fs.existsSync(f)) continue;
   try {
@@ -158,12 +160,9 @@ for (const f of desktopAuthFileCandidates()) {
       emitAndExit(0, "DECRYPT_RESULT:" + token);
       return;
     }
-    // 文件存在但无 accessToken：报具体错，不静默回退到旧版（避免掩盖新版存储故障）
-    emitAndExit(5, "DECRYPT_RESULT:ERR 新版认证文件已找到但缺少 auth.accessToken：" + f);
-    return;
+    // 文件存在但无 accessToken：落入旧版分支兜底
   } catch (e) {
-    emitAndExit(5, "DECRYPT_RESULT:ERR 解析新版认证文件失败(" + e.message + ")：" + f);
-    return;
+    // 解析失败（文件损坏 / 写入中）：忽略，落入旧版分支兜底
   }
 }
 
@@ -185,16 +184,23 @@ app.setName(APP_NAME);
 
 let dbPath = null;
 let raw = null;
+let legacyReadErr = null;
 for (const p of legacyVscdbCandidates()) {
   if (!fs.existsSync(p)) continue;
   for (const k of SESSION_KEYS) {
-    const v = readValue(p, k);
-    if (v) { dbPath = p; raw = v; break; }
+    try {
+      const v = readValue(p, k);
+      if (v) { dbPath = p; raw = v; break; }
+    } catch (e) {
+      legacyReadErr = e; // 记录但不中断，继续尝试其他候选 key/库
+    }
   }
   if (raw) break;
 }
 if (!raw) {
-  emitAndExit(2, "DECRYPT_RESULT:ERR 未找到 WorkBuddy 本地登录态（新版明文文件与旧版 state.vscdb 均未命中，请先安装并登录 WorkBuddy 桌面端）");
+  // 读取旧版库本身报错时附带原因，避免「未知原因」式失败（issue #68 投诉点）
+  const hint = legacyReadErr ? "（读取旧版 state.vscdb 失败：" + legacyReadErr.message + "）" : "";
+  emitAndExit(2, "DECRYPT_RESULT:ERR 未找到 WorkBuddy 本地登录态（新版明文文件与旧版 state.vscdb 均未命中" + hint + "，请先安装并登录 WorkBuddy 桌面端）");
   return;
 }
 

--- a/skills/workbuddy-checkin/scripts/decrypt-token.js
+++ b/skills/workbuddy-checkin/scripts/decrypt-token.js
@@ -1,45 +1,91 @@
 #!/usr/bin/env node
 /**
- * WorkBuddy 每日签到 - 令牌解密脚本（通用版，可分发）
+ * WorkBuddy 每日签到 - 令牌读取脚本（通用版，可分发）
  *
- * 从 WorkBuddy 桌面端的本地会话数据库（state.vscdb）读取用 Electron safeStorage
- * 加密的 auth session，解密后输出 accessToken，供签到脚本调用后端 API。
+ * 优先读取 WorkBuddy v5.3.8+ 的新版明文登录态；缺失时回退到旧版
+ * state.vscdb + Electron safeStorage 解密。最终输出 accessToken。
  *
  * ⚠️ 安全警示（务必阅读）：
  *   - 本脚本输出的 accessToken 等同 WorkBuddy 账号密码，属于高敏感凭据。
  *   - token 仅通过 stdout 的 `DECRYPT_RESULT:<token>` 单行输出，由调用方（checkin.sh/ps1）
  *     经管道立即消费；切勿 `tee`/重定向到文件、切勿粘贴分享、切勿提交到任何仓库。
  *   - 日志只记录签到结果（积分/连续天数），绝不记录 token 原文。
- *   - 解密成功时会向 stderr 打印一行安全提示（不进入 stdout，不会污染 token 管道）。
+ *   - 读取/解密成功时会向 stderr 打印一行安全提示（不进入 stdout，不会污染 token 管道）。
  *
- * 依赖：Electron 运行时（版本建议 >= 30，脚本内使用 node:sqlite 读取数据库）。
- * 运行方式：
- *   env -u ELECTRON_RUN_AS_NODE <electron二进制> decrypt-token.js
- *   （WorkBuddy 沙箱环境默认设置 ELECTRON_RUN_AS_NODE=1，会导致 require('electron')
- *     拿不到 safeStorage，因此必须显式取消该环境变量）
+ * 依赖：
+ *   - 新版明文分支：仅需 Node.js（无版本特殊要求），纯 Node 读取 JSON。
+ *   - 旧版 state.vscdb 分支：需要 Electron 运行时（≥ 30，使用 node:sqlite + safeStorage）。
+ *
+ * 运行方式（两种都支持，调用方按运行时可用性选择）：
+ *   node decrypt-token.js                                          # 新版明文优先，纯 Node 即可
+ *   env -u ELECTRON_RUN_AS_NODE <electron二进制> decrypt-token.js  # 旧版回退需要 Electron
  *
  * 输出：stdout 单行 `DECRYPT_RESULT:<accessToken>`；失败输出 DECRYPT_RESULT:ERR ...
  *
- * 跨平台：
- *   - macOS:   ~/Library/Application Support/WorkBuddy/User/globalStorage/state.vscdb
- *   - Windows: %APPDATA%\WorkBuddy\User\globalStorage\state.vscdb
- *   - Linux:   ~/.config/WorkBuddy/User/globalStorage/state.vscdb
- *   - 兼容旧版应用名 CodeBuddy 的路径。
+ * 跨平台登录态位置：
+ *   新版明文（v5.3.8+，主路径）：
+ *     - macOS:   ~/Library/Application Support/CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info
+ *     - Windows: %APPDATA%\CodeBuddyExtension\Data\Public\auth\workbuddy-desktop.info
+ *     - Linux:   ~/.config/CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info
+ *   旧版 state.vscdb（回退路径，兼容 WorkBuddy / CodeBuddy 早期版本）：
+ *     - macOS:   ~/Library/Application Support/{WorkBuddy,CodeBuddy}/User/globalStorage/state.vscdb
+ *     - Windows: %APPDATA%\{WorkBuddy,CodeBuddy}\User\globalStorage\state.vscdb
+ *     - Linux:   ~/.config/{WorkBuddy,CodeBuddy}/User/globalStorage/state.vscdb
  */
 "use strict";
 
-const { app, safeStorage } = require("electron");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
 const { execFileSync } = require("child_process");
 
-// ---------- 会话数据库候选路径（按优先级） ----------
-function candidatePaths() {
+// Electron 仅旧版 state.vscdb 分支需要；try/catch 使脚本可在纯 node 下执行。
+// 新版明文分支不依赖 Electron，require 失败时自动跳过旧版分支。
+let app = null;
+let safeStorage = null;
+try {
+  const electron = require("electron");
+  app = electron.app || null;
+  safeStorage = electron.safeStorage || null;
+} catch (e) {
+  // 纯 Node 运行（无 Electron）：仅新版明文分支可用，旧版 state.vscdb 分支自动禁用。
+}
+
+// ---------- 统一输出：先 flush stdout，延迟退出 ----------
+// 旧实现 console.log 后立即 app.exit() 在某些环境下会截断未 flush 的 stdout，
+// 改为 process.stdout.write 后延迟约 200ms 再退出，确保 token 完整送达调用方管道。
+function emitAndExit(code, line) {
+  process.stdout.write(line + "\n");
+  const exitFn = app ? () => app.exit(code) : () => process.exit(code);
+  setTimeout(exitFn, 200);
+}
+
+// ---------- 新版明文认证文件候选路径（按平台） ----------
+function desktopAuthFileCandidates() {
   const home = os.homedir();
   const ap = process.env.APPDATA || "";
   const xdg = process.env.XDG_CONFIG_HOME || path.join(home, ".config");
-  const list = [];
+  const rel = path.join(
+    "CodeBuddyExtension",
+    "Data",
+    "Public",
+    "auth",
+    "workbuddy-desktop.info",
+  );
+  if (process.platform === "darwin") {
+    return [path.join(home, "Library", "Application Support", rel)];
+  }
+  if (process.platform === "win32") {
+    return [path.join(ap, rel)];
+  }
+  return [path.join(xdg, rel)];
+}
+
+// ---------- 旧版 state.vscdb 会话库候选路径（按优先级） ----------
+function legacyVscdbCandidates() {
+  const home = os.homedir();
+  const ap = process.env.APPDATA || "";
+  const xdg = process.env.XDG_CONFIG_HOME || path.join(home, ".config");
   const apps = ["WorkBuddy", "CodeBuddy"];
   const roots =
     process.platform === "darwin"
@@ -47,13 +93,10 @@ function candidatePaths() {
       : process.platform === "win32"
         ? apps.map((a) => path.join(ap, a))
         : apps.map((a) => path.join(xdg, a));
-  for (const r of roots) {
-    list.push(path.join(r, "User", "globalStorage", "state.vscdb"));
-  }
-  return list;
+  return roots.map((r) => path.join(r, "User", "globalStorage", "state.vscdb"));
 }
 
-// ---------- 会话 key 候选 ----------
+// ---------- 旧版会话 key 候选 ----------
 const SESSION_KEYS = [
   'secret://{"extensionId":"tencent-cloud.coding-copilot","key":"planning-genie.new.accessTokencn"}',
 ];
@@ -97,7 +140,44 @@ function toBuffer(parsed) {
   return null;
 }
 
-// ---------- 主流程 ----------
+// ============================================================
+// 主流程：新版明文文件优先，旧版 state.vscdb 回退
+// ============================================================
+
+// ---------- 1. 新版明文认证文件（WorkBuddy v5.3.8+，纯 Node 读取）----------
+for (const f of desktopAuthFileCandidates()) {
+  if (!fs.existsSync(f)) continue;
+  try {
+    const j = JSON.parse(fs.readFileSync(f, "utf8"));
+    const token = j && j.auth && j.auth.accessToken;
+    if (token && typeof token === "string") {
+      process.stderr.write(
+        "[安全提示] 已从本地登录态读取 accessToken（新版明文存储），仅用于 WorkBuddy 官方签到接口；" +
+        "请勿将其写入日志、分享或提交。\n"
+      );
+      emitAndExit(0, "DECRYPT_RESULT:" + token);
+      return;
+    }
+    // 文件存在但无 accessToken：报具体错，不静默回退到旧版（避免掩盖新版存储故障）
+    emitAndExit(5, "DECRYPT_RESULT:ERR 新版认证文件已找到但缺少 auth.accessToken：" + f);
+    return;
+  } catch (e) {
+    emitAndExit(5, "DECRYPT_RESULT:ERR 解析新版认证文件失败(" + e.message + ")：" + f);
+    return;
+  }
+}
+
+// ---------- 2. 回退：旧版 state.vscdb + Electron safeStorage ----------
+if (!app || !safeStorage) {
+  // 纯 Node 运行且无新版明文文件：无法走 safeStorage 分支，给出明确指引。
+  emitAndExit(
+    6,
+    "DECRYPT_RESULT:ERR 未找到新版明文认证文件，且当前为纯 Node 运行（无 Electron）无法解密旧版 state.vscdb。" +
+    "请确认已安装并登录 WorkBuddy 桌面端 v5.3.8+；旧版账户请改用 Electron 运行时执行本脚本。"
+  );
+  return;
+}
+
 // 注意：app.setName 必须在 ready 之前调用，否则 safeStorage 会以默认应用名
 // 绑定钥匙串服务，导致解不到 WorkBuddy 的密钥。旧版应用名可通过环境变量覆盖。
 const APP_NAME = process.env.WB_CHECKIN_APP_NAME || "WorkBuddy";
@@ -105,7 +185,7 @@ app.setName(APP_NAME);
 
 let dbPath = null;
 let raw = null;
-for (const p of candidatePaths()) {
+for (const p of legacyVscdbCandidates()) {
   if (!fs.existsSync(p)) continue;
   for (const k of SESSION_KEYS) {
     const v = readValue(p, k);
@@ -114,16 +194,13 @@ for (const p of candidatePaths()) {
   if (raw) break;
 }
 if (!raw) {
-  console.log("DECRYPT_RESULT:ERR 未找到 WorkBuddy 本地会话（请先安装并登录 WorkBuddy 桌面端）");
-  app.exit(2);
+  emitAndExit(2, "DECRYPT_RESULT:ERR 未找到 WorkBuddy 本地登录态（新版明文文件与旧版 state.vscdb 均未命中，请先安装并登录 WorkBuddy 桌面端）");
   return;
 }
 
 app.whenReady().then(() => {
-  // safeStorage 可用性
   if (!safeStorage.isEncryptionAvailable()) {
-    console.log("DECRYPT_RESULT:ERR 系统加密不可用");
-    app.exit(3);
+    emitAndExit(3, "DECRYPT_RESULT:ERR 系统加密不可用");
     return;
   }
   try {
@@ -133,23 +210,20 @@ app.whenReady().then(() => {
     const session = JSON.parse(decrypted);
     const token = session && session.auth && session.auth.accessToken;
     if (token) {
-      // 安全提示走 stderr，不污染 stdout 的 token 管道
       process.stderr.write(
-        "[安全提示] 已从本地会话解密 accessToken，仅用于 WorkBuddy 官方签到接口；" +
+        "[安全提示] 已从本地会话解密 accessToken（旧版 state.vscdb），仅用于 WorkBuddy 官方签到接口；" +
         "请勿将其写入日志、分享或提交。\n"
       );
-      process.stdout.write("DECRYPT_RESULT:" + token + "\n");
-      app.exit(0);
+      emitAndExit(0, "DECRYPT_RESULT:" + token);
       return;
     }
-    console.log("DECRYPT_RESULT:ERR 会话中无 accessToken");
-    app.exit(4);
+    emitAndExit(4, "DECRYPT_RESULT:ERR 会话中无 accessToken");
   } catch (e) {
-    console.log(
+    emitAndExit(
+      4,
       "DECRYPT_RESULT:ERR 解密失败(" + e.message +
       ")。若为旧版应用（CodeBuddy），请设置环境变量 WB_CHECKIN_APP_NAME=CodeBuddy 后重试；" +
       "或打开 WorkBuddy 桌面端刷新登录态"
     );
-    app.exit(4);
   }
 });

--- a/skills/workbuddy-checkin/scripts/setup.ps1
+++ b/skills/workbuddy-checkin/scripts/setup.ps1
@@ -1,6 +1,9 @@
 # ============================================================
 # WorkBuddy 每日签到 - 环境安装脚本（Windows PowerShell 版）
-# 自动检测/下载 Electron 运行时，并验证令牌解密链路。
+# 检测运行时并验证令牌读取链路。
+#
+# v5.3.8+ 新版登录态为明文 JSON，纯 Node 即可读取，无需 Electron。
+# 仅当使用旧版 WorkBuddy/CodeBuddy（state.vscdb 加密登录态）时才需要 Electron。
 #
 # 用法：
 #   powershell -ExecutionPolicy Bypass -File setup.ps1
@@ -15,11 +18,25 @@ $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $SkillRoot = Split-Path -Parent $ScriptDir
 $RuntimeDir = Join-Path $SkillRoot ".runtime"
 $DefaultElectron = Join-Path $RuntimeDir "electron\electron.exe"
+$DecryptJs = Join-Path $ScriptDir "decrypt-token.js"
 
 Write-Output "== WorkBuddy 每日签到 · 环境检查 =="
 
+# ---------- 探测 Node（v5.3.8+ 新版明文登录态优先用 Node 直读）----------
+function Find-Node {
+    if ($env:WB_CHECKIN_NODE -and (Test-Path $env:WB_CHECKIN_NODE)) { return $env:WB_CHECKIN_NODE }
+    $cands = @(
+        (Get-Command node -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source),
+        (Join-Path $env:ProgramFiles "nodejs\node.exe"),
+        (Join-Path ${env:ProgramFiles(x86)} "nodejs\node.exe")
+    )
+    foreach ($c in $cands) { if ($c -and (Test-Path $c)) { return $c } }
+    return ""
+}
+
 function Find-Electron {
     if ($ElectronPath -and (Test-Path $ElectronPath)) { return $ElectronPath }
+    if ($env:WB_CHECKIN_ELECTRON -and (Test-Path $env:WB_CHECKIN_ELECTRON)) { return $env:WB_CHECKIN_ELECTRON }
     $cands = @(
         (Join-Path $HOME ".workbuddy\tools\electron\electron.exe"),
         $DefaultElectron,
@@ -29,15 +46,45 @@ function Find-Electron {
     return ""
 }
 
+# ---------- 用 Node 探测新版明文登录态是否可用（不输出 token 内容） ----------
+$NodeBin = Find-Node
+$Token = ""
+if ($NodeBin) {
+    try {
+        $out = & $NodeBin $DecryptJs 2>$null | Select-String "^DECRYPT_RESULT:"
+        if ($out) { $Token = (($out | Select-Object -First 1).Line -replace "^DECRYPT_RESULT:", "").Trim() }
+    } catch { $Token = "" }
+}
+
+# ============================================================
+# 路径 A：新版明文登录态（v5.3.8+）→ 纯 Node 即可，无需 Electron
+# ============================================================
+if ($NodeBin -and $Token -and -not $Token.StartsWith("ERR")) {
+    Write-Output "✅ 检测到新版登录态（WorkBuddy v5.3.8+ 明文存储），Node 可直接读取。"
+    Write-Output "✅ 令牌读取链路可用（运行时：$NodeBin），无需安装 Electron。"
+    Write-Output ""
+    Write-Output "== 完成 =="
+    $CheckinPs1 = Join-Path $ScriptDir "checkin.ps1"
+    Write-Output "运行签到：  powershell -ExecutionPolicy Bypass -File `"$CheckinPs1`""
+    exit 0
+}
+
+# ============================================================
+# 路径 B：旧版 state.vscdb 加密登录态 → 需要 Electron 运行时
+# ============================================================
+Write-Output "（未检测到新版明文登录态，按旧版 state.vscdb 流程处理，需要 Electron 运行时。）"
+Write-Output ""
+
 $Electron = Find-Electron
 if (-not $Electron) {
     # 供应链安全：自动从 npm 下载第三方运行时（约 100MB）默认关闭，需显式开启。
     if (-not $env:WB_CHECKIN_AUTO_INSTALL_ELECTRON) {
-        Write-Output "⚠️ 未检测到 Electron 运行时。"
-        Write-Output "   为降低供应链风险，自动下载默认关闭。请二选一："
+        Write-Output "⚠️ 未检测到 Node 可读的新版登录态，也未找到 Electron 运行时。"
+        Write-Output "   大多数用户应先确认：已安装 WorkBuddy 桌面端 v5.3.8+ 并登录（新版登录态优先用 Node 读取）。"
+        Write-Output "   仅旧版 WorkBuddy/CodeBuddy（state.vscdb）账户才需要 Electron，二选一："
         Write-Output "   1) 手动指定已校验的 Electron：  setup.ps1 -ElectronPath C:\path\to\electron.exe"
         Write-Output "   2) 确认要从官方 npm 下载（约 100MB），先执行："
-        Write-Output "        $env:WB_CHECKIN_AUTO_INSTALL_ELECTRON=1"
+        Write-Output "        `$env:WB_CHECKIN_AUTO_INSTALL_ELECTRON=1"
         Write-Output "      再运行本脚本。"
         exit 1
     }
@@ -69,18 +116,19 @@ if (-not $Electron) {
     Write-Output "✅ 已检测到 Electron：$Electron"
 }
 
-# ---------- 验证解密链路 ----------
+# ---------- 验证旧版解密链路 ----------
 Write-Output "== 验证令牌解密 =="
 Remove-Item Env:ELECTRON_RUN_AS_NODE -ErrorAction SilentlyContinue
 $Token = ""
 try {
-    $out = & $Electron (Join-Path $ScriptDir "decrypt-token.js") 2>$null | Select-String "^DECRYPT_RESULT:"
+    $out = & $Electron $DecryptJs 2>$null | Select-String "^DECRYPT_RESULT:"
     if ($out) { $Token = (($out | Select-Object -First 1).Line -replace "^DECRYPT_RESULT:", "").Trim() }
 } catch { $Token = "" }
 
 if (-not $Token -or $Token.StartsWith("ERR")) {
     Write-Output "❌ 解密失败（$Token）。请确认：1) 已安装并登录 WorkBuddy 桌面端；"
-    Write-Output "   2) 若为旧版应用名（CodeBuddy），设置环境变量 WB_CHECKIN_APP_NAME=CodeBuddy 后重试。"
+    Write-Output "   2) 旧版账户应用名若为 CodeBuddy，设置环境变量 WB_CHECKIN_APP_NAME=CodeBuddy 后重试；"
+    Write-Output "   3) 新版 v5.3.8+ 账户应安装 Node.js 用 Node 直读。"
     exit 1
 }
 

--- a/skills/workbuddy-checkin/scripts/setup.sh
+++ b/skills/workbuddy-checkin/scripts/setup.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 # ============================================================
 # WorkBuddy 每日签到 - 环境安装脚本（通用版）
-# 自动检测/安装 Electron 运行时，并验证令牌解密链路是否可用。
+# 检测运行时并验证令牌读取链路是否可用。
+#
+# v5.3.8+ 新版登录态为明文 JSON，纯 Node 即可读取，无需 Electron。
+# 仅当使用旧版 WorkBuddy/CodeBuddy（state.vscdb 加密登录态）时才需要 Electron。
 #
 # 用法：./setup.sh [--electron <路径或自动下载>]
-#   --electron auto   （默认）检测已有运行时，缺失则通过 npm 下载
-#   --electron <path> 指定已安装的 Electron 二进制
+#   （默认）自动探测：Node 优先；旧版账户缺失 Electron 时提示安装
+#   --electron auto   检测已有运行时，缺失则通过 npm 下载
+#   --electron <path> 指定已安装的 Electron 二进制（旧版账户用）
 # ============================================================
 set -uo pipefail
 
@@ -16,8 +20,23 @@ ELECTRON_BIN="$RUNTIME_DIR/electron/Electron.app/Contents/MacOS/Electron"
 
 echo "== WorkBuddy 每日签到 · 环境检查 =="
 
-# ---------- 检测已存在的 Electron ----------
-detect() {
+# ---------- 探测 Node（v5.3.8+ 新版明文登录态优先用 Node 直读）----------
+find_node() {
+  local cands=(
+    "$(command -v node 2>/dev/null)"
+    "$HOME/.local/bin/node"
+    "/opt/homebrew/bin/node"
+    "/usr/local/bin/node"
+    "$HOME/.nvm/versions/node"/*/bin/node
+  )
+  for c in "${cands[@]}"; do
+    if [ -n "$c" ] && [ -x "$c" ]; then echo "$c"; return 0; fi
+  done
+  return 1
+}
+
+# ---------- 探测已存在的 Electron（仅旧版 state.vscdb 回退需要）----------
+detect_electron() {
   local cands=(
     "$HOME/.workbuddy/tools/electron/Electron.app/Contents/MacOS/Electron"
     "$ELECTRON_BIN"
@@ -29,57 +48,96 @@ detect() {
   return 1
 }
 
+# ---------- 用 Node 探测新版明文登录态是否可用（不输出 token 内容）----------
+probe_token_with_node() {
+  local node_bin line
+  node_bin="$(find_node)" || return 1
+  line=$("$node_bin" "$SCRIPT_DIR/decrypt-token.js" 2>/dev/null | grep "^DECRYPT_RESULT:" | head -1)
+  [ -n "$line" ] || return 1
+  case "$line" in
+    DECRYPT_RESULT:ERR*) return 1;;   # 新版文件缺失/异常 → 走旧版流程
+    *) return 0;;
+  esac
+}
+
+chmod +x "$SCRIPT_DIR/checkin.sh" 2>/dev/null
+
+# ============================================================
+# 路径 A：新版明文登录态（v5.3.8+）→ 纯 Node 即可，无需 Electron
+# ============================================================
+if probe_token_with_node; then
+  NODE_BIN="$(find_node)"
+  echo "✅ 检测到新版登录态（WorkBuddy v5.3.8+ 明文存储），Node 可直接读取。"
+  echo "✅ 令牌读取链路可用（运行时：${NODE_BIN}），无需安装 Electron。"
+  echo ""
+  echo "== 完成 =="
+  echo "运行签到：  $SCRIPT_DIR/checkin.sh"
+  echo "设置定时：  每天 09:00 示例 → crontab -e 添加："
+  echo "  0 9 * * * $SCRIPT_DIR/checkin.sh >> $SKILL_ROOT/logs/checkin.log 2>&1"
+  exit 0
+fi
+
+# ============================================================
+# 路径 B：旧版 state.vscdb 加密登录态 → 需要 Electron 运行时
+# ============================================================
+echo "（未检测到新版明文登录态，按旧版 state.vscdb 流程处理，需要 Electron 运行时。）"
+echo ""
+
 MODE="${1:-auto}"
 ELECTRON=""
 
 # 供应链安全：自动从 npm 下载第三方运行时（约 100MB）默认关闭，需显式开启。
 # 推荐手动指定已校验的 Electron：setup.sh --electron /path/to/electron
 if [ -z "${WB_CHECKIN_AUTO_INSTALL_ELECTRON:-}" ] && [ "$MODE" = "auto" ]; then
-  echo "⚠️ 未检测到 Electron 运行时。"
-  echo "   为降低供应链风险，自动下载默认关闭。请二选一："
-  echo "   1) 手动指定已校验的 Electron：  setup.sh --electron /path/to/electron"
-  echo "   2) 确认要从官方 npm 下载（约 100MB），先执行："
-  echo "        export WB_CHECKIN_AUTO_INSTALL_ELECTRON=1"
-  echo "      再运行本脚本。"
-  echo "   （手动放置后也可用环境变量 WB_CHECKIN_ELECTRON=<path> 直接运行 checkin.sh）"
-  exit 1
+  if ELECTRON="$(detect_electron)"; then
+    echo "✅ 已检测到 Electron：$ELECTRON"
+  else
+    echo "⚠️ 未检测到 Node 可读的新版登录态，也未找到 Electron 运行时。"
+    echo "   大多数用户应先确认：已安装 WorkBuddy 桌面端 v5.3.8+ 并登录（新版登录态优先用 Node 读取）。"
+    echo "   仅旧版 WorkBuddy/CodeBuddy（state.vscdb）账户才需要 Electron，二选一："
+    echo "   1) 手动指定已校验的 Electron：  setup.sh --electron /path/to/electron"
+    echo "   2) 确认要从官方 npm 下载（约 100MB），先执行："
+    echo "        export WB_CHECKIN_AUTO_INSTALL_ELECTRON=1"
+    echo "      再运行本脚本。"
+    echo "   （手动放置后也可用环境变量 WB_CHECKIN_ELECTRON=<path> 直接运行 checkin.sh）"
+    exit 1
+  fi
+else
+  case "$MODE" in
+    auto)
+      if ELECTRON="$(detect_electron)"; then
+        echo "✅ 已检测到 Electron：$ELECTRON"
+      else
+        echo "⚠️ 未检测到 Electron 运行时，尝试通过 npm 下载（约 100MB，需要 node/npm）..."
+        echo "   ⚠️ 供应链提示：将从官方 npm registry 下载 electron@37 并执行，请确认网络可信。"
+        command -v npm >/dev/null 2>&1 || { echo "❌ 未找到 npm，请先安装 Node.js，或手动放置 Electron 后重试"; exit 1; }
+        mkdir -p "$RUNTIME_DIR"
+        cd "$RUNTIME_DIR"
+        npm init -y >/dev/null 2>&1
+        npm install electron@37 >/dev/null 2>&1 || { echo "❌ Electron 下载失败（网络/代理问题），请手动安装"; exit 1; }
+        mv node_modules/electron/dist "$RUNTIME_DIR/electron"
+        rm -rf node_modules package.json package-lock.json
+        ELECTRON="$ELECTRON_BIN"
+        echo "✅ Electron 安装完成：$ELECTRON"
+      fi
+      ;;
+    --electron)
+      ELECTRON="$2"
+      [ -x "$ELECTRON" ] || { echo "❌ 指定的 Electron 不存在：$ELECTRON"; exit 1; }
+      echo "✅ 使用指定 Electron：$ELECTRON"
+      ;;
+    *)
+      echo "用法：$0 [--electron <path>]"; exit 1;;
+  esac
 fi
 
-case "$MODE" in
-  auto)
-    if ELECTRON="$(detect)"; then
-      echo "✅ 已检测到 Electron：$ELECTRON"
-    else
-      echo "⚠️ 未检测到 Electron 运行时，尝试通过 npm 下载（约 100MB，需要 node/npm）..."
-      echo "   ⚠️ 供应链提示：将从官方 npm registry 下载 electron@37 并执行，请确认网络可信。"
-      command -v npm >/dev/null 2>&1 || { echo "❌ 未找到 npm，请先安装 Node.js，或手动放置 Electron 后重试"; exit 1; }
-      mkdir -p "$RUNTIME_DIR"
-      cd "$RUNTIME_DIR"
-      npm init -y >/dev/null 2>&1
-      npm install electron@37 >/dev/null 2>&1 || { echo "❌ Electron 下载失败（网络/代理问题），请手动安装"; exit 1; }
-      mv node_modules/electron/dist "$RUNTIME_DIR/electron"
-      rm -rf node_modules package.json package-lock.json
-      ELECTRON="$ELECTRON_BIN"
-      echo "✅ Electron 安装完成：$ELECTRON"
-    fi
-    ;;
-  --electron)
-    ELECTRON="$2"
-    [ -x "$ELECTRON" ] || { echo "❌ 指定的 Electron 不存在：$ELECTRON"; exit 1; }
-    echo "✅ 使用指定 Electron：$ELECTRON"
-    ;;
-  *)
-    echo "用法：$0 [--electron <path>]"; exit 1;;
-esac
-
-# ---------- 验证解密链路 ----------
-chmod +x "$SCRIPT_DIR/checkin.sh" 2>/dev/null
+# ---------- 验证旧版解密链路 ----------
 echo "== 验证令牌解密 =="
 TOKEN=$(env -u ELECTRON_RUN_AS_NODE "$ELECTRON" "$SCRIPT_DIR/decrypt-token.js" 2>/dev/null \
   | grep "^DECRYPT_RESULT:" | sed 's/^DECRYPT_RESULT://')
 
 if [ -z "$TOKEN" ] || [[ "$TOKEN" == ERR* ]]; then
-  echo "❌ 解密失败（${TOKEN:-未知原因}）。请确认：1) 已安装并登录 WorkBuddy 桌面端；2) 应用名是 WorkBuddy（老版本 CodeBuddy 会自动兼容）。"
+  echo "❌ 解密失败（${TOKEN:-未知原因}）。请确认：1) 已安装并登录 WorkBuddy 桌面端；2) 旧版账户应用名为 WorkBuddy（老版本 CodeBuddy 设 WB_CHECKIN_APP_NAME=CodeBuddy）；3) 新版 v5.3.8+ 账户应安装 Node.js 用 Node 直读。"
   exit 1
 fi
 


### PR DESCRIPTION
## 背景

Fixes #68

WorkBuddy 桌面端 v5.3.8 用户在 `workbuddy-checkin` v1.0.1 上连续报 `❌ 获取令牌失败（未知原因）`，每日自动化签到完全不可用。

## 根因（已在贡献者本机独立复核）

1. **新版桌面端不再用 `state.vscdb` 存当前登录态**：v5.3.8 改用明文 JSON 文件
   `~/Library/Application Support/CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info`
   （结构 `{account, auth:{accessToken,refreshToken,expiresAt,...}, accounts}`，桌面端临近过期自动刷新），v1.0.1 只读 `state.vscdb` 故取不到 token。
2. **macOS 直接跑 WorkBuddy.app 的 Electron 二进制不执行脚本**：会启动主应用而非跑 `decrypt-token.js`，无 `DECRYPT_RESULT:` 产出。
3. **`today_checked_in` 不可靠**：签到成功后仍可能为 `false`，当日重跑 `daily-checkin` 返回 `code=10001`（今天已签到），v1.0.1 将其误报为「签到未成功」，幂等分支失效。

## 改动（v1.0.1 → v1.0.2，8 文件）

- **`decrypt-token.js`**：新版明文文件优先、旧版 `state.vscdb` 回退；`require("electron")` 包 try/catch（纯 `node` 可执行）；统一 `emitAndExit()`（`stdout.write` 后延迟 ~200ms 退出，避免 flush 截断）。
- **`checkin.sh` / `checkin.ps1`**：Node 优先、Electron 回退（新增 `WB_CHECKIN_NODE=<path>`）；`daily-checkin` 返回 `code=10001` 识别为「今日已签到」。
- **`setup.sh` / `setup.ps1`**：Node 优先探测，v5.3.8 用户（仅有 Node）不再被误判「未找到 Electron」而失败。
- **`SKILL.md` / `references/dependencies.md` / `CHANGELOG.md`**：原理、平台路径（新版明文 + 旧版 vscdb 双列）、依赖（Electron 降级为仅旧版可选）、环境变量（新增 `WB_CHECKIN_NODE`）、排错（v5.3.8 专项条目）、v1.0.2 变更说明。

## 验证（贡献者本机真实 WorkBuddy v5.3.8 + 真实账号）

| 步骤 | 结果 |
|---|---|
| `node decrypt-token.js` 单测 | ✅ 输出 `DECRYPT_RESULT:<JWT>`，无需 Electron |
| 完整 `checkin.sh` 首跑 | ✅ `签到成功 credit=100` |
| 当日重跑 | ✅ 正确识别 `code=10001` 为「今日已签到」（v1.0.1 在此报失败） |
| 日志 token 泄漏检查 | ✅ 0 处匹配（`eyJ` / `DECRYPT_RESULT` 均未落盘） |
| `bash -n` / `node --check` | ✅ 通过 |

## 未验证（如实标注）

- `checkin.ps1` / `setup.ps1` 的 PowerShell 语法本机无 `pwsh` 未机器校验，逻辑镜像已验证的 bash 版与 v1.0.1 PS 结构。
- Windows / Linux 的 `CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info` 路径仅 macOS 实测命中，其他平台待真实环境确认（issue 第 2 条建议也提到此项）。

## 附带修复

bash 在 `set -u` 下 `$VAR` 紧跟全角标点（如 ``$TOKEN）``）会把多字节字符吞进变量名报 unbound，新增脚本中此类位置统一改 `${VAR}`（v1.0.1 原作者用 ``${TOKEN:-...}`` 规避过）。

Closes #68