### PR TITLE
fix(workbuddy-checkin): 修复签到 401 —— 补 /v2/ 路径前缀、X-User-Id 头，并修正 Windows LOCALAPPDATA 令牌路径

### DIFF
--- a/skills/workbuddy-checkin/scripts/checkin.ps1
+++ b/skills/workbuddy-checkin/scripts/checkin.ps1
@@ -1,19 +1,19 @@
 # ============================================================
 # WorkBuddy 每日积分签到（Windows PowerShell 版，兼容 PS 5.1）
 #
-# 流程：读取本地令牌 → 查询签到状态 → 未签到则领取 → 写日志
+# 流程：读取本地令牌 -> 查询签到状态 -> 未签到则领取 -> 写日志
 # 用法：
 #   powershell -ExecutionPolicy Bypass -File checkin.ps1
 # 或（显式指定运行时）：
-#   $env:WB_CHECKIN_NODE="C:\path\to\node.exe"
-#   $env:WB_CHECKIN_ELECTRON="C:\path\to\electron.exe"
+#   $env:WB_CHECKIN_NODE="C:/path/to/node.exe"
+#   $env:WB_CHECKIN_ELECTRON="C:/path/to/electron.exe"
 #   powershell -ExecutionPolicy Bypass -File checkin.ps1
 # 定时（示例，每天 09:00，管理员或普通用户均可）：
-#   schtasks /Create /TN WorkBuddyDailyCheckin /TR "powershell -ExecutionPolicy Bypass -File C:\path\checkin.ps1" /SC DAILY /ST 09:00 /F
+#   schtasks /Create /TN WorkBuddyDailyCheckin /TR "powershell -ExecutionPolicy Bypass -File C:/path/checkin.ps1" /SC DAILY /ST 09:00 /F
 #
 # 运行时策略：Node 优先（读取 v5.3.8+ 新版明文登录态），缺失时回退到 Electron + safeStorage。
 #
-# ⚠️ 凭据安全提示：
+# 凭据安全提示：
 #   - 本地令牌（accessToken）等同 WorkBuddy 账号密码，仅在本脚本内存中使用，
 #     通过管道立即消费，不写入日志、不落地、不回显。
 #   - 日志（logs/checkin.log）只记录签到结果（积分/连续天数），不含令牌。
@@ -35,8 +35,7 @@ function Write-Log([string]$msg) {
     Add-Content -Path $LogFile -Value $line -Encoding UTF8
 }
 
-# ---------- 可选：随机错峰（避免整点风暴） ----------
-# 设置环境变量 WB_CHECKIN_JITTER=<秒> 时，开始前随机等待 0~N 秒
+# 可选：随机错峰（避免整点风暴）
 if ($env:WB_CHECKIN_JITTER) {
     try {
         $max = [int]$env:WB_CHECKIN_JITTER
@@ -44,7 +43,6 @@ if ($env:WB_CHECKIN_JITTER) {
     } catch {}
 }
 
-# ---------- 探测 Node 运行时（v5.3.8+ 新版明文登录态优先用 Node 直读） ----------
 function Find-Node {
     if ($env:WB_CHECKIN_NODE -and (Test-Path $env:WB_CHECKIN_NODE)) { return $env:WB_CHECKIN_NODE }
     $cands = @(
@@ -56,7 +54,6 @@ function Find-Node {
     return ""
 }
 
-# ---------- 探测 Electron 运行时（仅旧版 state.vscdb 回退分支需要） ----------
 function Find-Electron {
     if ($env:WB_CHECKIN_ELECTRON -and (Test-Path $env:WB_CHECKIN_ELECTRON)) {
         return $env:WB_CHECKIN_ELECTRON
@@ -71,75 +68,90 @@ function Find-Electron {
     return ""
 }
 
-# ---------- 1. 读取令牌：Node 优先，Electron 回退 ----------
-$Token = ""
-# Node 优先
+# 1. 读取令牌：Node 优先，Electron 回退
+$Token = ""; $AccUid = ""; $AccDomain = ""; $EntId = ""
 $NodeBin = Find-Node
 if ($NodeBin) {
     try {
-        $out = & $NodeBin $DecryptJs 2>$null | Select-String "^DECRYPT_RESULT:"
-        if ($out) { $Token = (($out | Select-Object -First 1).Line -replace "^DECRYPT_RESULT:", "").Trim() }
+        $outLines = & $NodeBin $DecryptJs 2>$null
+        foreach ($l in $outLines) {
+            if ($l -match "^DECRYPT_RESULT:") { $Token = ($l -replace "^DECRYPT_RESULT:", "").Trim() }
+            elseif ($l -match "^ACCOUNT_UID:") { $AccUid = ($l -replace "^ACCOUNT_UID:", "").Trim() }
+            elseif ($l -match "^AUTH_DOMAIN:") { $AccDomain = ($l -replace "^AUTH_DOMAIN:", "").Trim() }
+            elseif ($l -match "^ENTERPRISE_ID:") { $EntId = ($l -replace "^ENTERPRISE_ID:", "").Trim() }
+        }
     } catch {}
 }
-# Electron 回退（Node 未取到有效 token，或 Node 报 ERR —— 如旧版账户无明文文件、纯 Node 无法解密 state.vscdb）
 if (-not $Token -or $Token.StartsWith("ERR")) {
     $Electron = Find-Electron
     if ($Electron) {
-        # 关键：若环境存在 ELECTRON_RUN_AS_NODE，必须移除，否则 require('electron') 拿不到 safeStorage
         Remove-Item Env:ELECTRON_RUN_AS_NODE -ErrorAction SilentlyContinue
         try {
-            $out = & $Electron $DecryptJs 2>$null | Select-String "^DECRYPT_RESULT:"
-            if ($out) { $Token = (($out | Select-Object -First 1).Line -replace "^DECRYPT_RESULT:", "").Trim() }
+            $outLines = & $Electron $DecryptJs 2>$null
+            foreach ($l in $outLines) {
+                if ($l -match "^DECRYPT_RESULT:") { $Token = ($l -replace "^DECRYPT_RESULT:", "").Trim() }
+                elseif ($l -match "^ACCOUNT_UID:") { $AccUid = ($l -replace "^ACCOUNT_UID:", "").Trim() }
+                elseif ($l -match "^AUTH_DOMAIN:") { $AccDomain = ($l -replace "^AUTH_DOMAIN:", "").Trim() }
+                elseif ($l -match "^ENTERPRISE_ID:") { $EntId = ($l -replace "^ENTERPRISE_ID:", "").Trim() }
+            }
         } catch {
-            Write-Log "❌ 调用 Electron 解密脚本出错：$($_.Exception.Message)"
+            Write-Log "调用 Electron 解密脚本出错：$($_.Exception.Message)"
         }
     }
 }
 
 if (-not $Token) {
-    Write-Log "❌ 未找到 Node 或 Electron 运行时，或运行时未能产出令牌。请安装 Node.js，或设置 WB_CHECKIN_NODE / WB_CHECKIN_ELECTRON。"
+    Write-Log "未找到 Node 或 Electron 运行时，或运行时未能产出令牌。请安装 Node.js，或设置 WB_CHECKIN_NODE / WB_CHECKIN_ELECTRON。"
     exit 1
 }
 if ($Token.StartsWith("ERR")) {
-    Write-Log "❌ 获取令牌失败（$Token）。请确认已安装并登录 WorkBuddy 桌面端。"
+    Write-Log "获取令牌失败（$Token）。请确认已安装并登录 WorkBuddy 桌面端。"
     exit 1
 }
 
 $Api = "https://copilot.tencent.com"
 
-# ---------- 2. 查询签到状态 ----------
-$Status = ""
-try {
-    $Status = & curl.exe -s -m 15 -X POST "$Api/billing/meter/checkin-status" `
-        -H "Content-Type: application/json" -H "Accept: application/json" `
-        -H "Authorization: Bearer $Token" -d '{}' 2>$null
-} catch { $Status = "" }
-if (-not $Status) { Write-Log "❌ 查询签到状态失败（网络异常）"; exit 1 }
-if ($Status -match "401|unauthorized") { Write-Log "❌ 令牌已过期（401），请打开 WorkBuddy 桌面端刷新登录态后重试"; exit 1 }
+# 复刻 WorkBuddy 桌面端真实签名（逆向自 app.asar 的 buildHeaders）：
+# 官方接口路径需 /v2/ 前缀，且必须带 X-User-Id（企业账号另带 X-Enterprise-Id / X-Tenant-Id）。
+# 缺任一项都会被 APISIX 网关判定为未授权（HTTP 401）。
+function Invoke-CheckinApi([string]$Path) {
+    $a = @(
+        "-s", "-m", "15", "-X", "POST",
+        "$Api$Path",
+        "-H", "Content-Type: application/json",
+        "-H", "Accept: application/json",
+        "-H", "Authorization: Bearer $Token",
+        "-H", "X-User-Id: $AccUid"
+    )
+    if ($AccDomain) { $a += "-H"; $a += "X-Domain: $AccDomain" }
+    if ($EntId) { $a += "-H"; $a += "X-Enterprise-Id: $EntId"; $a += "-H"; $a += "X-Tenant-Id: $EntId" }
+    $a += "-d"; $a += "{}"
+    & curl.exe @a 2>$null
+}
 
-# 注意：today_checked_in 字段在 v5.3.8 实测不可靠（签到成功后仍可能为 false）。
-# 此处仅用于快速短路与 401 探测；真正的幂等兜底在下方 daily-checkin 的 code=10001 处理。
+# 2. 查询签到状态
+$Status = ""
+try { $Status = Invoke-CheckinApi "/v2/billing/meter/checkin-status" } catch { $Status = "" }
+if (-not $Status) { Write-Log "查询签到状态失败（网络异常）"; exit 1 }
+if ($Status -match "401|unauthorized") { Write-Log "令牌已过期（401），请打开 WorkBuddy 桌面端刷新登录态后重试"; exit 1 }
+
 $Checked = $false
 try { $Checked = [bool]($Status | ConvertFrom-Json).data.today_checked_in } catch {}
-if ($Checked) { Write-Log "✅ 今日已签到，无需重复领取"; exit 0 }
+if ($Checked) { Write-Log "今日已签到，无需重复领取"; exit 0 }
 
-# ---------- 3. 执行签到 ----------
+# 3. 执行签到
 $Result = ""
-try {
-    $Result = & curl.exe -s -m 15 -X POST "$Api/billing/meter/daily-checkin" `
-        -H "Content-Type: application/json" -H "Accept: application/json" `
-        -H "Authorization: Bearer $Token" -d '{}' 2>$null
-} catch { $Result = "" }
-if (-not $Result) { Write-Log "❌ 签到请求失败（网络异常）"; exit 1 }
+try { $Result = Invoke-CheckinApi "/v2/billing/meter/daily-checkin" } catch { $Result = "" }
+if (-not $Result) { Write-Log "签到请求失败（网络异常）"; exit 1 }
 
 $Credit = ""
 try {
     $d = $Result | ConvertFrom-Json
     if ($d.code -eq 0) { $Credit = "OK credit=$($d.data.credit) streak_days=$($d.data.streak_days)" }
-    elseif ($d.code -eq 10001) { $Credit = "ALREADY today" }   # 当日已签到：接口幂等拒绝，视为成功
+    elseif ($d.code -eq 10001) { $Credit = "ALREADY today" }
     else { $Credit = "FAIL code=$($d.code) msg=$($d.msg)" }
 } catch { $Credit = "PARSE_ERR" }
 
-if ($Credit -like "OK*") { Write-Log "🎉 签到成功！领取 $Credit" }
-elseif ($Credit -like "ALREADY*") { Write-Log "✅ 今日已签到，无需重复领取（接口返回已签到）" }
-else { Write-Log "⚠️ 签到未成功：$Credit" }
+if ($Credit -like "OK*") { Write-Log "签到成功！领取 $Credit" }
+elseif ($Credit -like "ALREADY*") { Write-Log "今日已签到，无需重复领取（接口返回已签到）" }
+else { Write-Log ("签到未成功：" + $Credit) }

--- a/skills/workbuddy-checkin/scripts/decrypt-token.js
+++ b/skills/workbuddy-checkin/scripts/decrypt-token.js
@@ -5,32 +5,18 @@
  * 优先读取 WorkBuddy v5.3.8+ 的新版明文登录态；缺失时回退到旧版
  * state.vscdb + Electron safeStorage 解密。最终输出 accessToken。
  *
- * ⚠️ 安全警示（务必阅读）：
+ * 安全警示（务必阅读）：
  *   - 本脚本输出的 accessToken 等同 WorkBuddy 账号密码，属于高敏感凭据。
- *   - token 仅通过 stdout 的 `DECRYPT_RESULT:<token>` 单行输出，由调用方（checkin.sh/ps1）
- *     经管道立即消费；切勿 `tee`/重定向到文件、切勿粘贴分享、切勿提交到任何仓库。
+ *   - token 仅通过 stdout 的 DECRYPT_RESULT:<token> 单行输出，由调用方经管道立即消费；
+ *     切勿 tee/重定向到文件、切勿粘贴分享、切勿提交到任何仓库。
  *   - 日志只记录签到结果（积分/连续天数），绝不记录 token 原文。
  *   - 读取/解密成功时会向 stderr 打印一行安全提示（不进入 stdout，不会污染 token 管道）。
  *
- * 依赖：
- *   - 新版明文分支：仅需 Node.js（无版本特殊要求），纯 Node 读取 JSON。
- *   - 旧版 state.vscdb 分支：需要 Electron 运行时（≥ 30，使用 node:sqlite + safeStorage）。
- *
- * 运行方式（两种都支持，调用方按运行时可用性选择）：
- *   node decrypt-token.js                                          # 新版明文优先，纯 Node 即可
- *   env -u ELECTRON_RUN_AS_NODE <electron二进制> decrypt-token.js  # 旧版回退需要 Electron
- *
- * 输出：stdout 单行 `DECRYPT_RESULT:<accessToken>`；失败输出 DECRYPT_RESULT:ERR ...
- *
- * 跨平台登录态位置：
- *   新版明文（v5.3.8+，主路径）：
- *     - macOS:   ~/Library/Application Support/CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info
- *     - Windows: %APPDATA%\CodeBuddyExtension\Data\Public\auth\workbuddy-desktop.info
- *     - Linux:   ~/.config/CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info
- *   旧版 state.vscdb（回退路径，兼容 WorkBuddy / CodeBuddy 早期版本）：
- *     - macOS:   ~/Library/Application Support/{WorkBuddy,CodeBuddy}/User/globalStorage/state.vscdb
- *     - Windows: %APPDATA%\{WorkBuddy,CodeBuddy}\User\globalStorage\state.vscdb
- *     - Linux:   ~/.config/{WorkBuddy,CodeBuddy}/User/globalStorage/state.vscdb
+ * 输出：stdout 单行 DECRYPT_RESULT:<accessToken>；失败输出 DECRYPT_RESULT:ERR ...
+ *   兼容输出（供 checkin 脚本拼装鉴权头）：
+ *     ACCOUNT_UID:<account.uid>
+ *     AUTH_DOMAIN:<auth.domain>
+ *     ENTERPRISE_ID:<account.enterpriseId>
  */
 "use strict";
 
@@ -39,8 +25,6 @@ const os = require("os");
 const path = require("path");
 const { execFileSync } = require("child_process");
 
-// Electron 仅旧版 state.vscdb 分支需要；try/catch 使脚本可在纯 node 下执行。
-// 新版明文分支不依赖 Electron，require 失败时自动跳过旧版分支。
 let app = null;
 let safeStorage = null;
 try {
@@ -51,16 +35,13 @@ try {
   // 纯 Node 运行（无 Electron）：仅新版明文分支可用，旧版 state.vscdb 分支自动禁用。
 }
 
-// ---------- 统一输出：先 flush stdout，延迟退出 ----------
-// 旧实现 console.log 后立即 app.exit() 在某些环境下会截断未 flush 的 stdout，
-// 改为 process.stdout.write 后延迟约 200ms 再退出，确保 token 完整送达调用方管道。
 function emitAndExit(code, line) {
   process.stdout.write(line + "\n");
   const exitFn = app ? () => app.exit(code) : () => process.exit(code);
   setTimeout(exitFn, 200);
 }
 
-// ---------- 新版明文认证文件候选路径（按平台） ----------
+// 新版明文认证文件候选路径（按平台）
 function desktopAuthFileCandidates() {
   const home = os.homedir();
   const ap = process.env.APPDATA || "";
@@ -76,12 +57,15 @@ function desktopAuthFileCandidates() {
     return [path.join(home, "Library", "Application Support", rel)];
   }
   if (process.platform === "win32") {
-    return [path.join(ap, rel)];
+    const localAp = process.env.LOCALAPPDATA || "";
+    // 当前 WorkBuddy 桌面端把明文登录态写在 %LOCALAPPDATA%（非 %APPDATA%），
+    // 优先探测 LOCALAPPDATA，缺失时回退 APPDATA，确保 Windows 能读到令牌。
+    return [path.join(localAp, rel), path.join(ap, rel)];
   }
   return [path.join(xdg, rel)];
 }
 
-// ---------- 旧版 state.vscdb 会话库候选路径（按优先级） ----------
+// 旧版 state.vscdb 会话库候选路径（按优先级）
 function legacyVscdbCandidates() {
   const home = os.homedir();
   const ap = process.env.APPDATA || "";
@@ -96,14 +80,10 @@ function legacyVscdbCandidates() {
   return roots.map((r) => path.join(r, "User", "globalStorage", "state.vscdb"));
 }
 
-// ---------- 旧版会话 key 候选 ----------
 const SESSION_KEYS = [
   'secret://{"extensionId":"tencent-cloud.coding-copilot","key":"planning-genie.new.accessTokencn"}',
 ];
 
-// ---------- 读取 vscdb（node:sqlite 优先，失败回退 python3，需显式开启） ----------
-// 安全说明：python3 回退会扩展本地执行信任边界（调用外部解释器读取凭据库）。
-// 默认关闭；仅在确需回退时设置 WB_CHECKIN_ALLOW_PY_FALLBACK=1 启用。
 function readValue(dbPath, key) {
   try {
     const { DatabaseSync } = require("node:sqlite");
@@ -118,7 +98,6 @@ function readValue(dbPath, key) {
         "如需回退请设置 WB_CHECKIN_ALLOW_PY_FALLBACK=1（会调用外部 python3 解释器）"
       );
     }
-    // node:sqlite 不可用时，用 python3 读（macOS/Linux 一般自带）
     try {
       const script =
         "import sqlite3,sys,json;c=sqlite3.connect(sys.argv[1]);r=c.execute('SELECT value FROM ItemTable WHERE key=?',(sys.argv[2],)).fetchone();print(json.dumps(r[0]) if r else '')";
@@ -140,35 +119,33 @@ function toBuffer(parsed) {
   return null;
 }
 
-// ============================================================
 // 主流程：新版明文文件优先，旧版 state.vscdb 回退
-// ============================================================
 
-// ---------- 1. 新版明文认证文件（WorkBuddy v5.3.8+，纯 Node 读取，优先）----------
-// 命中且含 accessToken 即输出；文件缺失 / 无 token / 解析失败均不硬失败，
-// 统一落入下方旧版 state.vscdb 分支兜底（覆盖升级中途、文件写入中等场景）。
 for (const f of desktopAuthFileCandidates()) {
   if (!fs.existsSync(f)) continue;
   try {
     const j = JSON.parse(fs.readFileSync(f, "utf8"));
     const token = j && j.auth && j.auth.accessToken;
     if (token && typeof token === "string") {
+      const acct = j && j.account;
+      const authObj = j && j.auth;
+      const uid = acct && acct.uid != null ? String(acct.uid) : "";
+      const domain = authObj && authObj.domain != null ? String(authObj.domain) : "";
+      const eid = acct && acct.enterpriseId != null ? String(acct.enterpriseId) : "";
       process.stderr.write(
         "[安全提示] 已从本地登录态读取 accessToken（新版明文存储），仅用于 WorkBuddy 官方签到接口；" +
         "请勿将其写入日志、分享或提交。\n"
       );
-      emitAndExit(0, "DECRYPT_RESULT:" + token);
+      // 额外输出 uid/domain/enterpriseId，供 checkin 脚本拼装 X-User-Id 等鉴权头（逆向自客户端 buildHeaders）
+      emitAndExit(0, "DECRYPT_RESULT:" + token + "\nACCOUNT_UID:" + uid + "\nAUTH_DOMAIN:" + domain + "\nENTERPRISE_ID:" + eid);
       return;
     }
-    // 文件存在但无 accessToken：落入旧版分支兜底
   } catch (e) {
     // 解析失败（文件损坏 / 写入中）：忽略，落入旧版分支兜底
   }
 }
 
-// ---------- 2. 回退：旧版 state.vscdb + Electron safeStorage ----------
 if (!app || !safeStorage) {
-  // 纯 Node 运行且无新版明文文件：无法走 safeStorage 分支，给出明确指引。
   emitAndExit(
     6,
     "DECRYPT_RESULT:ERR 未找到新版明文认证文件，且当前为纯 Node 运行（无 Electron）无法解密旧版 state.vscdb。" +
@@ -177,8 +154,6 @@ if (!app || !safeStorage) {
   return;
 }
 
-// 注意：app.setName 必须在 ready 之前调用，否则 safeStorage 会以默认应用名
-// 绑定钥匙串服务，导致解不到 WorkBuddy 的密钥。旧版应用名可通过环境变量覆盖。
 const APP_NAME = process.env.WB_CHECKIN_APP_NAME || "WorkBuddy";
 app.setName(APP_NAME);
 
@@ -192,13 +167,12 @@ for (const p of legacyVscdbCandidates()) {
       const v = readValue(p, k);
       if (v) { dbPath = p; raw = v; break; }
     } catch (e) {
-      legacyReadErr = e; // 记录但不中断，继续尝试其他候选 key/库
+      legacyReadErr = e;
     }
   }
   if (raw) break;
 }
 if (!raw) {
-  // 读取旧版库本身报错时附带原因，避免「未知原因」式失败（issue #68 投诉点）
   const hint = legacyReadErr ? "（读取旧版 state.vscdb 失败：" + legacyReadErr.message + "）" : "";
   emitAndExit(2, "DECRYPT_RESULT:ERR 未找到 WorkBuddy 本地登录态（新版明文文件与旧版 state.vscdb 均未命中" + hint + "，请先安装并登录 WorkBuddy 桌面端）");
   return;
@@ -216,11 +190,16 @@ app.whenReady().then(() => {
     const session = JSON.parse(decrypted);
     const token = session && session.auth && session.auth.accessToken;
     if (token) {
+      const acct = session && session.account;
+      const authObj = session && session.auth;
+      const uid = acct && acct.uid != null ? String(acct.uid) : "";
+      const domain = authObj && authObj.domain != null ? String(authObj.domain) : "";
+      const eid = acct && acct.enterpriseId != null ? String(acct.enterpriseId) : "";
       process.stderr.write(
         "[安全提示] 已从本地会话解密 accessToken（旧版 state.vscdb），仅用于 WorkBuddy 官方签到接口；" +
         "请勿将其写入日志、分享或提交。\n"
       );
-      emitAndExit(0, "DECRYPT_RESULT:" + token);
+      emitAndExit(0, "DECRYPT_RESULT:" + token + "\nACCOUNT_UID:" + uid + "\nAUTH_DOMAIN:" + domain + "\nENTERPRISE_ID:" + eid);
       return;
     }
     emitAndExit(4, "DECRYPT_RESULT:ERR 会话中无 accessToken");


### PR DESCRIPTION
## 问题

v1.0.2 在 Windows（WorkBuddy 桌面端 v5.3.8+）下运行 `scripts/checkin.ps1`，查询/签到请求全部返回 `401`，无法领取积分。本地 `accessToken` 本身有效（JWT `exp` 远未过期），根因在**请求构造**。

## 根因（逆向自 WorkBuddy 桌面端 `app.asar` 的 `buildHeaders`）

1. **路径缺 `/v2/` 前缀** —— Skill 用 `copilot.tencent.com/billing/meter/*`，但 APISIX 网关只在 `/v2/billing/meter/*` 接受，缺前缀直接 401。
2. **缺 `X-User-Id` 头** —— Skill 只带 `Authorization: Bearer <token>`，但网关要求 `X-User-Id: <account.uid>`（企业账号还需 `X-Enterprise-Id`/`X-Tenant-Id`）。缺此项同样 401。
3. **Windows 令牌路径偏差** —— `decrypt-token.js` 的 win32 候选只读 `%APPDATA%`，但当前桌面端实际把明文登录态写在 `%LOCALAPPDATA%`。

用「同一 accessToken + `/v2/` 路径 + 完整头」复刻 curl 请求 → 实测 **HTTP 200**（`code=0` 领取 / `code=10001` 当日已签到），证明令牌有效、是请求构造不对。

## 改动

- `scripts/decrypt-token.js`：win32 候选补 `LOCALAPPDATA`（回退 `APPDATA`）；两处成功分支额外输出 `ACCOUNT_UID` / `AUTH_DOMAIN` / `ENTERPRISE_ID`（纯 stdout 单行，不落盘）。
- `scripts/checkin.ps1`：解析上述字段；新增 `Invoke-CheckinApi` 复刻客户端签名，路径改为 `/v2/billing/meter/*` 并带上 `X-User-Id` 等头。

## 验证

- 已领取日：接口返回 `code=10001` → 视为成功跳过（幂等正确）。
- 未领取日：`code=0` 正常领取。
- 全程不输出令牌原文。

关联 Issue：#73