### PR TITLE
fix(workbuddy-checkin): 修复假 401 漏签，同步 1.0.3 文档与 #74 根因更正

### DIFF
--- a/skills/workbuddy-checkin/CHANGELOG.md
+++ b/skills/workbuddy-checkin/CHANGELOG.md
@@ -1,5 +1,55 @@
 # 变更日志
 
+## [1.0.3] - 2026-08-12
+
+### 修复
+
+- **Windows 读不到新版明文登录态导致持续 401**（#73 / PR #74）：`decrypt-token.js` 的 win32 候选原本只探 `%APPDATA%\CodeBuddyExtension\...`，而当前桌面端实际把明文登录态写在 **`%LOCALAPPDATA%`**。读不到新文件时会回退旧版 `state.vscdb` 分支，取到**过期的历史会话令牌**，表现为「令牌能读出来、但接口一律 401」。现改为 **优先 `%LOCALAPPDATA%`、回退 `%APPDATA%`**。
+  - **这是本次唯一修复 401 的改动。**
+
+- **假 401 导致当日签到被跳过、连续签到中断**（`checkin.sh` / `checkin.ps1`，合并 PR #74 时发现）：401 判定原本是**扫响应体子串**（`grep -qi "401\|unauthorized"` / `$Status -match "401|unauthorized"`），而响应体带一个**每次随机的 UUID `requestId`**。UUID 里恰好出现 `401` 时，HTTP 200、`code=0` 的正常响应会被判成「令牌已过期」，脚本在调 `daily-checkin` **之前**就 `exit 1`。
+  - **后果**：当日积分未领取；更贵的是**连续签到中断**，第 7 天的 1000 积分奖励作废。
+  - **概率**：蒙特卡洛 20 万次实测 **0.566%/次**（理论 22/4096）。按每天跑一次计，**一年内约 87% 概率至少踩中一次**，期望每 177 天一次。
+  - **修复**：改用 `curl -w '\n%{http_code}'` 取真实 HTTP 状态码，与响应体分离判定；`000`→网络异常、`401/403`→令牌失效、其他非 `200`→带状态码报错。日志从此能区分「网络异常 / 鉴权失败 / 业务失败」，便于事后诊断。
+  - **验证**：4 例离线单测全绿（含「200 + requestId 含 401」这条关键用例，旧实现在此误判、新实现正确放行）；`checkin.sh` 端到端连跑 3 次均 `exit 0` 且幂等正确。
+
+### 改进
+
+- **请求签名对齐桌面端 `buildHeaders`**（`checkin.ps1`）：路径改用 `/v2/billing/meter/*`，并附带 `X-User-Id: <account.uid>`；有 `auth.domain` 时加 `X-Domain`，企业账号另加 `X-Enterprise-Id` / `X-Tenant-Id`。
+  - **定位：前向兼容加固，不是 401 的修复项。** 网关当前并不强制这两项（见下方验证矩阵）。对齐上游的意义在于——官方哪天真收紧鉴权时，跟随桌面端的实现不会跟着挂。
+- `decrypt-token.js` 在两处成功分支追加输出 `ACCOUNT_UID` / `AUTH_DOMAIN` / `ENTERPRISE_ID` 三行（纯 stdout，不落盘、不写日志），供调用方拼装鉴权头。
+  - **调用方契约**：stdout 不再是单行，消费方**必须**按行前缀过滤（`grep '^DECRYPT_RESULT:'` / `Select-String`），不可整段捕获。现有 4 个消费方（`checkin.sh:79,87`、`setup.sh:55,136`、`checkin.ps1`、`setup.ps1:54,124`）均已是前缀过滤写法，无需改动。
+
+### 根因更正（重要）
+
+Issue #73 与 PR #74 原文断言「APISIX 网关只在 `/v2/billing/meter/*` 接受，**缺前缀直接 401**」「网关要求 `X-User-Id`，**缺此项同样 401**」。**这两条经实测证伪，不要据此排查后续 401。**
+
+合并前用真实令牌跑的 2×2 只读验证矩阵（`checkin-status`，个人账号，macOS）：
+
+| 组合 | 结果 |
+|---|---|
+| 旧 `/billing/meter` + 仅 `Authorization` | HTTP 200 `code=0 msg=OK` |
+| 旧 `/billing/meter` + 完整头 | HTTP 200 `code=0` |
+| `/v2/billing/meter` + 仅 `Authorization` | HTTP 200 `code=0` |
+| `/v2/billing/meter` + 完整头 | HTTP 200 `code=0` |
+
+写接口另行验证：`checkin.sh`（旧路径、不带 `X-User-Id`）实跑 `daily-checkin` 返回业务码 `code=10001`（今日已签到），**非 401**。
+
+原实验之所以得出错误结论，是因为一次同时改动了三个变量（路径、请求头、**令牌来源**），而真正起作用的是第三个——手工 curl 用的是从 `%LOCALAPPDATA%` 现取的新鲜令牌。
+
+**已知验证边界**：矩阵在个人账号（无 `enterpriseId`）、单一区域、单一时间点取得；企业账号或后续网关策略调整下的行为未覆盖。
+
+### 文档
+
+- `SKILL.md`：版本升至 1.0.3；原理章节补充 `/v2/` 与 `buildHeaders` 签名及其"非必要条件"的定位；平台表 Windows 行改为 `%LOCALAPPDATA%`（回退 `%APPDATA%`）；安全说明的网络访问范围补 `/v2/` 路径；排错新增「Windows 已登录却持续 401」条目，明确指向令牌来源而非请求构造。
+- `decrypt-token.js`：恢复 PR #74 中被一并删除的维护性注释——跨平台登录态路径清单（并修正 Windows 为 `%LOCALAPPDATA%`）、依赖与运行方式、`emitAndExit` 延迟退出的原因、`app.setName` 必须早于 ready 的警告、python3 回退的信任边界说明。
+- `checkin.ps1`：恢复 `today_checked_in` 字段不可靠的说明（它是 `code=10001` 幂等兜底存在的理由）、`ELECTRON_RUN_AS_NODE` 必须移除的原因、`WB_CHECKIN_JITTER` 用法说明。
+
+### 已知限制
+
+- `checkin.sh`（macOS / Linux）仍使用不带 `/v2/` 前缀、仅 `Authorization` 的旧写法。实测可用，故本版未改动；如需与桌面端完全对齐可后续收敛。
+- Windows 侧（`%LOCALAPPDATA%` 路径修复、`/v2/` 签名、`checkin.ps1` 的 HTTP 状态码判定）**未在 Windows 实机验证**，本版验证均在 macOS 完成；以 PR #74 提交者与后续使用者反馈为准。
+
 ## [1.0.2] - 2026-08-06
 
 ### 修复

--- a/skills/workbuddy-checkin/SKILL.md
+++ b/skills/workbuddy-checkin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workbuddy-checkin
 description: WorkBuddy 每日积分自动签到。自动解密本地登录令牌，调用官方签到 API 完成每日积分领取（100 积分/天，连续第 7 天 1000 积分），并支持配置定时任务。触发词：WorkBuddy 签到、每日积分、check-in、credits。
-version: "1.0.2"
+version: "1.0.3"
 license: MIT
 ---
 
@@ -18,9 +18,10 @@ license: MIT
 2. **旧版 WorkBuddy/CodeBuddy** 仍把 auth session 用 Electron `safeStorage` 加密存于 `state.vscdb`；新版明文文件缺失时回退到此路径，用 Electron 运行时执行 `safeStorage.decryptString()` 解密（macOS 命中钥匙串；Windows/Linux 走 DPAPI/keyring）。
 3. 运行时策略：**Node 优先**（读新版明文文件，无需 Electron），缺失时回退 Electron（解旧版 `state.vscdb`）。
 4. 调用腾讯官方签到 API：
-   - 查状态：`POST https://copilot.tencent.com/billing/meter/checkin-status`
-   - 执行签到：`POST https://copilot.tencent.com/billing/meter/daily-checkin`
-   - 认证：`Authorization: Bearer <accessToken>`
+   - 查状态：`POST https://copilot.tencent.com/v2/billing/meter/checkin-status`
+   - 执行签到：`POST https://copilot.tencent.com/v2/billing/meter/daily-checkin`
+   - 认证：`Authorization: Bearer <accessToken>`，并按桌面端 `buildHeaders` 附带 `X-User-Id: <account.uid>`；有 `auth.domain` 时加 `X-Domain`，企业账号另加 `X-Enterprise-Id` / `X-Tenant-Id`
+   - 兼容说明：`checkin.ps1` 走上述 `/v2/` 全量签名（对齐桌面端）；`checkin.sh` 仍走不带 `/v2/` 前缀、仅 `Authorization` 的旧写法。**两种写法实测均返回 200**（见 CHANGELOG 1.0.3 的验证矩阵），网关当前未强制 `/v2/` 或 `X-User-Id`；对齐桌面端属前向兼容加固，不是修复 401 的必要条件
 5. 脚本幂等：先查状态（命中即跳过）；`daily-checkin` 返回 `code=10001`（今天已签到）同样视为成功，避免重复请求被误报为失败。
 
 > ⚠️ v5.3.8 实测 `checkin-status` 的 `today_checked_in` 字段不可靠（签到成功后仍可能为 `false`）。因此幂等性主要靠 `daily-checkin` 的 `code=10001` 兜底。
@@ -151,7 +152,7 @@ WorkBuddy 环境下可调用自动化任务工具（`automation_update`，recurr
 | 平台 | 脚本 | 新版明文登录态（v5.3.8+，主路径） | 旧版 state.vscdb（回退） |
 |---|---|---|---|
 | macOS | `checkin.sh` | `~/Library/Application Support/CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info` | `~/Library/Application Support/WorkBuddy/User/globalStorage/state.vscdb` |
-| Windows | `checkin.ps1`（或 Git Bash 跑 `checkin.sh`） | `%APPDATA%\CodeBuddyExtension\Data\Public\auth\workbuddy-desktop.info` | `%APPDATA%\WorkBuddy\User\globalStorage\state.vscdb` |
+| Windows | `checkin.ps1`（或 Git Bash 跑 `checkin.sh`） | `%LOCALAPPDATA%\CodeBuddyExtension\Data\Public\auth\workbuddy-desktop.info`（回退 `%APPDATA%`） | `%APPDATA%\WorkBuddy\User\globalStorage\state.vscdb` |
 | Linux | `checkin.sh` | `~/.config/CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info` | `~/.config/WorkBuddy/User/globalStorage/state.vscdb` |
 
 Windows PowerShell 执行策略用 `-ExecutionPolicy Bypass`；需 `curl.exe`（Win10 1803+ 自带）。
@@ -173,6 +174,8 @@ Windows PowerShell 执行策略用 `-ExecutionPolicy Bypass`；需 `curl.exe`（
 - **v5.3.8 已登录但仍报令牌失败**：本机 skill 版本过旧（< 1.0.2），不识别新版明文存储；升级到 1.0.2+。
 - **当日重跑提示「签到未成功 / code=10001」**：旧版本（< 1.0.2）未把 `code=10001` 识别为「已签到」；1.0.2+ 会正确报告「今日已签到」。
 - **401 令牌过期**：打开 WorkBuddy 刷新登录态，脚本每次运行会重新读取最新 token，次日自动恢复。
+- **偶发「令牌已过期（401）」但次日又正常（< 1.0.3）**：401 判定原为扫响应体子串，响应体里的随机 `requestId` 恰好含 `401` 时会误判（约 0.57%/次），当日签到被跳过且连续签到中断。1.0.3 起改用真实 HTTP 状态码判定。
+- **Windows 已登录却持续 401（< 1.0.3）**：1.0.2 的 win32 候选只探 `%APPDATA%`，而桌面端实际把明文登录态写在 `%LOCALAPPDATA%`；读不到新文件时会回退旧版 `state.vscdb`，取到**过期的历史会话令牌**，表现为「能拿到 token 但接口 401」。1.0.3 起优先探 `%LOCALAPPDATA%`。**排查 401 请先确认令牌来源，而非怀疑请求路径或请求头**（实测网关不强制 `/v2/` 与 `X-User-Id`，见 CHANGELOG 1.0.3）。
 - **macOS 解密报错但已登录（旧版账户）**：旧版迁移应用名仍是 `CodeBuddy`，设 `export WB_CHECKIN_APP_NAME=CodeBuddy` 后重试（仅走 state.vscdb 分支时生效）。
 - **Electron 下载慢/失败（旧版账户）**：配置 npm 镜像（见 `references/dependencies.md`）后重跑 setup；或手动放置 Electron 后用环境变量/参数指定。v5.3.8+ 新版账户无需 Electron。
 - **Windows 提示不是内部或外部命令**：用 `powershell -ExecutionPolicy Bypass -File …` 运行；确认 `curl.exe` 存在。
@@ -184,7 +187,7 @@ Windows PowerShell 执行策略用 `-ExecutionPolicy Bypass`；需 `curl.exe`（
 
 - 令牌仅在内存中使用，通过管道立即被签到请求消费，**不写入任何日志文件、不落盘、不回显到终端、不提交到仓库**。
 - `logs/` 仅记录签到结果（积分 / 连续天数 / 成功失败），**绝不含令牌原文**。切勿将日志或脚本输出粘贴分享。
-- 网络访问仅发往腾讯官方接口 `copilot.tencent.com/billing/meter/*`，不上传任何第三方。
+- 网络访问仅发往腾讯官方接口 `copilot.tencent.com/billing/meter/*` 与 `copilot.tencent.com/v2/billing/meter/*`，不上传任何第三方。
 - 解密成功时脚本会向 stderr 打印一行安全提示（不影响 stdout 的 token 管道），便于你确认凭据正在被使用。
 - 请勿用于他人账户、批量注册刷分或任何违反 WorkBuddy 用户协议的用途；使用者自行承担使用风险。
 

--- a/skills/workbuddy-checkin/scripts/checkin.ps1
+++ b/skills/workbuddy-checkin/scripts/checkin.ps1
@@ -35,7 +35,8 @@ function Write-Log([string]$msg) {
     Add-Content -Path $LogFile -Value $line -Encoding UTF8
 }
 
-# 可选：随机错峰（避免整点风暴）
+# ---------- 可选：随机错峰（避免整点风暴） ----------
+# 设置环境变量 WB_CHECKIN_JITTER=<秒> 时，开始前随机等待 0~N 秒
 if ($env:WB_CHECKIN_JITTER) {
     try {
         $max = [int]$env:WB_CHECKIN_JITTER
@@ -82,9 +83,11 @@ if ($NodeBin) {
         }
     } catch {}
 }
+# Electron 回退（Node 未取到有效 token，或 Node 报 ERR —— 如旧版账户无明文文件、纯 Node 无法解密 state.vscdb）
 if (-not $Token -or $Token.StartsWith("ERR")) {
     $Electron = Find-Electron
     if ($Electron) {
+        # 关键：若环境存在 ELECTRON_RUN_AS_NODE，必须移除，否则 require('electron') 拿不到 safeStorage
         Remove-Item Env:ELECTRON_RUN_AS_NODE -ErrorAction SilentlyContinue
         try {
             $outLines = & $Electron $DecryptJs 2>$null
@@ -116,7 +119,7 @@ $Api = "https://copilot.tencent.com"
 # 缺任一项都会被 APISIX 网关判定为未授权（HTTP 401）。
 function Invoke-CheckinApi([string]$Path) {
     $a = @(
-        "-s", "-m", "15", "-X", "POST",
+        "-s", "-m", "15", "-w", "\n%{http_code}", "-X", "POST",
         "$Api$Path",
         "-H", "Content-Type: application/json",
         "-H", "Accept: application/json",
@@ -126,29 +129,45 @@ function Invoke-CheckinApi([string]$Path) {
     if ($AccDomain) { $a += "-H"; $a += "X-Domain: $AccDomain" }
     if ($EntId) { $a += "-H"; $a += "X-Enterprise-Id: $EntId"; $a += "-H"; $a += "X-Tenant-Id: $EntId" }
     $a += "-d"; $a += "{}"
-    & curl.exe @a 2>$null
+    $raw = & curl.exe @a 2>$null
+    # 末行是 HTTP 状态码，其余为响应体；返回 [状态码, 响应体]
+    if (-not $raw) { return @("000", "") }
+    $lines = @($raw)
+    $code = [string]($lines | Select-Object -Last 1)
+    $body = if ($lines.Count -gt 1) { ($lines | Select-Object -First ($lines.Count - 1)) -join "" } else { "" }
+    return @($code, $body)
 }
 
 # 2. 查询签到状态
-$Status = ""
-try { $Status = Invoke-CheckinApi "/v2/billing/meter/checkin-status" } catch { $Status = "" }
-if (-not $Status) { Write-Log "查询签到状态失败（网络异常）"; exit 1 }
-if ($Status -match "401|unauthorized") { Write-Log "令牌已过期（401），请打开 WorkBuddy 桌面端刷新登录态后重试"; exit 1 }
+# 鉴权失败一律以真实 HTTP 状态码判定，不再匹配响应体子串。
+# 旧实现用 `$Status -match "401|unauthorized"` 扫响应体，而响应体带随机 UUID 的 requestId，
+# 约 0.57%/次 会因 UUID 里恰好出现 "401" 被误判为令牌过期 —— 脚本在调 daily-checkin
+# 之前就退出，导致当日积分未领取、连续签到中断（第 7 天 1000 积分奖励作废）。
+$Status = ""; $HttpCode = "000"
+try { $r = Invoke-CheckinApi "/v2/billing/meter/checkin-status"; $HttpCode = $r[0]; $Status = $r[1] } catch { $HttpCode = "000"; $Status = "" }
+if ($HttpCode -eq "000") { Write-Log "查询签到状态失败（网络异常）"; exit 1 }
+if ($HttpCode -eq "401" -or $HttpCode -eq "403") { Write-Log "令牌已过期或无权限（HTTP $HttpCode），请打开 WorkBuddy 桌面端刷新登录态后重试"; exit 1 }
+if ($HttpCode -ne "200") { Write-Log "查询签到状态失败（HTTP $HttpCode）"; exit 1 }
+if (-not $Status) { Write-Log "查询签到状态失败（响应为空，HTTP $HttpCode）"; exit 1 }
 
+# 注意：today_checked_in 字段在 v5.3.8 实测不可靠（签到成功后仍可能为 false）。
+# 此处仅用于快速短路与 401 探测；真正的幂等兜底在下方 daily-checkin 的 code=10001 处理。
 $Checked = $false
 try { $Checked = [bool]($Status | ConvertFrom-Json).data.today_checked_in } catch {}
 if ($Checked) { Write-Log "今日已签到，无需重复领取"; exit 0 }
 
 # 3. 执行签到
-$Result = ""
-try { $Result = Invoke-CheckinApi "/v2/billing/meter/daily-checkin" } catch { $Result = "" }
-if (-not $Result) { Write-Log "签到请求失败（网络异常）"; exit 1 }
+$Result = ""; $HttpCode2 = "000"
+try { $r2 = Invoke-CheckinApi "/v2/billing/meter/daily-checkin"; $HttpCode2 = $r2[0]; $Result = $r2[1] } catch { $HttpCode2 = "000"; $Result = "" }
+if ($HttpCode2 -eq "000") { Write-Log "签到请求失败（网络异常）"; exit 1 }
+if ($HttpCode2 -eq "401" -or $HttpCode2 -eq "403") { Write-Log "令牌已过期或无权限（HTTP $HttpCode2），请打开 WorkBuddy 桌面端刷新登录态后重试"; exit 1 }
+if (-not $Result) { Write-Log "签到请求失败（响应为空，HTTP $HttpCode2）"; exit 1 }
 
 $Credit = ""
 try {
     $d = $Result | ConvertFrom-Json
     if ($d.code -eq 0) { $Credit = "OK credit=$($d.data.credit) streak_days=$($d.data.streak_days)" }
-    elseif ($d.code -eq 10001) { $Credit = "ALREADY today" }
+    elseif ($d.code -eq 10001) { $Credit = "ALREADY today" }   # 当日已签到：接口幂等拒绝，视为成功
     else { $Credit = "FAIL code=$($d.code) msg=$($d.msg)" }
 } catch { $Credit = "PARSE_ERR" }
 

--- a/skills/workbuddy-checkin/scripts/checkin.sh
+++ b/skills/workbuddy-checkin/scripts/checkin.sh
@@ -119,16 +119,31 @@ fi
 API="https://copilot.tencent.com"
 
 # ---------- 2. 查询签到状态 ----------
-STATUS=$(curl -s -m 15 -X POST "$API/billing/meter/checkin-status" \
+# 鉴权失败一律以真实 HTTP 状态码判定，不再匹配响应体子串。
+# 旧实现用 `grep -qi "401\|unauthorized"` 扫响应体，而响应体带随机 UUID 的 requestId，
+# 约 0.57%/次 会因 UUID 里恰好出现 "401" 被误判为令牌过期 —— 脚本在调 daily-checkin
+# 之前就退出，导致当日积分未领取、连续签到中断（第 7 天 1000 积分奖励作废）。
+# 每天跑一次时，一年内约 87% 概率至少踩中一次。
+RESP=$(curl -s -m 15 -w '\n%{http_code}' -X POST "$API/billing/meter/checkin-status" \
   -H "Content-Type: application/json" -H "Accept: application/json" \
   -H "Authorization: Bearer $TOKEN" -d '{}' 2>/dev/null || echo "")
+HTTP_CODE=$(printf '%s' "$RESP" | tail -n 1)
+STATUS=$(printf '%s' "$RESP" | sed '$d')
 
-if [ -z "$STATUS" ]; then
+if [ -z "$RESP" ] || [ "$HTTP_CODE" = "000" ]; then
   log "❌ 查询签到状态失败（网络异常）"
   exit 1
 fi
-if echo "$STATUS" | grep -qi "401\|unauthorized"; then
-  log "❌ 令牌已过期（401），请打开 WorkBuddy 桌面端刷新登录态后重试"
+if [ "$HTTP_CODE" = "401" ] || [ "$HTTP_CODE" = "403" ]; then
+  log "❌ 令牌已过期或无权限（HTTP $HTTP_CODE），请打开 WorkBuddy 桌面端刷新登录态后重试"
+  exit 1
+fi
+if [ "$HTTP_CODE" != "200" ]; then
+  log "❌ 查询签到状态失败（HTTP $HTTP_CODE）"
+  exit 1
+fi
+if [ -z "$STATUS" ]; then
+  log "❌ 查询签到状态失败（响应为空，HTTP $HTTP_CODE）"
   exit 1
 fi
 
@@ -150,12 +165,22 @@ if [ "$CHECKED" = "True" ]; then
 fi
 
 # ---------- 3. 执行签到 ----------
-RESULT=$(curl -s -m 15 -X POST "$API/billing/meter/daily-checkin" \
+RESP2=$(curl -s -m 15 -w '\n%{http_code}' -X POST "$API/billing/meter/daily-checkin" \
   -H "Content-Type: application/json" -H "Accept: application/json" \
   -H "Authorization: Bearer $TOKEN" -d '{}' 2>/dev/null || echo "")
+HTTP_CODE2=$(printf '%s' "$RESP2" | tail -n 1)
+RESULT=$(printf '%s' "$RESP2" | sed '$d')
 
-if [ -z "$RESULT" ]; then
+if [ -z "$RESP2" ] || [ "$HTTP_CODE2" = "000" ]; then
   log "❌ 签到请求失败（网络异常）"
+  exit 1
+fi
+if [ "$HTTP_CODE2" = "401" ] || [ "$HTTP_CODE2" = "403" ]; then
+  log "❌ 令牌已过期或无权限（HTTP $HTTP_CODE2），请打开 WorkBuddy 桌面端刷新登录态后重试"
+  exit 1
+fi
+if [ -z "$RESULT" ]; then
+  log "❌ 签到请求失败（响应为空，HTTP $HTTP_CODE2）"
   exit 1
 fi
 

--- a/skills/workbuddy-checkin/scripts/decrypt-token.js
+++ b/skills/workbuddy-checkin/scripts/decrypt-token.js
@@ -7,16 +7,37 @@
  *
  * 安全警示（务必阅读）：
  *   - 本脚本输出的 accessToken 等同 WorkBuddy 账号密码，属于高敏感凭据。
- *   - token 仅通过 stdout 的 DECRYPT_RESULT:<token> 单行输出，由调用方经管道立即消费；
+ *   - token 仅通过 stdout 的 DECRYPT_RESULT:<token> 首行输出，由调用方经管道立即消费；
  *     切勿 tee/重定向到文件、切勿粘贴分享、切勿提交到任何仓库。
  *   - 日志只记录签到结果（积分/连续天数），绝不记录 token 原文。
  *   - 读取/解密成功时会向 stderr 打印一行安全提示（不进入 stdout，不会污染 token 管道）。
  *
- * 输出：stdout 单行 DECRYPT_RESULT:<accessToken>；失败输出 DECRYPT_RESULT:ERR ...
- *   兼容输出（供 checkin 脚本拼装鉴权头）：
+ * 依赖：
+ *   - 新版明文分支：仅需 Node.js（无版本特殊要求），纯 Node 读取 JSON。
+ *   - 旧版 state.vscdb 分支：需要 Electron 运行时（≥ 30，使用 node:sqlite + safeStorage）。
+ *
+ * 运行方式（两种都支持，调用方按运行时可用性选择）：
+ *   node decrypt-token.js                                          # 新版明文优先，纯 Node 即可
+ *   env -u ELECTRON_RUN_AS_NODE <electron二进制> decrypt-token.js  # 旧版回退需要 Electron
+ *
+ * 输出：stdout 首行 DECRYPT_RESULT:<accessToken>；失败输出 DECRYPT_RESULT:ERR ...
+ *   随后追加三行账号字段（供 checkin 脚本拼装鉴权头，逆向自客户端 buildHeaders）：
  *     ACCOUNT_UID:<account.uid>
  *     AUTH_DOMAIN:<auth.domain>
  *     ENTERPRISE_ID:<account.enterpriseId>
+ *   注意：调用方必须按行前缀过滤（grep '^DECRYPT_RESULT:' / Select-String），
+ *   不可整段捕获 stdout，否则账号字段会混入 token。
+ *
+ * 跨平台登录态位置：
+ *   新版明文（v5.3.8+，主路径）：
+ *     - macOS:   ~/Library/Application Support/CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info
+ *     - Windows: %LOCALAPPDATA%\CodeBuddyExtension\Data\Public\auth\workbuddy-desktop.info
+ *                （旧实现只探 %APPDATA%，实测当前桌面端写在 LOCALAPPDATA；APPDATA 保留为回退）
+ *     - Linux:   ~/.config/CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info
+ *   旧版 state.vscdb（回退路径，兼容 WorkBuddy / CodeBuddy 早期版本）：
+ *     - macOS:   ~/Library/Application Support/{WorkBuddy,CodeBuddy}/User/globalStorage/state.vscdb
+ *     - Windows: %APPDATA%\{WorkBuddy,CodeBuddy}\User\globalStorage\state.vscdb
+ *     - Linux:   ~/.config/{WorkBuddy,CodeBuddy}/User/globalStorage/state.vscdb
  */
 "use strict";
 
@@ -25,6 +46,8 @@ const os = require("os");
 const path = require("path");
 const { execFileSync } = require("child_process");
 
+// Electron 仅旧版 state.vscdb 分支需要；try/catch 使脚本可在纯 node 下执行。
+// 新版明文分支不依赖 Electron，require 失败时自动跳过旧版分支。
 let app = null;
 let safeStorage = null;
 try {
@@ -35,6 +58,9 @@ try {
   // 纯 Node 运行（无 Electron）：仅新版明文分支可用，旧版 state.vscdb 分支自动禁用。
 }
 
+// 统一输出：先 flush stdout，延迟退出。
+// 旧实现 console.log 后立即 app.exit() 在某些环境下会截断未 flush 的 stdout，
+// 改为 process.stdout.write 后延迟约 200ms 再退出，确保 token 完整送达调用方管道。
 function emitAndExit(code, line) {
   process.stdout.write(line + "\n");
   const exitFn = app ? () => app.exit(code) : () => process.exit(code);
@@ -80,10 +106,14 @@ function legacyVscdbCandidates() {
   return roots.map((r) => path.join(r, "User", "globalStorage", "state.vscdb"));
 }
 
+// 旧版会话 key 候选
 const SESSION_KEYS = [
   'secret://{"extensionId":"tencent-cloud.coding-copilot","key":"planning-genie.new.accessTokencn"}',
 ];
 
+// 读取 vscdb（node:sqlite 优先，失败回退 python3，需显式开启）
+// 安全说明：python3 回退会扩展本地执行信任边界（调用外部解释器读取凭据库）。
+// 默认关闭；仅在确需回退时设置 WB_CHECKIN_ALLOW_PY_FALLBACK=1 启用。
 function readValue(dbPath, key) {
   try {
     const { DatabaseSync } = require("node:sqlite");
@@ -99,6 +129,7 @@ function readValue(dbPath, key) {
       );
     }
     try {
+      // node:sqlite 不可用时，用 python3 读（macOS/Linux 一般自带）
       const script =
         "import sqlite3,sys,json;c=sqlite3.connect(sys.argv[1]);r=c.execute('SELECT value FROM ItemTable WHERE key=?',(sys.argv[2],)).fetchone();print(json.dumps(r[0]) if r else '')";
       const out = execFileSync("python3", [ "-c", script, dbPath, key ], {
@@ -119,8 +150,13 @@ function toBuffer(parsed) {
   return null;
 }
 
+// ============================================================
 // 主流程：新版明文文件优先，旧版 state.vscdb 回退
+// ============================================================
 
+// 1. 新版明文认证文件（WorkBuddy v5.3.8+，纯 Node 读取，优先）
+// 命中且含 accessToken 即输出；文件缺失 / 无 token / 解析失败均不硬失败，
+// 统一落入下方旧版 state.vscdb 分支兜底（覆盖升级中途、文件写入中等场景）。
 for (const f of desktopAuthFileCandidates()) {
   if (!fs.existsSync(f)) continue;
   try {
@@ -140,12 +176,15 @@ for (const f of desktopAuthFileCandidates()) {
       emitAndExit(0, "DECRYPT_RESULT:" + token + "\nACCOUNT_UID:" + uid + "\nAUTH_DOMAIN:" + domain + "\nENTERPRISE_ID:" + eid);
       return;
     }
+    // 文件存在但无 accessToken：落入旧版分支兜底
   } catch (e) {
     // 解析失败（文件损坏 / 写入中）：忽略，落入旧版分支兜底
   }
 }
 
+// 2. 回退：旧版 state.vscdb + Electron safeStorage
 if (!app || !safeStorage) {
+  // 纯 Node 运行且无新版明文文件：无法走 safeStorage 分支，给出明确指引。
   emitAndExit(
     6,
     "DECRYPT_RESULT:ERR 未找到新版明文认证文件，且当前为纯 Node 运行（无 Electron）无法解密旧版 state.vscdb。" +
@@ -154,6 +193,8 @@ if (!app || !safeStorage) {
   return;
 }
 
+// 注意：app.setName 必须在 ready 之前调用，否则 safeStorage 会以默认应用名
+// 绑定钥匙串服务，导致解不到 WorkBuddy 的密钥。旧版应用名可通过环境变量覆盖。
 const APP_NAME = process.env.WB_CHECKIN_APP_NAME || "WorkBuddy";
 app.setName(APP_NAME);
 
@@ -167,12 +208,13 @@ for (const p of legacyVscdbCandidates()) {
       const v = readValue(p, k);
       if (v) { dbPath = p; raw = v; break; }
     } catch (e) {
-      legacyReadErr = e;
+      legacyReadErr = e; // 记录但不中断，继续尝试其他候选 key/库
     }
   }
   if (raw) break;
 }
 if (!raw) {
+  // 读取旧版库本身报错时附带原因，避免「未知原因」式失败（issue #68 投诉点）
   const hint = legacyReadErr ? "（读取旧版 state.vscdb 失败：" + legacyReadErr.message + "）" : "";
   emitAndExit(2, "DECRYPT_RESULT:ERR 未找到 WorkBuddy 本地登录态（新版明文文件与旧版 state.vscdb 均未命中" + hint + "，请先安装并登录 WorkBuddy 桌面端）");
   return;


### PR DESCRIPTION
承接 #74 的收尾：修复合并该 PR 时发现的一个更严重的既有缺陷，并补齐 #74 未做的文档同步。

## 摘要

### 1. 修复「假 401」导致漏签 + 连续签到中断（主要变更）

`checkin.sh` / `checkin.ps1` 的 401 判定原本是**扫响应体子串**：

```bash
if echo "$STATUS" | grep -qi "401\|unauthorized"; then   # ← 匹配响应体任意位置
```

而响应体带一个**每次随机的 UUID `requestId`**。UUID 里恰好出现 `401` 时，HTTP 200 + `code=0` 的正常响应被判成「令牌已过期」，脚本在调 `daily-checkin` **之前**就 `exit 1`。

- **后果**：当日积分未领取；更贵的是**连续签到中断**，第 7 天 1000 积分奖励作废
- **概率**：蒙特卡洛 20 万次实测 **0.566%/次**（理论 22/4096）。按每天跑一次计，**一年内约 87% 概率至少踩中一次**
- **修复**：改用 `curl -w '\n%{http_code}'` 取真实状态码并与响应体分离判定。`000`→网络异常、`401/403`→鉴权失败、其他非 `200`→带状态码报错，日志从此能区分三类失败

### 2. #74 根因更正

#74 与 #73 断言「缺 `/v2/` 前缀直接 401」「缺 `X-User-Id` 同样 401」，**经实测证伪**：

| 组合 | 结果 |
|---|---|
| 旧 `/billing/meter` + 仅 `Authorization` | HTTP 200 `code=0` |
| 旧 `/billing/meter` + 完整头 | HTTP 200 `code=0` |
| `/v2/billing/meter` + 仅 `Authorization` | HTTP 200 `code=0` |
| `/v2/billing/meter` + 完整头 | HTTP 200 `code=0` |

写接口另测：旧路径实跑 `daily-checkin` 返回业务码 `10001`，非 401。

原实验一次同时改动了路径、请求头、**令牌来源**三个变量，真正起作用的是第三个。#74 中真正修复 401 的只有 `%LOCALAPPDATA%` 一处；`/v2/` + `buildHeaders` 重新定位为**前向兼容加固**。排查后续 401 应先确认令牌来源，而非请求构造。

### 3. 文档同步与注释恢复

- `SKILL.md` 升至 1.0.3；API 章节标注 `/v2/` 与 `X-User-Id` 的非必要定位；平台表 Windows 行改为 `%LOCALAPPDATA%`（回退 `%APPDATA%`）；新增两条 401 排错条目
- `CHANGELOG.md` 1.0.3，含验证矩阵与已知边界
- 恢复 #74 一并删除的维护注释：跨平台登录态路径清单、依赖与运行方式、`emitAndExit` 延迟退出原因、`app.setName` 须早于 ready 的警告、python3 回退信任边界、`today_checked_in` 不可靠说明；并补上「调用方必须按行前缀过滤 stdout」的契约

## 测试计划

- [x] 401 判定 4 例离线单测全绿，含「200 + requestId 含 401」关键用例（旧实现误判、新实现放行）
- [x] `checkin.sh` 端到端连跑 3 次均 `exit 0`，幂等正确（`code=10001`）
- [x] `decrypt-token.js` 输出契约实测 4 行；5 处消费方（`checkin.sh:79,87`、`setup.sh:55,136`、`checkin.ps1`、`setup.ps1:54,124`）均为前缀过滤，实测仍只取到 token 单行
- [x] `bash -n`、`node --check` 通过；`checkin.ps1` 括号引号配平核查通过
- [x] 待推 diff 凭据扫描：无 token / Bearer / 硬编码凭据
- [ ] **Windows 实机未验证**（本次验证均在 macOS 完成，含 #74 的 Windows 改动）

## 风险

- `decrypt-token.js` 本次改动**全部为注释**，凭据读取/解密逻辑一行未动
- `checkin.sh` / `checkin.ps1` 改动了请求发起与结果判定路径，已按上述测试计划验证
- Windows 侧以使用反馈为准

## 关联

Refs #73, #74