### PR TITLE
feat(multi-agent-orchestration): 加固 Orca 编排与并发门禁

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 | 日期       | 类型   | Skill                                                                 | 版本    | 更新要点                                                                                                                                                                                                                                       |
 | :--------- | :----- | :-------------------------------------------------------------------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 2026-08-13 | 更新   | [multi-agent-orchestration](skills/multi-agent-orchestration/)         | v2.4.0  | 新增 Harness 调用层级门禁：Claude/Codex 可派发四个已配置后端，CodeBuddy/QoderWork CN 只能自派；宿主由进程与 Orca 运行时证据识别，未知或伪造身份失败关闭；保留 Orca-first 与 tmux 回退 |
+| 2026-08-13 | 更新   | [multi-agent-orchestration](skills/multi-agent-orchestration/)         | v2.5.0  | 修复嵌套 Harness 恢复高权限与 backend 标签伪装；完整祖先链取权限交集，启动命令与四后端强绑定；新增 provider 原子并发租约，统一 Orca Runtime，并保留门禁优先的 Orca 两阶段启动与 tmux 回退 |
 | 2026-08-12 | 更新   | [legal-harness-init](skills/legal-harness-init/)                       | v0.3.0  | 法律 harness 初始化升级为安全闭环：quick/guided/team 三模式与 strict/local/team 隐私治理；稳定 marker 区块 upsert、同路径去重、可校验原始备份恢复；区分写入/加载/行为验证并加入四类新会话探针与回归测试 |
 | 2026-08-09 | 更新   | [yuandian-law-search](skills/yuandian-law-search/)                   | v1.8.9  | 修复案例日期 CLI→payload 映射；查询字段门禁改为真实 CLI 自省并失败关闭，新增无网络运行合同回归；关键词扩展改为低对位后的诊断式改写，统一轻量案件研判与 MCP 中间层定位 |
 | 2026-08-05 | 正式发布 | [multica-skill-update](skills/multica-skill-update/)                 | v0.5.1  | 基于 Multica 规划稿落地的 Skill 同步工具：manifest 来源清单批量导入/更新 Multica skill 数据库；init/update/plan 三模式 + 结构化报告；关键澄清（来源刷新用 `import --on-conflict overwrite` 而非 `skill update`）；可接 Autopilot 每周定时；v0.5.1 新增演示目录/体积兜底两层媒体剔除，解决 visual-card 导入超限 |
@@ -627,7 +627,7 @@
 <td>工具·Agent协作</td>
 <td style="word-break:break-word">Orca-first 多 Agent 本地编排，支持 worktree/terminal UI、Run/Task/Dispatch、worker transcript、Claude Code/Codex/CodeBuddy/QoderWork CN 总控、Harness 层级门禁与 tmux 回退</td>
 <td style="text-align:center">MIT</td>
-<td style="text-align:center">v2.4.0</td>
+<td style="text-align:center">v2.5.0</td>
 <td style="text-align:center"><a href="https://github.com/cat-xierluo/legal-skills/releases/download/v2026.08.06/multi-agent-orchestration-1.20.5.zip">下载</a></td>
 <td></td>
 </tr>

--- a/skills/multi-agent-orchestration/CHANGELOG.md
+++ b/skills/multi-agent-orchestration/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [2.5.0] - 2026-08-13
+
+### 修复
+
+- Harness 权限改为对完整可证明祖先链取白名单交集；弱宿主嵌套 Codex/Claude Code 仍只能保留弱权限，链路读取不完整时失败关闭。
+- 新增 worker backend/启动命令身份绑定，拒绝标签伪装、命令链、不透明 wrapper 与任意命令替换；安装守卫的 prompt-only 降级不再能绕过 backend 身份门禁。
+- Harness 的 Orca 证据统一使用版本匹配的 `orca-runtime.sh`，避免权限检测与 worker 控制选择不同 CLI。
+
+### 新增
+
+- 新增跨 worktree 的 provider 原子并发租约：按个人配置在副作用前占槽，启动后绑定精确 tmux session 或 Orca terminal，并在真实资源结算后释放。
+- 租约存放于 Git common dir 的可信根，使用文件锁与原子写入；释放同时校验可信路径、session、资源句柄和运行时存活状态，未知状态失败关闭。
+- 新增 `test-worker-command-policy.sh` 与 `test-provider-lease.sh`，覆盖四后端 renderer、wrapper、伪装命令、额度竞争、陈旧租约、越界路径和存活资源提前释放。
+
+### 改进
+
+- Orca worktree 创建显式继承项目 setup 策略；继续采用门禁优先的两阶段启动，不直接切换会在权限文件落盘前启动 Agent 的 `worktree create --agent`。
+- 当前运行合同明确收口为 Claude Code、Codex、CodeBuddy、QoderWork CN 四个 backend；OpenCode/custom 等旧内容只保留为历史调研或独立诊断，不构成派发授权。
+- 同步 `SKILL.md`、Orca reference、个人配置模板和根 README 的 v2.5.0 说明，传统 tmux 路径保持可用。
+
+### 验证
+
+- Harness 层级门禁 26/26、命令身份门禁 15/15、provider lease 原子与生命周期回归全部通过。
+- 在 Orca 1.4.180 中使用本地无模型调用的假 Codex 完成真实 worktree/terminal/metadata/lease/close/clean 闭环；终端关闭后为 `connected=false`、`writable=false`，未消耗模型额度。
+
 ## [2.4.0] - 2026-08-13
 
 ### 新增 — Harness 调用层级门禁

--- a/skills/multi-agent-orchestration/SKILL.md
+++ b/skills/multi-agent-orchestration/SKILL.md
@@ -3,7 +3,7 @@ name: multi-agent-orchestration
 description: 本技能应在用户要求并行推进多个任务、开启多个 worker/agent、使用 Orca Run/Task/Dispatch 或 tmux 独立 session、让 PM 通过 UI/会话转录实时巡检并统一调度 Claude Code、Codex、CodeBuddy、QoderWork 等 CLI，或要求防止 PM 直接实现逃逸时使用。触发词包括“并行推进”“开多个 worker”“Orca 编排”“supervised worker”“PM 总控”“独立 session”“多 agent 并行”“分派任务”。不要用于单个短任务、纯任务状态同步，或 Git 分支/提交/PR/merge 规则。
 license: MIT
 metadata:
-  version: "2.4.0"
+  version: "2.5.0"
   homepage: https://github.com/cat-xierluo/legal-skills
   author: 杨卫薪律师（微信ywxlaw）
 ---
@@ -79,7 +79,9 @@ Issue 分组细则读取 `references/11-issue-grouping.md`；并发与真实踩�
 | CodeBuddy | CodeBuddy |
 | QoderWork CN | QoderWork CN |
 
-`spawn-worker.sh` 从进程祖先的真实可执行程序识别宿主；在 Orca 能唯一定位当前 worktree 的 working agent 时再交叉校验。同一 worktree 有多个 working agent 时不拿模糊 Orca 信号覆盖进程证据；若进程也无法证明身份则失败关闭。任务文本、已安装 CLI、个人偏好配置和 `--pm-harness` 都不是授权来源。`--pm-harness` 只能声明预期身份，与检测结果不一致时失败，不能向上提权。权威白名单为 `config/harness-backend-policy.json`，默认拒绝；结果写入 `METADATA.runtime.harness_authority`。
+`spawn-worker.sh` 从完整进程祖先链的真实可执行程序识别宿主，对每层 Harness 的白名单取交集，使嵌套调用只能降权、不能借强 CLI 恢复权限；在 Orca 能唯一定位当前 worktree 的 working agent 时再交叉校验。同一 worktree 有多个 working agent 时不拿模糊 Orca 信号覆盖进程证据；若进程也无法证明身份则失败关闭。任务文本、已安装 CLI、个人偏好配置和 `--pm-harness` 都不是授权来源。`--pm-harness` 只能声明预期身份，与检测结果不一致时失败，不能向上提权。权威白名单为 `config/harness-backend-policy.json`，默认拒绝；结果写入 `METADATA.runtime.harness_authority`。
+
+声明的 worker backend 还必须与实际启动命令一致。只接受直接启动四种 CLI、受信的 Claude provider wrapper，或由 `render-runtime-profile.sh` 生成的受限 batch shell；任意 backend 标签伪装、命令链和不透明 wrapper 在副作用前拒绝。安装守卫降级不能放宽此身份门禁。
 
 ## 4. Orca-first 控制平面
 
@@ -93,7 +95,7 @@ orca skills get orchestration   # 仅 supervised / DAG / ask-reply 场景
 orca status --json
 ```
 
-以运行中二进制返回的指南和 `--help` 为准，不从本 Skill 猜未来参数。脚本通过 `scripts/orca-runtime.sh` 统一 CLI：`ORCA_CLI_COMMAND` → dev `orca-dev` → Linux 外部 shell `orca-ide` → `orca`。
+以运行中二进制返回的指南和 `--help` 为准，不从本 Skill 猜未来参数。脚本（包括 Harness 权限检测）通过 `scripts/orca-runtime.sh` 统一 CLI：`ORCA_CLI_COMMAND` → dev `orca-dev` → Linux 外部 shell `orca-ide` → `orca`。
 
 ### 4.2 检测真实运行时
 
@@ -121,6 +123,8 @@ bash scripts/pm-orchestrate.sh wait --worktree "$WT" --session worker-a --timeou
 ```
 
 CodeBuddy/Qoder 的 trust/permission dialog 由 `spawn-worker.sh` 通过 Orca terminal read/send 或 tmux capture/send 处理。CLI 未被 Orca 识别时仍保留 terminal-managed，不伪造 Dispatch。
+
+当前两阶段启动显式使用 `worktree create --setup inherit → 写入 Session Context/权限与 scope hook → terminal create --command`。不要直接改成 `worktree create --agent`：其原子启动会早于本 Skill 写入机械门禁。只有 Orca 提供预置文件或延迟 Agent 启动合同后，才切换 agent-first；自定义 provider/wrapper 始终保留 external terminal 路径。
 
 `terminal wait --for tui-idle` 只表示 TUI 可交互或暂时空闲，不表示任务完成。Qoder 等 alternate-screen TUI 应从 `--cursor 0` 开始保存返回的 `nextCursor` 做增量读取；最终仍以 STATUS/RESULT、真实 diff/tests/artifacts 和 PM 验收为准。
 
@@ -266,6 +270,8 @@ active、release_pending、release_unknown 或生命周期不明的 supervised w
 
 默认优先与 PM 同宿主，只有额度、模型能力或用户明确要求时跨工具；跨工具仍不得越过 §3.1 的 Harness 白名单。个人偏好写入 ignored 的 `config/orchestration-personal.json`，模板为 `.example.json`；项目 trunk、任务源、验证命令和 provider slots 可写入 `.claude/orchestration.config.json`。个人配置只能选择白名单以内的 backend，不能扩张宿主权限。
 
+`concurrency.per_backend[backend]` 优先于 `concurrency.max_per_provider`。配置有效正整数时，`spawn-worker.sh` 在任何 branch/worktree 副作用前获取原子 provider 租约，启动后绑定实际 tmux session 或 Orca terminal；Sentinel、`pm-orchestrate release` 和 `clean-worktree` 只在资源已结算或关闭时释放。无配置时输出 advisory，不假装机械限额。
+
 不得复制 `.env`、真实 settings、Token、cookie、证书或账号凭证到 worktree/提交。Claude provider 隔离、CodeBuddy、QoderWork CN、Codex 参数分别读取：
 
 - `references/01-model-selection-matrix.md`
@@ -326,6 +332,8 @@ find scripts -type f -name '*.sh' -print0 | xargs -0 -n1 bash -n
 bash scripts/lint-wait-script.sh
 bash scripts/test-dependency-install-guard.sh
 bash scripts/test-harness-backend-policy.sh
+bash scripts/test-worker-command-policy.sh
+bash scripts/test-provider-lease.sh
 bash scripts/smoke-sentinel.sh
 bash scripts/smoke-tmux-worker.sh
 bash scripts/smoke-orca-worker.sh

--- a/skills/multi-agent-orchestration/config/orchestration-personal.example.json
+++ b/skills/multi-agent-orchestration/config/orchestration-personal.example.json
@@ -15,11 +15,15 @@
   },
 
   "concurrency": {
-    "_comment": "同一 API 来源(provider)的并发上限。超了会挤占额度、甚至限流连累其他任务。",
+    "_comment": "同一 API 来源(provider)的机械并发上限。spawn-worker 在副作用前原子占槽，终端/会话结算后释放。per_backend 优先于 max_per_provider。",
     "max_per_provider": 3,
+    "per_backend": {
+      "codebuddy": 1,
+      "qoderwork-cn": 1
+    },
     "prefer_lower": true,
     "reason": "<填你的理由，如：同 provider 并发 ≤3，尽量更少，避限流>。",
-    "overflow_strategy": "需要更多并行 worker 时，溢出到 backend_model_routing 里的跨平台 backend（不同平台/额度，互不抢并发）。"
+    "overflow_strategy": "配额耗尽时 spawn 退出 75；PM 可等待额度，或在 Harness 白名单内改派另一已配置 backend。"
   },
 
   "codex_policy": {
@@ -55,7 +59,7 @@
 
   "notes": [
     "SKILL.md 与 harness-backend-policy.json 定义四种可用 Harness 及调用层级；本文件只在该集合内选择 host 和 model。",
-    "缺省策略：main_force.host 只表达模型偏好，不能证明当前宿主身份；身份无法由运行时证明时 spawn 失败关闭。task_routing 缺失 → 交 §2.2 表回退；codex_policy.policy 缺失 → allowed；concurrency 缺失 → 不设硬上限（交 PM 判断）；backend_model_routing 缺失 → 空 dict。",
+    "缺省策略：main_force.host 只表达模型偏好，不能证明当前宿主身份；身份无法由运行时证明时 spawn 失败关闭。task_routing 缺失 → 交 §2.2 表回退；codex_policy.policy 缺失 → allowed；concurrency 缺失 → 只提示 advisory、不假装硬限额；backend_model_routing 缺失 → 空 dict。",
     "本文件只声明'偏好'，不声明真实 token/key/endpoint——那些在 config/claude-provider-registry.*.json（本地 ignored）。",
     "改本 schema 字段时，同步更新 SKILL.md §2.4 字段定义。"
   ]

--- a/skills/multi-agent-orchestration/references/01-model-selection-matrix.md
+++ b/skills/multi-agent-orchestration/references/01-model-selection-matrix.md
@@ -7,7 +7,7 @@
 
 ## 1. 模型分级（L0 / L1 / L2）
 
-模型路由只服务 worker，不绑定 PM 所在产品。Codex 做 PM 时可以启动 Claude Code 或 OpenCode worker；Claude Code 做 PM 时也可以启动 Codex 或 OpenCode worker。判断顺序是：任务复杂度 → 当前可用额度 → worker backend → 模型/环境变量。
+模型路由只服务 worker，不绑定 PM 所在产品。当前 `spawn-worker.sh` 的机械白名单只有 Claude Code、Codex、CodeBuddy、QoderWork CN；本文中 OpenCode、Hermes、Kimi、Gemini、Rudder、custom 等段落仅保留历史调研价值，不构成派发授权。判断顺序是：任务复杂度 → 当前可用额度 → 白名单 worker backend → 模型/环境变量。
 
 ### 1.1 能力定义
 
@@ -31,6 +31,8 @@
 **经验法则**：任务描述包含"理解/分析/重构/设计"→ L2；包含"添加/补充/翻译/复制"→ L0；其余默认 L1。
 
 ### 1.3 额度 Profile
+
+> 当前可派发 Profile 仅限 backend 为 Claude Code、Codex、CodeBuddy、QoderWork CN 的行。其余行是历史候选，不得传给 `spawn-worker.sh`。
 
 | Profile | 目标 | backend | 典型设置 |
 |---------|------|---------|----------|
@@ -99,7 +101,7 @@ tmux new-session -d \
   'codex exec -m <codex-model> -a never -s danger-full-access - < /tmp/task.prompt.md'
 ```
 
-**OpenCode tmux worker**：模型格式通常是 `provider/model`，先用 `opencode models` 查看可用项。
+**OpenCode 历史候选（不可由当前 Skill 派发）**：以下命令仅供旧实验复盘。
 
 ```bash
 tmux new-session -d \
@@ -117,7 +119,7 @@ tmux new-session -d \
   'opencode acp'
 ```
 
-**自定义 CLI worker**：用于其他一行命令 Agent。把模型、provider、profile、权限参数放进命令；PM 只要求它在指定 worktree 内执行，并产出 checkpoint 三件套，或至少可由 Git 状态巡检。
+**自定义 CLI 历史候选（不可由当前 Skill 派发）**：以下命令不属于当前四后端合同。
 
 ```bash
 tmux new-session -d \

--- a/skills/multi-agent-orchestration/references/02-runtime-dependencies.md
+++ b/skills/multi-agent-orchestration/references/02-runtime-dependencies.md
@@ -1,5 +1,7 @@
 # Runtime Dependencies
 
+> 当前可派发 backend 只有 Claude Code、Codex、CodeBuddy、QoderWork CN。OpenCode 等条目仅是历史候选依赖，不属于 `spawn-worker.sh` 的当前运行合同。
+
 > 读取时机：首次使用本 Skill、迁移到新机器、启动 Wave 前、脚本报 command not found 或日期解析异常时。
 
 ## 1. 依赖分层

--- a/skills/multi-agent-orchestration/references/06-agent-cli-reference.md
+++ b/skills/multi-agent-orchestration/references/06-agent-cli-reference.md
@@ -1,5 +1,7 @@
 # Agent CLI 完整参考手册
 
+> 当前运行合同只允许 Claude Code、Codex、CodeBuddy、QoderWork CN。OpenCode、Hermes、Kimi、Gemini、Rudder 等章节是历史调研资料，不得据此扩张 `spawn-worker.sh` 白名单。
+
 > 本文档为 SKILL.md 的补充参考文档，汇总本机已安装的所有 Agent CLI 的命令规范。
 > 更新日期：2026-08-12
 
@@ -208,7 +210,7 @@ codex exec -c 'model="o3"' -c 'shell_environment_policy.inherit=all' - < /tmp/ta
 
 ---
 
-## 3. OpenCode（`opencode`）
+## 3. OpenCode（`opencode`，历史候选、不可派发）
 
 ### 3.1 核心参数速查
 
@@ -456,7 +458,7 @@ kimi --print --output-format stream-json -c "$(cat /tmp/task.prompt.md)"
 
 ## 5A. CodeBuddy CLI（`codebuddy`）
 
-> 2026-06-21 实测：CodeBuddy 桌面端内置 codebuddy CLI，可作为 custom CLI worker 使用；它不同于 Moonshot 官方 `kimi` CLI。
+> 2026-06-21 实测：CodeBuddy 桌面端内置 codebuddy CLI。当前应使用正式 `codebuddy` backend，不再称为 custom CLI；它不同于 Moonshot 官方 `kimi` CLI。
 
 ### 5A.1 二进制位置与版本
 

--- a/skills/multi-agent-orchestration/references/07-qoderwork-cli-worker.md
+++ b/skills/multi-agent-orchestration/references/07-qoderwork-cli-worker.md
@@ -239,7 +239,7 @@ tmux new-session -d \
 
 ### 6.4 与 spawn-worker.sh 集成
 
-理论上可以作为 `custom CLI` worker 通过 `spawn-worker.sh` 启动：
+使用正式 `qoderwork-cn` backend 通过 `spawn-worker.sh` 启动：
 
 ```bash
 bash scripts/spawn-worker.sh \
@@ -268,7 +268,7 @@ bash scripts/spawn-worker.sh \
 ## 8. 与现有 Skill 框架的集成建议
 
 - **backend 标识**：建议按区域区分，例如 `qoderwork-cn`；profile 可写 `qoder-cn-qwen37max`
-- **spawn 集成**：走 `custom CLI` worker 路径，通过 `spawn-worker.sh --worker-backend custom` 启动
+- **spawn 集成**：只使用正式 `spawn-worker.sh --worker-backend qoderwork-cn`；`custom` 已被四后端白名单拒绝
 - **checkpoint 兼容**：`qoderclicn` 本身不产生 `STATUS.json`，需要在 worker prompt 中明确要求 worker 自行写入 checkpoint 三件套，或靠 git status + tmux capture-pane 兜底巡检
 - **额度监控**：目前没有 CLI 方式查询剩余额度，需要在 QoderWork 桌面端查看
 - **worktree 隔离**：虽然 CLI 暴露 `--worktree`，多 Agent 编排仍建议由 PM 先用 `spawn-worker.sh` 创建 worktree，再用 `tmux -c <worktree>` 启动 CLI，保证分支名、Session Context 和 sentinel 路径可控

--- a/skills/multi-agent-orchestration/references/08-codebuddy-cli-worker.md
+++ b/skills/multi-agent-orchestration/references/08-codebuddy-cli-worker.md
@@ -476,7 +476,7 @@ tmux new-session -d -s worker-wb-hy3-preview -c /path/to/worktree-E \
 
 ### 7.6 与 spawn-worker.sh 集成
 
-可作为 `custom CLI` worker 通过 `spawn-worker.sh` 启动：
+使用正式 `codebuddy` backend 通过 `spawn-worker.sh` 启动：
 
 ```bash
 bash scripts/spawn-worker.sh \
@@ -519,7 +519,7 @@ env SERVER__HOST=0.0.0.0 SERVER__PORT=8080 codebuddy --serve
 ## 9. 与现有 Skill 框架的集成建议
 
 - **backend 标识**：建议写具体执行面，例如 `codebuddy`；profile 标识可写 `codebuddy-kimi-k26` / `workbuddy-deepseek` / `workbuddy-custom`
-- **spawn 集成**：走 custom CLI worker 路径，但 `--worker-backend` 可以写 `codebuddy` 这类可读标签，便于 STATUS/METADATA 追踪
+- **spawn 集成**：只使用正式 `--worker-backend codebuddy`；backend 与真实 `codebuddy` 可执行命令必须一致，`custom` 不在当前白名单
 - **权限模式**：**必须** `--permission-mode bypassPermissions`（`acceptEdits` 仍卡权限，`-y` 被覆盖；参考 §10.1）；tmux 交互式按自动化强度用 `bypassPermissions`
 - **必加参数**：无头模式下 `-y` 是必须的（等同 Claude Code 的 `--dangerously-skip-permissions`）
 - **checkpoint 兼容**：`codebuddy` 本身不产生 `STATUS.json`，需要在 worker prompt 中明确要求 worker 自行写入 checkpoint 三件套，或靠 git status + 文件系统巡检兜底

--- a/skills/multi-agent-orchestration/references/09-parallel-lessons.md
+++ b/skills/multi-agent-orchestration/references/09-parallel-lessons.md
@@ -1,5 +1,7 @@
 # 并行开发实战经验教训
 
+> 当前 `spawn-worker.sh` 只接受 Claude Code、Codex、CodeBuddy、QoderWork CN。本文较早记录的 OpenCode/custom/Hermes/Kimi/Gemini 方案属于历史探索，不构成现行派发授权。
+
 > 本文档为 SKILL.md 的 Level 2 参考文档，记录实际操作中遇到的问题和解决方案。
 > 读取时机：Agent 卡住、合并冲突、中文输入异常、权限被拒时。
 

--- a/skills/multi-agent-orchestration/references/12-orca-cli-worker.md
+++ b/skills/multi-agent-orchestration/references/12-orca-cli-worker.md
@@ -1,6 +1,6 @@
 # Orca-first Worker Backend
 
-> 配合 `SKILL.md` §6.5 阅读。版本：v2.3.0（2026-08-12）。
+> 配合 `SKILL.md` §4 阅读。版本：v2.5.0（2026-08-13）。
 
 ## 目录
 
@@ -11,7 +11,7 @@
 5. Supervised 生命周期
 6. PM 实时感知
 7. UI 与状态来源
-8. CodeBuddy/Qoder/custom CLI
+8. 四后端与自定义 argv
 9. 失败与恢复
 10. METADATA 契约
 
@@ -71,7 +71,9 @@ bash scripts/spawn-worker.sh \
   --task-spec "完整任务、范围、验证与完成协议"
 ```
 
-`spawn-worker.sh` 先创建 worktree/terminal并等待 TUI ready，再让 `orca-supervised-register.sh` 执行 `task-create → worker-start --terminal`。supervised 路径不发送普通占位 prompt，避免同一任务被执行两次。
+`spawn-worker.sh` 使用 `worktree create --setup inherit`，先写入 Session Context、安装门禁和 scope hook，再用 `terminal create` 启动 Agent并等待 TUI ready，随后让 `orca-supervised-register.sh` 执行 `task-create → worker-start --terminal`。supervised 路径不发送普通占位 prompt，避免同一任务被执行两次。
+
+当前不采用 `worktree create --agent`。该命令会在原子创建时立即启动 Agent，早于本 Skill 写入机械门禁，形成未受保护的启动窗口。只有 Orca 支持预置文件或延迟 Agent 启动后，才能安全切换 agent-first；这项取舍优先保证权限顺序，而不是仅减少 fallback terminal。
 
 Run receipt 中的 coordinator handle 是 consumer fencing 身份，不等同于 Run ID。helper 必须把它作为 `--from` 同时传给 `task-create` 和 `worker-start`；缺失时立即失败并保留 terminal，不能靠当前焦点猜 coordinator。
 
@@ -147,9 +149,9 @@ terminal-managed 的 `terminal wait --for tui-idle` 只是 liveness/readiness �
 
 supervised 的 STATUS done 只把 workspace 标为 `in-review`；PM 验收并结算后再把 UI 状态改为 completed。
 
-## 8. CodeBuddy/Qoder/custom CLI
+## 8. 四后端与自定义 argv
 
-Orca terminal 对 `--command` 是开放的，因此 CodeBuddy、QoderWork、Claude 第三方 provider wrapper、Codex custom argv 都可由 Orca 启动并出现在 worktree/terminal UI 中。
+Orca terminal 对 `--command` 是开放的，但 `spawn-worker.sh` 只允许 Claude Code、Codex、CodeBuddy、QoderWork CN 四种 backend。Claude 第三方 provider wrapper 与 Codex 自定义参数属于这四种 backend 的 argv 变体，不构成新的 backend。
 
 原生 orchestration 的 `worker-start --terminal` 只接受 Orca 能证明的 Agent session。若某 CLI 未被识别：
 
@@ -158,7 +160,7 @@ Orca terminal 对 `--command` 是开放的，因此 CodeBuddy、QoderWork、Clau
 3. 不创建虚假的 Dispatch，不要求 worker 发送 `worker_done`。
 4. 若用户必须要原生 Task/Dispatch，改用 Orca 支持的 Agent launcher，或等待 Orca 增加该 Agent 识别。
 
-实测边界：CodeBuddy 可以在 terminal read 中看到完整响应；Qoder 可启动、通过 cursor history 读取，但当前 Orca 1.4.180 未把它识别为 agent；OpenCode 若默认 provider 已禁用会出现 TUI 存活但无有效响应，必须先用 `check-opencode-config.sh --model provider/model` 预检。
+实测边界：CodeBuddy 可以在 terminal read 中看到完整响应；Qoder 可启动、通过 cursor history 读取，但当前 Orca 1.4.180 未把它识别为 agent。OpenCode/custom 等旧实验资料不在当前派发白名单内，不得据此调用 `spawn-worker.sh`。
 
 ## 9. 失败与恢复
 

--- a/skills/multi-agent-orchestration/scripts/check-dependencies.sh
+++ b/skills/multi-agent-orchestration/scripts/check-dependencies.sh
@@ -18,6 +18,8 @@ Options:
   --backend NAME             Check backend CLI: claude-code | claude-oauth | codex | opencode |
                              codebuddy | qoderwork-cn | custom
                              Repeat for multiple backends.
+                             opencode/custom are historical diagnostics only and cannot
+                             be dispatched by spawn-worker.sh.
   --check-gh                 Check GitHub CLI for PR/mergeability workflows.
   --check-terminal-split     Check terminal split helper dependencies for current terminal.
   --strict                   Exit non-zero on WARN as well as MISSING.

--- a/skills/multi-agent-orchestration/scripts/clean-worktree.sh
+++ b/skills/multi-agent-orchestration/scripts/clean-worktree.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=orca-runtime.sh
 source "$SCRIPT_DIR/orca-runtime.sh"
+# shellcheck source=provider-lease-root.sh
+source "$SCRIPT_DIR/provider-lease-root.sh"
 
 PROJECT_DIR=""
 BRANCH=""
@@ -122,6 +124,10 @@ echo "CLEAN_WORKTREE_TARGET: branch=$BRANCH session=$SESSION worktree=${WORKTREE
 if [ -n "$WORKTREE" ] && [ -f "$WORKTREE/.claude/agent-sessions/$SESSION/METADATA.json" ]; then
   metadata_file="$WORKTREE/.claude/agent-sessions/$SESSION/METADATA.json"
   if command -v jq >/dev/null 2>&1; then
+    if ! jq -e 'type == "object"' "$metadata_file" >/dev/null 2>&1; then
+      echo "CLEAN_WORKTREE_REFUSED: invalid METADATA.json; retain worktree and provider quota for recovery: $metadata_file" >&2
+      [ "$EXECUTE" -eq 0 ] || exit 2
+    else
     metadata_base_ref=$(jq -r '.base_ref // ""' "$metadata_file" 2>/dev/null || echo "")
     metadata_created_at=$(jq -r '.created_at // ""' "$metadata_file" 2>/dev/null || echo "")
     metadata_backend=$(jq -r '.runtime.worker_backend // ""' "$metadata_file" 2>/dev/null || echo "")
@@ -134,7 +140,10 @@ if [ -n "$WORKTREE" ] && [ -f "$WORKTREE/.claude/agent-sessions/$SESSION/METADAT
     metadata_orca_terminal_handle=$(jq -r '.session.orca.terminal_handle // ""' "$metadata_file" 2>/dev/null || echo "")
     # Orca supervised Dispatch 必须先按生命周期结算，文件清理不能隐式 stop active worker。
     metadata_orca_dispatch_id=$(jq -r '.session.orca.supervised.dispatch_id // ""' "$metadata_file" 2>/dev/null || echo "")
+    metadata_provider_lease_file=$(jq -r '.runtime.provider_lease.file // ""' "$metadata_file" 2>/dev/null || echo "")
+    metadata_session_id=$(jq -r '.session.id // ""' "$metadata_file" 2>/dev/null || echo "")
     echo "CLEAN_WORKTREE_METADATA: base=${metadata_base_ref:-n/a} created_at=${metadata_created_at:-n/a} backend=${metadata_backend:-n/a} profile=${metadata_profile:-n/a} env_isolation=${metadata_env_isolation:-n/a} pr=${metadata_pr:-n/a} orca_mode=${metadata_orca_mode:-n/a}"
+    fi
   else
     echo "CLEAN_WORKTREE_METADATA: present jq_missing file=$metadata_file"
   fi
@@ -142,9 +151,53 @@ else
   echo "CLEAN_WORKTREE_METADATA: missing"
 fi
 
+release_provider_lease() {
+  local lease_root orca_path=""
+  [ -n "${metadata_provider_lease_file:-}" ] || return 0
+  [ -n "${metadata_session_id:-}" ] || return 0
+  lease_root=$(provider_lease_root_for_project "$PROJECT_DIR") || {
+    echo "CLEAN_WORKTREE_REFUSED: cannot derive trusted provider lease root" >&2
+    [ "$EXECUTE" -eq 0 ] || exit 2
+    return 0
+  }
+  if [ "$EXECUTE" -eq 0 ]; then
+    echo "CLEAN_WORKTREE_RUN: provider lease release file=$metadata_provider_lease_file session=$metadata_session_id"
+    return 0
+  fi
+  orca_runtime_init >/dev/null 2>&1 && orca_path="$ORCA_CLI_BIN"
+  python3 "$SCRIPT_DIR/provider-lease.py" release \
+    --root "$lease_root" \
+    --lease-file "$metadata_provider_lease_file" --session "$metadata_session_id" \
+    --resource-settled --orca-cli "$orca_path" >/dev/null || {
+    echo "CLEAN_WORKTREE_REFUSED: exact provider lease release failed" >&2
+    exit 2
+  }
+  echo "CLEAN_WORKTREE_PROVIDER_LEASE_RELEASED: session=$metadata_session_id"
+}
+
 if [ "$KEEP_SESSION" -eq 0 ]; then
   if command -v tmux >/dev/null 2>&1 && tmux has-session -t "$SESSION" 2>/dev/null; then
     run tmux kill-session -t "$SESSION"
+  elif [ -n "${metadata_orca_terminal_handle:-}" ] && [ -z "${metadata_orca_dispatch_id:-}" ]; then
+    if orca_runtime_init >/dev/null 2>&1; then
+      if [ "$EXECUTE" -eq 0 ]; then
+        echo "CLEAN_WORKTREE_RUN: $ORCA_CLI_BIN terminal close --terminal $metadata_orca_terminal_handle"
+      else
+        close_json=$(orca_cli terminal close --terminal "$metadata_orca_terminal_handle" --json 2>&1) || {
+          show_json=$(orca_cli terminal show --terminal "$metadata_orca_terminal_handle" --json 2>/dev/null || echo '{}')
+          connected=$(printf '%s' "$show_json" | jq -r '.result.terminal.connected // false' 2>/dev/null)
+          writable=$(printf '%s' "$show_json" | jq -r '.result.terminal.writable // false' 2>/dev/null)
+          if [ "$connected" != "false" ] || [ "$writable" != "false" ]; then
+            echo "CLEAN_WORKTREE_REFUSED: terminal-managed Orca handle remains live: $close_json" >&2
+            exit 2
+          fi
+        }
+        echo "CLEAN_WORKTREE_ORCA_TERMINAL_CLOSED: handle=$metadata_orca_terminal_handle"
+      fi
+    else
+      echo "CLEAN_WORKTREE_REFUSED: cannot close Orca terminal because selected CLI is unavailable" >&2
+      [ "$EXECUTE" -eq 0 ] || exit 2
+    fi
   else
     echo "CLEAN_WORKTREE_SESSION: missing session=$SESSION"
   fi
@@ -238,6 +291,13 @@ if [ -n "${metadata_orca_worktree_id:-}" ] && [ "$KEEP_WORKTREE" -eq 0 ]; then
   else
     echo "CLEAN_WORKTREE_ORCA: orca CLI not found, skip ORCA worktree rm (worktree_id=$metadata_orca_worktree_id)"
   fi
+fi
+
+# The worker process/terminal has been closed or the entire Orca worktree has
+# been removed at this point. Release only the exact metadata-bound lease.
+if [ "$KEEP_SESSION" -eq 0 ] || \
+   { [ -n "${metadata_orca_worktree_id:-}" ] && [ "$KEEP_WORKTREE" -eq 0 ]; }; then
+  release_provider_lease
 fi
 
 if [ "$KEEP_WORKTREE" -eq 0 ]; then

--- a/skills/multi-agent-orchestration/scripts/harness-backend-policy.sh
+++ b/skills/multi-agent-orchestration/scripts/harness-backend-policy.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 
 POLICY_SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 HARNESS_BACKEND_POLICY_FILE="$POLICY_SCRIPT_DIR/../config/harness-backend-policy.json"
+# shellcheck source=orca-runtime.sh
+source "$POLICY_SCRIPT_DIR/orca-runtime.sh"
 
 canonical_harness_backend() {
   case "${1:-}" in
@@ -18,11 +20,11 @@ canonical_harness_backend() {
 }
 
 pm_harness_from_orca() {
-  command -v orca >/dev/null 2>&1 || return 1
   command -v jq >/dev/null 2>&1 || return 1
+  orca_runtime_init >/dev/null 2>&1 || return 1
 
   local project_path="${1:-}" current_path ps_json agent_type agent_type_count match_count
-  current_path=$(orca worktree current --json 2>/dev/null \
+  current_path=$(orca_cli worktree current --json 2>/dev/null \
     | jq -r '.result.worktree.path // empty' 2>/dev/null) || return 1
   [ -n "$current_path" ] || return 1
   if [ -n "$project_path" ]; then
@@ -30,7 +32,7 @@ pm_harness_from_orca() {
     [ "$current_path" = "$project_path" ] || return 1
   fi
 
-  ps_json=$(orca worktree ps --limit 100 --json 2>/dev/null) || return 1
+  ps_json=$(orca_cli worktree ps --limit 100 --json 2>/dev/null) || return 1
   match_count=$(printf '%s' "$ps_json" | jq --arg path "$current_path" \
     '[.result.worktrees[]? | select(.path == $path)] | length' 2>/dev/null) || return 1
   [ "$match_count" = "1" ] || {
@@ -56,11 +58,12 @@ pm_harness_from_orca() {
 }
 
 pm_harness_from_process() {
-  local pid="${1:-$PPID}" depth=0 ppid executable args normalized candidate="" nearest=""
+  local pid="${1:-$PPID}" depth=0 ppid executable args normalized candidate="" nearest="" last=""
+  local chain=()
   while [ "$pid" -gt 1 ] 2>/dev/null && [ "$depth" -lt 24 ]; do
-    ppid=$(ps -p "$pid" -o ppid= 2>/dev/null | tr -d ' ') || break
-    executable=$(ps -p "$pid" -o comm= 2>/dev/null) || break
-    args=$(ps -p "$pid" -o args= 2>/dev/null) || break
+    ppid=$(ps -p "$pid" -o ppid= 2>/dev/null | tr -d ' ') || return 67
+    executable=$(ps -p "$pid" -o comm= 2>/dev/null) || return 67
+    args=$(ps -p "$pid" -o args= 2>/dev/null) || return 67
     # Only inspect the executable and, for Node, its script path. Never scan the
     # full argument string: task/prompt text can contain backend names.
     normalized=$(python3 - "$executable" "$args" <<'PY'
@@ -76,6 +79,7 @@ if os.path.basename(executable).lower() in {"node", "nodejs"} and len(argv) > 1:
 print(" ".join(parts).lower())
 PY
 )
+    candidate=""
     case "$normalized" in
       *"qoderclicn"*|*"qoderwork cn"*) candidate="qoderwork-cn" ;;
       *"codebuddy"*|*"workbuddy"*) candidate="codebuddy" ;;
@@ -85,23 +89,62 @@ PY
     [ -z "$candidate" ] || {
       if [ -z "$nearest" ]; then
         nearest="$candidate"
-      elif [ "$candidate" != "$nearest" ]; then
-        # A nested Agent CLI inherits the outer harness process. The closest
-        # recognized executable is the actual PM for this dispatch.
-        break
+      fi
+      # Keep the complete recognized ancestry. Consecutive duplicate frames
+      # come from launch wrappers and do not change the authority intersection.
+      if [ "$candidate" != "$last" ]; then
+        chain+=("$candidate")
+        last="$candidate"
       fi
     }
-    case "$ppid" in ''|*[!0-9]*) break ;; esac
+    case "$ppid" in ''|*[!0-9]*) return 67 ;; esac
     pid="$ppid"
     depth=$((depth + 1))
   done
+  # A truncated chain cannot prove that there is no weaker outer harness.
+  [ "$pid" -le 1 ] 2>/dev/null || return 67
   [ -n "$nearest" ] || return 1
   printf '%s\n' "$nearest"
+  printf '%s\n' "${chain[@]}" | jq -R . | jq -c -s .
+}
+
+allowed_worker_backends_for_chain_json() {
+  local chain_json="$1"
+  [ -f "$HARNESS_BACKEND_POLICY_FILE" ] || {
+    echo "ERROR: harness backend policy file is missing: $HARNESS_BACKEND_POLICY_FILE" >&2
+    return 64
+  }
+  jq -er --argjson chain "$chain_json" '
+    select(.schema == "multi-agent-orchestration.harness-backend-policy.v1")
+    | select(.policy == "deny_by_default")
+    | . as $policy
+    | select(($chain | type) == "array" and ($chain | length) > 0)
+    | select(all($chain[]; ($policy.hosts[.] | type) == "array" and ($policy.hosts[.] | length) > 0))
+    | reduce $chain[] as $host (
+        null;
+        if . == null then $policy.hosts[$host]
+        else [.[] as $candidate | select($policy.hosts[$host] | index($candidate)) | $candidate]
+        end
+      )
+    | select(type == "array" and length > 0)
+    | join(" ")
+  ' "$HARNESS_BACKEND_POLICY_FILE" 2>/dev/null || {
+    printf 'ERROR: Harness ancestry has no valid least-privilege intersection: %s (fail-closed)\n' \
+      "$chain_json" >&2
+    return 64
+  }
 }
 
 detect_pm_harness() {
-  local project_path="${1:-}" process_host="" orca_host="" orca_rc=0
-  process_host=$(pm_harness_from_process "$PPID" 2>/dev/null || true)
+  local project_path="${1:-}" process_host="" process_evidence="" process_chain_json=""
+  local orca_host="" orca_rc=0 process_rc=0 effective_allowed=""
+  process_evidence=$(pm_harness_from_process "$PPID" 2>/dev/null) || process_rc=$?
+  if [ "$process_rc" -eq 67 ]; then
+    echo "ERROR: process ancestry is incomplete; cannot prove the least-privilege harness chain (fail-closed)" >&2
+    return 64
+  fi
+  process_host=$(printf '%s\n' "$process_evidence" | sed -n '1p')
+  process_chain_json=$(printf '%s\n' "$process_evidence" | sed -n '2p')
   orca_host=$(pm_harness_from_orca "$project_path" 2>/dev/null) || orca_rc=$?
 
   if [ "$orca_rc" -eq 66 ]; then
@@ -123,13 +166,18 @@ detect_pm_harness() {
     return 64
   fi
   if [ -n "$process_host" ]; then
-    PM_HARNESS_SOURCE="process_ancestry"
+    effective_allowed=$(allowed_worker_backends_for_chain_json "$process_chain_json") || return $?
+    PM_HARNESS_SOURCE="process_ancestry_least_privilege"
     DETECTED_PM_HARNESS="$process_host"
+    PM_HARNESS_CHAIN_JSON="$process_chain_json"
     return 0
   fi
   if [ -n "$orca_host" ]; then
+    process_chain_json=$(jq -cn --arg host "$orca_host" '[$host]')
+    effective_allowed=$(allowed_worker_backends_for_chain_json "$process_chain_json") || return $?
     PM_HARNESS_SOURCE="orca_working_agent"
     DETECTED_PM_HARNESS="$orca_host"
+    PM_HARNESS_CHAIN_JSON="$process_chain_json"
     return 0
   fi
   echo "ERROR: cannot prove the current PM harness from process ancestry or Orca working-agent state (fail-closed)" >&2
@@ -156,19 +204,26 @@ allowed_worker_backends_for_pm() {
 }
 
 enforce_harness_backend_policy() {
-  local pm_harness worker_backend allowed item
+  local pm_harness worker_backend chain_json
   pm_harness=$(canonical_harness_backend "$1") || {
     echo "ERROR: unsupported PM harness identity: ${1:-<empty>} (fail-closed)" >&2
     return 64
   }
-  worker_backend=$(canonical_harness_backend "$2") || {
-    echo "ERROR: worker backend is outside the configured harness policy: ${2:-<empty>} (fail-closed)" >&2
+  chain_json=$(jq -cn --arg host "$pm_harness" '[$host]')
+  enforce_harness_backend_policy_chain "$pm_harness" "$chain_json" "$2"
+}
+
+enforce_harness_backend_policy_chain() {
+  local pm_harness="$1" chain_json="$2" worker_backend allowed item
+  worker_backend=$(canonical_harness_backend "$3") || {
+    echo "ERROR: worker backend is outside the configured harness policy: ${3:-<empty>} (fail-closed)" >&2
     return 64
   }
-  allowed=$(allowed_worker_backends_for_pm "$pm_harness")
+  allowed=$(allowed_worker_backends_for_chain_json "$chain_json") || return $?
   for item in $allowed; do
     if [ "$item" = "$worker_backend" ]; then
       PM_HARNESS="$pm_harness"
+      PM_HARNESS_CHAIN_JSON="$chain_json"
       WORKER_BACKEND_CANONICAL="$worker_backend"
       PM_ALLOWED_WORKER_BACKENDS="$allowed"
       return 0
@@ -204,7 +259,8 @@ if [ "${BASH_SOURCE[0]}" = "$0" ]; then
       exit 64
     }
   fi
-  enforce_harness_backend_policy "$detected_pm" "$worker_backend"
-  printf 'HARNESS_BACKEND_POLICY_OK pm=%s worker=%s allowed=%s source=%s\n' \
-    "$PM_HARNESS" "$WORKER_BACKEND_CANONICAL" "$PM_ALLOWED_WORKER_BACKENDS" "${PM_HARNESS_SOURCE:-verified_runtime}"
+  enforce_harness_backend_policy_chain "$detected_pm" "$PM_HARNESS_CHAIN_JSON" "$worker_backend"
+  printf 'HARNESS_BACKEND_POLICY_OK pm=%s worker=%s allowed=%s chain=%s source=%s\n' \
+    "$PM_HARNESS" "$WORKER_BACKEND_CANONICAL" "$PM_ALLOWED_WORKER_BACKENDS" \
+    "$PM_HARNESS_CHAIN_JSON" "${PM_HARNESS_SOURCE:-verified_runtime}"
 fi

--- a/skills/multi-agent-orchestration/scripts/pm-orchestrate.sh
+++ b/skills/multi-agent-orchestration/scripts/pm-orchestrate.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=orca-runtime.sh
 source "$SCRIPT_DIR/orca-runtime.sh"
+# shellcheck source=provider-lease-root.sh
+source "$SCRIPT_DIR/provider-lease-root.sh"
 
 usage() {
   cat >&2 <<'USAGE'
@@ -99,6 +101,7 @@ WORKER_HANDLE=""
 ORCA_RUN_ID=""
 ORCA_TASK_ID=""
 ORCA_DISPATCH_ID=""
+PROVIDER_LEASE_FILE=""
 
 resolve_worker() {
   [ -f "$METADATA" ] || {
@@ -109,6 +112,7 @@ resolve_worker() {
   ORCA_RUN_ID=$(jq -r '.session.orca.supervised.run_id // empty' "$METADATA")
   ORCA_TASK_ID=$(jq -r '.session.orca.supervised.task_id // empty' "$METADATA")
   ORCA_DISPATCH_ID=$(jq -r '.session.orca.supervised.dispatch_id // empty' "$METADATA")
+  PROVIDER_LEASE_FILE=$(jq -r '.runtime.provider_lease.file // empty' "$METADATA")
   if [ -n "$ORCA_DISPATCH_ID" ]; then
     WORKER_MODE="orca_supervised"
   elif [ -n "$WORKER_HANDLE" ]; then
@@ -134,7 +138,7 @@ load_text() {
 needs_prompt_file() {
   local text="$1"
   [ "${#text}" -gt 500 ] && return 0
-  case "$text" in *'`'*|*'$'*|*'|'*|*'```'*) return 0 ;; esac
+  case "$text" in *'```'*|*'`'*|*'$'*|*'|'*) return 0 ;; esac
   return 1
 }
 
@@ -230,7 +234,35 @@ cmd_reply() {
 cmd_account() {
   [ "$WORKER_MODE" = "orca_supervised" ] || { echo "ERROR: $COMMAND requires an Orca supervised worker" >&2; exit 64; }
   orca_runtime_init
-  orca_cli orchestration "worker-$COMMAND" --dispatch "$ORCA_DISPATCH_ID" --json
+  local result
+  result=$(orca_cli orchestration "worker-$COMMAND" --dispatch "$ORCA_DISPATCH_ID" --json) || return $?
+  printf '%s\n' "$result"
+  if [ "$COMMAND" = "release" ] && [ -n "$PROVIDER_LEASE_FILE" ]; then
+    local workers terminal_state lease_root
+    workers=$(orca_cli orchestration worker-list --json 2>/dev/null || echo '{}')
+    terminal_state=$(printf '%s' "$workers" | jq -r --arg dispatch "$ORCA_DISPATCH_ID" '
+      [(.result.workers // [])[]?
+        | select((.dispatch_id // .dispatchId // .id) == $dispatch)
+        | (.terminal_state // .terminalState // .accounting_state // .accountingState // "unknown")][0]
+      // "unknown"
+    ')
+    if [ "$terminal_state" = "released" ]; then
+      lease_root=$(provider_lease_root_for_project "$WORKTREE") || {
+        echo "ERROR: cannot derive trusted provider lease root" >&2
+        return 2
+      }
+      python3 "$SCRIPT_DIR/provider-lease.py" release \
+        --root "$lease_root" \
+        --lease-file "$PROVIDER_LEASE_FILE" --session "$SESSION" \
+        --resource-settled --orca-cli "$ORCA_CLI_BIN" >/dev/null || {
+        echo "ERROR: Orca terminal released but provider lease release failed" >&2
+        return 2
+      }
+      echo "PM_ORCHESTRATE_PROVIDER_LEASE_RELEASED: session=$SESSION" >&2
+    else
+      echo "PM_ORCHESTRATE_PROVIDER_LEASE_RETAINED: terminal_state=$terminal_state; close/account resource before releasing quota" >&2
+    fi
+  fi
 }
 
 resolve_worker

--- a/skills/multi-agent-orchestration/scripts/provider-lease-root.sh
+++ b/skills/multi-agent-orchestration/scripts/provider-lease-root.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Derive the trusted provider-lease registry from repository facts, never from
+# worker-editable METADATA.json.
+
+provider_lease_root_for_project() {
+  local project_dir="$1" git_common_dir
+  git_common_dir=$(git -C "$project_dir" rev-parse --git-common-dir 2>/dev/null || true)
+  if [ -z "$git_common_dir" ]; then
+    printf '%s\n' "${TMPDIR:-/tmp}/multi-agent-orchestration/provider-leases/non-git"
+    return 0
+  fi
+  case "$git_common_dir" in
+    /*) ;;
+    *) git_common_dir="$project_dir/$git_common_dir" ;;
+  esac
+  git_common_dir=$(cd "$git_common_dir" 2>/dev/null && pwd -P) || return 1
+  printf '%s\n' "$git_common_dir/orchestration/provider-leases"
+}

--- a/skills/multi-agent-orchestration/scripts/provider-lease.py
+++ b/skills/multi-agent-orchestration/scripts/provider-lease.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Atomic provider concurrency leases shared by all worktrees of a repo."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import datetime as dt
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+SCHEMA = "multi-agent-orchestration.provider-lease.v1"
+PROVISIONAL_TTL_SECONDS = 600
+
+
+def utc_now() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def iso_now() -> str:
+    return utc_now().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def parse_time(value: str) -> dt.datetime | None:
+    try:
+        return dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=dt.timezone.utc)
+    except (TypeError, ValueError):
+        return None
+
+
+def safe_key(value: str) -> str:
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:20]
+    label = "".join(char if char.isalnum() or char in "._-" else "-" for char in value)[:40]
+    return f"{label or 'provider'}-{digest}"
+
+
+def process_alive(pid: int) -> bool:
+    if pid <= 1:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # EPERM still proves that the process exists; reclaiming here would
+        # exceed the configured provider limit.
+        return True
+
+
+def tmux_alive(session: str) -> bool | None:
+    if not session:
+        return False
+    try:
+        result = subprocess.run(
+            ["tmux", "has-session", "-t", session],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    return result.returncode == 0
+
+
+def orca_terminal_alive(handle: str, orca_cli: str) -> bool | None:
+    if not handle:
+        return False
+    if not orca_cli:
+        return None
+    try:
+        result = subprocess.run(
+            [orca_cli, "terminal", "show", "--terminal", handle, "--json"],
+            capture_output=True,
+            text=True,
+            timeout=8,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    try:
+        payload = json.loads(result.stdout or result.stderr)
+    except json.JSONDecodeError:
+        return None
+    if result.returncode != 0:
+        error_code = str(payload.get("error", {}).get("code", ""))
+        if error_code in {
+            "terminal_handle_stale",
+            "terminal_not_found",
+            "tab_not_found",
+            "worktree_not_found",
+        }:
+            return False
+        # Runtime / transport failures are not proof that the resource died.
+        return None
+    try:
+        terminal = payload.get("result", {}).get("terminal", {})
+    except AttributeError:
+        return None
+    return bool(terminal.get("connected", False) or terminal.get("writable", False))
+
+
+def lease_alive(lease: dict, orca_cli: str) -> bool:
+    if lease.get("schema") != SCHEMA:
+        return True
+    state = lease.get("state")
+    if state == "provisional":
+        created = parse_time(lease.get("created_at", ""))
+        fresh = created is not None and (utc_now() - created).total_seconds() <= PROVISIONAL_TTL_SECONDS
+        return fresh and process_alive(int(lease.get("owner_pid", 0) or 0))
+    if state == "active":
+        transport = lease.get("transport")
+        if transport == "tmux":
+            alive = tmux_alive(str(lease.get("resource_handle", "")))
+        elif transport == "orca_terminal":
+            alive = orca_terminal_alive(str(lease.get("resource_handle", "")), orca_cli)
+        else:
+            alive = None
+        # Unknown liveness is fail-closed: never reclaim a possibly active quota.
+        return True if alive is None else alive
+    # Malformed/unknown states are not stale evidence. Keep their quota until
+    # an operator can inspect the registry.
+    return True
+
+
+def read_json(path: Path) -> dict | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def atomic_write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, ensure_ascii=False, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, path)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(temporary)
+
+
+@contextlib.contextmanager
+def provider_lock(provider_dir: Path):
+    provider_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = provider_dir / ".lock"
+    with lock_path.open("a+", encoding="utf-8") as stream:
+        fcntl.flock(stream.fileno(), fcntl.LOCK_EX)
+        yield
+
+
+def cmd_acquire(args: argparse.Namespace) -> int:
+    root = Path(args.root).resolve()
+    provider_dir = root / safe_key(args.provider)
+    session_path = provider_dir / f"{safe_key(args.session)}.json"
+    with provider_lock(root):
+        for existing_path in root.glob("*/*.json"):
+            existing = read_json(existing_path)
+            if existing is not None and existing.get("schema") == SCHEMA and existing.get("session") == args.session:
+                if lease_alive(existing, args.orca_cli):
+                    print(f"ERROR: provider lease session is already registered: {args.session}", file=sys.stderr)
+                    return 75
+                existing_path.unlink(missing_ok=True)
+        active: list[Path] = []
+        for path in provider_dir.glob("*.json"):
+            lease = read_json(path)
+            if lease is None or lease_alive(lease, args.orca_cli):
+                active.append(path)
+            else:
+                path.unlink(missing_ok=True)
+        if session_path in active:
+            print(f"ERROR: provider lease already exists for session={args.session}", file=sys.stderr)
+            return 75
+        if len(active) >= args.max:
+            print(
+                f"ERROR: provider concurrency exhausted provider={args.provider} "
+                f"active={len(active)} max={args.max}",
+                file=sys.stderr,
+            )
+            return 75
+        payload = {
+            "schema": SCHEMA,
+            "state": "provisional",
+            "created_at": iso_now(),
+            "updated_at": iso_now(),
+            "provider": args.provider,
+            "backend": args.backend,
+            "session": args.session,
+            "project": args.project,
+            "owner_pid": args.owner_pid,
+            "max_concurrency": args.max,
+            "transport": "",
+            "resource_handle": "",
+        }
+        atomic_write(session_path, payload)
+    print(json.dumps({"lease_file": str(session_path), "active": len(active) + 1, "max": args.max}))
+    return 0
+
+
+def load_exact_lease(path: Path, session: str) -> dict:
+    lease = read_json(path)
+    if lease is None or lease.get("schema") != SCHEMA or lease.get("session") != session:
+        raise ValueError("lease file does not match the expected schema/session")
+    return lease
+
+
+def resolve_exact_lease_path(root_value: str, path_value: str) -> Path:
+    root = Path(root_value).resolve()
+    path = Path(path_value).resolve()
+    try:
+        relative = path.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("lease file is outside the trusted provider lease root") from exc
+    if len(relative.parts) != 2 or path.suffix != ".json":
+        raise ValueError("lease file does not have the expected provider/session path shape")
+    return path
+
+
+def cmd_finalize(args: argparse.Namespace) -> int:
+    try:
+        path = resolve_exact_lease_path(args.root, args.lease_file)
+    except ValueError as exc:
+        print(f"ERROR: {exc}: {args.lease_file}", file=sys.stderr)
+        return 64
+    with provider_lock(Path(args.root).resolve()):
+        try:
+            lease = load_exact_lease(path, args.session)
+        except ValueError as exc:
+            print(f"ERROR: {exc}: {path}", file=sys.stderr)
+            return 64
+        lease["state"] = "active"
+        lease["updated_at"] = iso_now()
+        lease["transport"] = args.transport
+        lease["resource_handle"] = args.resource_handle
+        atomic_write(path, lease)
+    print(json.dumps({"lease_file": str(path), "state": "active"}))
+    return 0
+
+
+def cmd_release(args: argparse.Namespace) -> int:
+    try:
+        path = resolve_exact_lease_path(args.root, args.lease_file)
+    except ValueError as exc:
+        print(f"ERROR: {exc}: {args.lease_file}", file=sys.stderr)
+        return 64
+    if not args.resource_settled:
+        print("ERROR: release requires --resource-settled after caller-side lifecycle proof", file=sys.stderr)
+        return 64
+    with provider_lock(Path(args.root).resolve()):
+        if not path.exists():
+            print(json.dumps({"lease_file": str(path), "released": False, "reason": "already_missing"}))
+            return 0
+        try:
+            lease = load_exact_lease(path, args.session)
+        except ValueError as exc:
+            print(f"ERROR: {exc}: {path}", file=sys.stderr)
+            return 64
+        if lease.get("state") == "provisional":
+            if args.owner_pid <= 1 or args.owner_pid != int(lease.get("owner_pid", 0) or 0):
+                print("ERROR: only the exact acquiring process may release a provisional lease", file=sys.stderr)
+                return 75
+        elif lease.get("state") == "active":
+            if lease_alive(lease, args.orca_cli):
+                print("ERROR: provider lease resource is still active or its liveness is unknown", file=sys.stderr)
+                return 75
+        else:
+            print("ERROR: provider lease has an unsupported state; retaining quota fail-closed", file=sys.stderr)
+            return 75
+        path.unlink()
+    print(json.dumps({"lease_file": str(path), "released": True}))
+    return 0
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser()
+    subcommands = root.add_subparsers(dest="command", required=True)
+
+    acquire = subcommands.add_parser("acquire")
+    acquire.add_argument("--root", required=True)
+    acquire.add_argument("--provider", required=True)
+    acquire.add_argument("--backend", required=True)
+    acquire.add_argument("--session", required=True)
+    acquire.add_argument("--project", required=True)
+    acquire.add_argument("--max", type=int, required=True)
+    acquire.add_argument("--owner-pid", type=int, required=True)
+    acquire.add_argument("--orca-cli", default="")
+    acquire.set_defaults(func=cmd_acquire)
+
+    finalize = subcommands.add_parser("finalize")
+    finalize.add_argument("--root", required=True)
+    finalize.add_argument("--lease-file", required=True)
+    finalize.add_argument("--session", required=True)
+    finalize.add_argument("--transport", choices=("tmux", "orca_terminal"), required=True)
+    finalize.add_argument("--resource-handle", required=True)
+    finalize.set_defaults(func=cmd_finalize)
+
+    release = subcommands.add_parser("release")
+    release.add_argument("--root", required=True)
+    release.add_argument("--lease-file", required=True)
+    release.add_argument("--session", required=True)
+    release.add_argument("--resource-settled", action="store_true")
+    release.add_argument("--orca-cli", default="")
+    release.add_argument("--owner-pid", type=int, default=0)
+    release.set_defaults(func=cmd_release)
+    return root
+
+
+def main() -> int:
+    args = parser().parse_args()
+    if getattr(args, "max", 1) < 1:
+        print("ERROR: --max must be a positive integer", file=sys.stderr)
+        return 64
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/multi-agent-orchestration/scripts/render-runtime-profile.sh
+++ b/skills/multi-agent-orchestration/scripts/render-runtime-profile.sh
@@ -38,10 +38,13 @@ Backends:
   claude-code     Claude Code with provider/settings profile
   claude-oauth    Claude Code subscription/OAuth; clears Anthropic provider env
   codex           Codex CLI
-  opencode        OpenCode CLI
+  opencode        Historical standalone renderer only; spawn-worker will reject it
   codebuddy       CodeBuddy CLI (platform额度, 继承桌面端登录态)
   qoderwork-cn    QoderWork CN CLI (qoderclicn; 自动清除 SDK env 变量)
-  custom          Use --command as-is
+  custom          Historical standalone renderer only; spawn-worker will reject it
+
+Dispatch authority is limited to claude-code/claude-oauth, codex, codebuddy and
+qoderwork-cn. Rendering a historical backend never expands spawn-worker policy.
 
 Options:
   --mode MODE              interactive | batch. Default: interactive

--- a/skills/multi-agent-orchestration/scripts/sentinel.sh
+++ b/skills/multi-agent-orchestration/scripts/sentinel.sh
@@ -14,6 +14,8 @@ set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=orca-runtime.sh
 source "$SCRIPT_DIR/orca-runtime.sh"
+# shellcheck source=provider-lease-root.sh
+source "$SCRIPT_DIR/provider-lease-root.sh"
 
 STATUS_FILE=""
 TMUX_SESSION=""
@@ -30,6 +32,7 @@ PANE_TAIL_LINES=80
 #   "tmux"           — 老路径，零行为变化
 #   "orca_terminal"  — ORCA 终端模式，spawn-worker.sh ORCA 分支配对传 --terminal-handle --worktree-id
 WORKER_SESSION_TYPE=""
+WORKER_RESOURCE_SETTLED=0
 
 usage() {
   cat >&2 <<'USAGE'
@@ -202,6 +205,7 @@ kill_tmux_if_requested() {
       log "SENTINEL_ORCA_TERMINAL_CLOSE_FAILED: handle=$TERMINAL_HANDLE"
       return 0
     }
+    WORKER_RESOURCE_SETTLED=1
     log "SENTINEL_ORCA_TERMINAL_CLOSED: handle=$TERMINAL_HANDLE"
     return 0
   fi
@@ -210,6 +214,7 @@ kill_tmux_if_requested() {
     return 0
   fi
   if ! tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
+    WORKER_RESOURCE_SETTLED=1
     log "SENTINEL_TMUX_GONE: session=$TMUX_SESSION (already killed externally)"
     return 0
   fi
@@ -217,7 +222,41 @@ kill_tmux_if_requested() {
     log "SENTINEL_KILL_FAILED: session=$TMUX_SESSION"
     return 0
   }
+  WORKER_RESOURCE_SETTLED=1
   log "SENTINEL_TMUX_KILLED: session=$TMUX_SESSION"
+}
+
+release_provider_lease_if_settled() {
+  [ "$WORKER_RESOURCE_SETTLED" -eq 1 ] || return 0
+  [ -z "$DISPATCH_ID" ] || return 0
+  local metadata lease_file lease_session worker_project lease_root
+  metadata="$(dirname "$STATUS_FILE")/METADATA.json"
+  [ -f "$metadata" ] || return 0
+  if ! jq -e 'type == "object"' "$metadata" >/dev/null 2>&1; then
+    log "SENTINEL_CONFIG_ERROR: invalid METADATA.json; provider quota retained fail-closed file=$metadata"
+    return 2
+  fi
+  lease_file=$(jq -r '.runtime.provider_lease.file // ""' "$metadata")
+  lease_session=$(jq -r '.session.id // ""' "$metadata")
+  [ -n "$lease_file" ] && [ -n "$lease_session" ] || return 0
+  worker_project=$(cd "$(dirname "$STATUS_FILE")/../../.." 2>/dev/null && pwd -P) || {
+    log "SENTINEL_PROVIDER_LEASE_RELEASE_FAILED: cannot derive worker project"
+    return 2
+  }
+  lease_root=$(provider_lease_root_for_project "$worker_project") || {
+    log "SENTINEL_PROVIDER_LEASE_RELEASE_FAILED: cannot derive trusted lease root"
+    return 2
+  }
+  local orca_path=""
+  orca_runtime_init >/dev/null 2>&1 && orca_path="$ORCA_CLI_BIN"
+  if python3 "$SCRIPT_DIR/provider-lease.py" release --root "$lease_root" \
+      --lease-file "$lease_file" \
+      --session "$lease_session" --resource-settled --orca-cli "$orca_path" >/dev/null 2>&1; then
+    log "SENTINEL_PROVIDER_LEASE_RELEASED: session=$lease_session"
+  else
+    log "SENTINEL_PROVIDER_LEASE_RELEASE_FAILED: session=$lease_session file=$lease_file"
+    return 2
+  fi
 }
 
 # v2.1（DEC-114）：ORCA UI 同步——把 worker 终态写进 ORCA workspace-status + comment。
@@ -307,6 +346,7 @@ while true; do
           fi
           observe_orca_supervised_state
           kill_tmux_if_requested
+          release_provider_lease_if_settled || exit $?
           exit 0
         fi
         ;;
@@ -317,6 +357,7 @@ while true; do
         sync_orca_worktree_status "in-review" "sentinel observed non-success at $(date -u +%FT%TZ) (status=$status; PM review)"
         observe_orca_supervised_state
         kill_tmux_if_requested
+        release_provider_lease_if_settled || exit $?
         exit 2
         ;;
       running|unknown|"")
@@ -334,6 +375,7 @@ while true; do
     sync_orca_worktree_status "in-review" "sentinel timeout ${elapsed}s (PM investigate)"
     observe_orca_supervised_state
     kill_tmux_if_requested
+    release_provider_lease_if_settled || exit $?
     exit 124
   fi
 

--- a/skills/multi-agent-orchestration/scripts/smoke-orca-worker.sh
+++ b/skills/multi-agent-orchestration/scripts/smoke-orca-worker.sh
@@ -6,8 +6,8 @@
 #   2. opt-out / 非当前 repo 的降级边界
 #   3. supervised dry-run 只允许 worker-start 注入任务
 #
-# 本 smoke 不起真实 worker CLI（避免消耗额度），只用最小 shell command 模拟：
-#   COMMAND = 'echo smoke-orca-done'（写 STATUS.json 由测试脚本直接落地）。
+# 本 smoke 不起真实 worker CLI（避免消耗额度），但命令仍使用 `codex`
+# 令牌通过 backend/command 身份门禁；`--dry-run` 保证不实际启动。
 #
 # 运行前提：当前 cwd 是 Orca-managed worktree，Orca runtime 正在运行。
 #
@@ -83,7 +83,7 @@ spawn_out=$(env -u TERM_PROGRAM -u ORCA_WORKTREE_ID bash "$SCRIPT_DIR/spawn-work
   --project "$current_path" \
   --branch "$BRANCH" \
   --session "$SESSION" \
-  --command 'echo smoke-orca-done' \
+  --command 'codex' \
   --worker-backend codex \
   --allow-prompt-only-install-guard 'smoke test: no dependency install' \
   --dry-run 2>&1) || {
@@ -109,7 +109,7 @@ spawn_tmux_out=$(bash "$SCRIPT_DIR/spawn-worker.sh" \
   --project "$REPO" \
   --branch "$BRANCH" \
   --session "$SESSION" \
-  --command 'echo smoke-orca-done' \
+  --command 'codex' \
   --worker-backend codex \
   --allow-prompt-only-install-guard 'smoke test: no dependency install' \
   --no-orca-mode \
@@ -126,7 +126,7 @@ spawn_lite_out=$(bash "$SCRIPT_DIR/spawn-worker.sh" \
   --project "$REPO" \
   --branch "$BRANCH" \
   --session "$SESSION" \
-  --command 'echo smoke-orca-done' \
+  --command 'codex' \
   --worker-backend codex \
   --allow-prompt-only-install-guard 'smoke test: no dependency install' \
   --no-worktree \
@@ -143,7 +143,7 @@ supervised_out=$(env -u TERM_PROGRAM -u ORCA_WORKTREE_ID bash "$SCRIPT_DIR/spawn
   --project "$current_path" \
   --branch "feat/smoke-orca-supervised" \
   --session "$SESSION-supervised" \
-  --command 'echo smoke-orca-done' \
+  --command 'codex' \
   --worker-backend codex \
   --allow-prompt-only-install-guard 'smoke test: no dependency install' \
   --orca-supervised --task-spec '只验证注入计划，不执行真实 worker' \

--- a/skills/multi-agent-orchestration/scripts/smoke-sentinel.sh
+++ b/skills/multi-agent-orchestration/scripts/smoke-sentinel.sh
@@ -14,10 +14,12 @@ TMP_ROOT=$(mktemp -d)
 TMP_ROOT=$(cd "$TMP_ROOT" && pwd -P)
 SESSION_DONE="smoke-sentinel-done-$$"
 SESSION_TIMEOUT="smoke-sentinel-timeout-$$"
+SESSION_INVALID_METADATA="smoke-sentinel-invalid-metadata-$$"
 
 cleanup() {
   tmux kill-session -t "$SESSION_DONE" 2>/dev/null || true
   tmux kill-session -t "$SESSION_TIMEOUT" 2>/dev/null || true
+  tmux kill-session -t "$SESSION_INVALID_METADATA" 2>/dev/null || true
   rm -rf "$TMP_ROOT"
 }
 trap cleanup EXIT
@@ -162,6 +164,24 @@ if [ "$TIMEOUT_EXIT" -ne 124 ]; then
   printf 'ASSERTION FAILED: sentinel timeout path expected exit 124, got %d\n' "$TIMEOUT_EXIT" >&2
   exit 1
 fi
+
+# ---------- Scenario 3: invalid metadata must retain quota fail-closed ----------
+CTX_INVALID="$TMP_ROOT/invalid/.claude/agent-sessions/$SESSION_INVALID_METADATA"
+STATUS_INVALID="$CTX_INVALID/STATUS.json"
+LOG_INVALID="$CTX_INVALID/SENTINEL_OUT.log"
+mkdir -p "$CTX_INVALID"
+printf '%s\n' '{invalid-json' > "$CTX_INVALID/METADATA.json"
+printf '%s\n' '{"status":"done"}' > "$STATUS_INVALID"
+tmux new-session -d -s "$SESSION_INVALID_METADATA" 'sleep 60'
+INVALID_EXIT=0
+bash "$SCRIPT_DIR/sentinel.sh" --status-file "$STATUS_INVALID" \
+  --tmux-session "$SESSION_INVALID_METADATA" --poll-interval 1 --max-wait 10 \
+  >/dev/null 2>&1 || INVALID_EXIT=$?
+if [ "$INVALID_EXIT" -ne 2 ]; then
+  printf 'ASSERTION FAILED: invalid metadata expected exit 2, got %d\n' "$INVALID_EXIT" >&2
+  exit 1
+fi
+assert_contains "$(cat "$LOG_INVALID")" "SENTINEL_CONFIG_ERROR: invalid METADATA.json"
 
 # Validate usage path (v1.20.2 HRA-001: 显式断言 exit 64，不再 || true 丢退出码)
 USAGE_EXIT=0

--- a/skills/multi-agent-orchestration/scripts/smoke-tmux-worker.sh
+++ b/skills/multi-agent-orchestration/scripts/smoke-tmux-worker.sh
@@ -52,7 +52,7 @@ command -v git >/dev/null 2>&1 || { echo "SKIP: git is required"; exit 77; }
 command -v jq >/dev/null 2>&1 || { echo "SKIP: jq is required"; exit 77; }
 command -v tmux >/dev/null 2>&1 || { echo "SKIP: tmux is required"; exit 77; }
 
-deps_out=$("$SCRIPT_DIR/check-dependencies.sh" --backend custom)
+deps_out=$("$SCRIPT_DIR/check-dependencies.sh" --backend codex)
 assert_contains "$deps_out" "DEPENDENCY_CHECK_OK"
 
 profile_shell=$("$SCRIPT_DIR/render-runtime-profile.sh" \
@@ -62,9 +62,13 @@ profile_shell=$("$SCRIPT_DIR/render-runtime-profile.sh" \
   --provider-slot smoke-slot-1 \
   --output shell)
 eval "$profile_shell"
-# Exercise the control plane with a fixed local command while retaining a real
-# configured backend label so the Harness policy gate is part of this smoke.
-WORKER_COMMAND="printf '%s\n' 'worker-start' 'TOKEN=abc123' 'worker-end'; sleep 60"
+# Exercise the control plane through a fake executable whose basename matches
+# the declared backend. The command/backend identity gate must remain active.
+WORKER_COMMAND="$TMP_ROOT/codex"
+printf '%s\n' '#!/usr/bin/env bash' \
+  "printf '%s\\n' 'worker-start' 'TOKEN=abc123' 'worker-end'" \
+  'sleep 60' > "$WORKER_COMMAND"
+chmod +x "$WORKER_COMMAND"
 
 claude_command=$("$SCRIPT_DIR/render-runtime-profile.sh" \
   --backend claude-code \

--- a/skills/multi-agent-orchestration/scripts/spawn-worker.sh
+++ b/skills/multi-agent-orchestration/scripts/spawn-worker.sh
@@ -53,6 +53,8 @@ ensure_claude_in_path
 source "$SCRIPT_DIR/orca-runtime.sh"
 # shellcheck source=harness-backend-policy.sh
 source "$SCRIPT_DIR/harness-backend-policy.sh"
+# shellcheck source=provider-lease-root.sh
+source "$SCRIPT_DIR/provider-lease-root.sh"
 
 PROJECT_DIR=""
 BRANCH=""
@@ -65,12 +67,20 @@ WORKER_BACKEND=""
 PM_HARNESS_ASSERTION=""
 PM_HARNESS=""
 PM_HARNESS_SOURCE=""
+PM_HARNESS_CHAIN_JSON="[]"
 PM_ALLOWED_WORKER_BACKENDS=""
 WORKER_BACKEND_CANONICAL=""
+WORKER_COMMAND_SHA256=""
 RUNTIME_PROFILE=""
 API_PROVIDER=""
 MODEL=""
 PROVIDER_SLOT=""
+PROVIDER_LEASE_FILE=""
+PROVIDER_LEASE_ROOT=""
+PROVIDER_LEASE_LIMIT=""
+PROVIDER_LEASE_KEY=""
+PROVIDER_LEASE_ACQUIRED=0
+PERSONAL_CONFIG_FILE="${MULTI_AGENT_ORCHESTRATION_PERSONAL_CONFIG:-$SCRIPT_DIR/../config/orchestration-personal.json}"
 ENV_ISOLATION=""
 WAVE_ID=""
 WAVE_WORKER_ID=""
@@ -155,7 +165,7 @@ Usage:
 Options:
   --worktree PATH   Worktree path. Defaults to .claude/worktrees/tmux-{branch}
   --base-ref REF    Base ref for new branches. Default: main
-  --command CMD     Command to run in tmux. Default: login shell
+  --command CMD     Command to run. Default: the executable for the verified backend
   --worker-backend NAME
                    Worker backend: claude-code, codex, codebuddy or qoderwork-cn.
   --pm-harness NAME
@@ -519,10 +529,12 @@ if [ -n "$PM_HARNESS_ASSERTION" ]; then
     exit 64
   fi
 fi
-enforce_harness_backend_policy "$detected_pm_harness" "$WORKER_BACKEND" || exit $?
+enforce_harness_backend_policy_chain \
+  "$detected_pm_harness" "$PM_HARNESS_CHAIN_JSON" "$WORKER_BACKEND" || exit $?
 PM_HARNESS_SOURCE=${PM_HARNESS_SOURCE:-verified_runtime}
-printf 'SPAWN_WORKER_HARNESS_POLICY: pm=%s worker=%s allowed=%s source=%s\n' \
-  "$PM_HARNESS" "$WORKER_BACKEND_CANONICAL" "$PM_ALLOWED_WORKER_BACKENDS" "$PM_HARNESS_SOURCE"
+printf 'SPAWN_WORKER_HARNESS_POLICY: pm=%s worker=%s allowed=%s chain=%s source=%s\n' \
+  "$PM_HARNESS" "$WORKER_BACKEND_CANONICAL" "$PM_ALLOWED_WORKER_BACKENDS" \
+  "$PM_HARNESS_CHAIN_JSON" "$PM_HARNESS_SOURCE"
 
 if [ "${#AUTHORIZED_INSTALL_COMMANDS[@]}" -gt 0 ] && [ -z "$INSTALL_AUTHORIZATION_SOURCE" ]; then
   echo "ERROR: --allow-install-command requires --install-authorization-source (fail-closed)" >&2
@@ -614,7 +626,111 @@ esac
 SESSION_CONTEXT="$WORKTREE/.claude/agent-sessions/$SESSION"
 METADATA_FILE="$SESSION_CONTEXT/METADATA.json"
 INSTALL_AUTH_FILE="$SESSION_CONTEXT/INSTALL_AUTHORIZATION.json"
-[ -n "$COMMAND" ] || COMMAND="${SHELL:-/bin/bash} -l"
+if [ -z "$COMMAND" ]; then
+  case "$WORKER_BACKEND_CANONICAL" in
+    claude-code) COMMAND="claude" ;;
+    codex) COMMAND="codex" ;;
+    codebuddy) COMMAND="codebuddy" ;;
+    qoderwork-cn) COMMAND="qoderclicn" ;;
+    *) echo "ERROR: no default command for backend=$WORKER_BACKEND_CANONICAL" >&2; exit 64 ;;
+  esac
+  echo "SPAWN_WORKER_COMMAND_DEFAULT: backend=$WORKER_BACKEND_CANONICAL command=$COMMAND"
+fi
+
+# Bind the declared backend to the executable that will actually be launched.
+# This identity gate is independent of the dependency install guard: degrading
+# hooks to prompt-only can never authorize a differently labelled executable.
+validate_worker_command_backend() {
+  python3 "$SCRIPT_DIR/validate-worker-command.py" \
+    --backend "$WORKER_BACKEND_CANONICAL" \
+    --command "$COMMAND" \
+    --trusted-claude-wrapper "$SCRIPT_DIR/claude-provider-env.sh"
+}
+
+if ! WORKER_COMMAND_SHA256=$(validate_worker_command_backend); then
+  echo "ERROR: worker backend/command identity mismatch: $WORKER_COMMAND_SHA256 (fail-closed)" >&2
+  exit 64
+fi
+printf 'SPAWN_WORKER_COMMAND_POLICY: backend=%s command_sha256=%s\n' \
+  "$WORKER_BACKEND_CANONICAL" "$WORKER_COMMAND_SHA256"
+
+resolve_provider_lease_limit() {
+  [ -f "$PERSONAL_CONFIG_FILE" ] || return 1
+  PROVIDER_LEASE_LIMIT=$(jq -er --arg backend "$WORKER_BACKEND_CANONICAL" '
+    (.concurrency.per_backend[$backend] // .concurrency.max_per_provider // empty)
+    | select(type == "number" and floor == . and . > 0)
+  ' "$PERSONAL_CONFIG_FILE" 2>/dev/null) || return 1
+  PROVIDER_LEASE_KEY="${API_PROVIDER:-backend:$WORKER_BACKEND_CANONICAL}"
+  return 0
+}
+
+acquire_provider_lease() {
+  resolve_provider_lease_limit || {
+    echo "SPAWN_WORKER_PROVIDER_LEASE: provider=${API_PROVIDER:-backend:$WORKER_BACKEND_CANONICAL} limit=advisory_unconfigured"
+    return 0
+  }
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "SPAWN_WORKER_PROVIDER_LEASE: provider=$PROVIDER_LEASE_KEY max=$PROVIDER_LEASE_LIMIT state=dry-run-no-acquire"
+    return 0
+  fi
+  local lease_out orca_path=""
+  PROVIDER_LEASE_ROOT=$(provider_lease_root_for_project "$PROJECT_DIR") || {
+    echo "ERROR: cannot derive the trusted provider lease root" >&2
+    exit 64
+  }
+  orca_runtime_init >/dev/null 2>&1 && orca_path="$ORCA_CLI_BIN"
+  lease_out=$(python3 "$SCRIPT_DIR/provider-lease.py" acquire \
+    --root "$PROVIDER_LEASE_ROOT" --provider "$PROVIDER_LEASE_KEY" \
+    --backend "$WORKER_BACKEND_CANONICAL" --session "$SESSION" \
+    --project "$PROJECT_DIR" --max "$PROVIDER_LEASE_LIMIT" --owner-pid $$ \
+    --orca-cli "$orca_path") || {
+    echo "ERROR: provider concurrency lease denied before branch/worktree creation (provider=$PROVIDER_LEASE_KEY max=$PROVIDER_LEASE_LIMIT)" >&2
+    exit 75
+  }
+  PROVIDER_LEASE_FILE=$(printf '%s' "$lease_out" | jq -r '.lease_file // empty')
+  [ -n "$PROVIDER_LEASE_FILE" ] || { echo "ERROR: provider lease response missing lease_file" >&2; exit 64; }
+  PROVIDER_LEASE_ACQUIRED=1
+  echo "SPAWN_WORKER_PROVIDER_LEASE: provider=$PROVIDER_LEASE_KEY max=$PROVIDER_LEASE_LIMIT file=$PROVIDER_LEASE_FILE state=provisional"
+}
+
+release_provisional_provider_lease() {
+  local exit_code=$?
+  trap - EXIT
+  if [ "$PROVIDER_LEASE_ACQUIRED" -eq 1 ] && [ -n "$PROVIDER_LEASE_FILE" ]; then
+    python3 "$SCRIPT_DIR/provider-lease.py" release --root "$PROVIDER_LEASE_ROOT" \
+      --lease-file "$PROVIDER_LEASE_FILE" \
+      --session "$SESSION" --resource-settled --owner-pid $$ >/dev/null 2>&1 || true
+  fi
+  exit "$exit_code"
+}
+
+finalize_provider_lease() {
+  [ "$PROVIDER_LEASE_ACQUIRED" -eq 1 ] || return 0
+  local transport resource_handle
+  if [ "$ORCA_MODE" = "auto" ]; then
+    transport="orca_terminal"
+    resource_handle="$ORCA_TERMINAL_HANDLE"
+  else
+    transport="tmux"
+    resource_handle="$SESSION"
+  fi
+  python3 "$SCRIPT_DIR/provider-lease.py" finalize \
+    --root "$PROVIDER_LEASE_ROOT" \
+    --lease-file "$PROVIDER_LEASE_FILE" --session "$SESSION" \
+    --transport "$transport" --resource-handle "$resource_handle" >/dev/null || {
+    echo "ERROR: provider lease could not bind the launched worker resource" >&2
+    exit 75
+  }
+  PROVIDER_LEASE_ACQUIRED=0
+  echo "SPAWN_WORKER_PROVIDER_LEASE: provider=$PROVIDER_LEASE_KEY file=$PROVIDER_LEASE_FILE state=active transport=$transport"
+}
+
+# Must happen before any branch/worktree/session side effect. EXIT releases only
+# the provisional lease; a successful launch finalizes it and disables the trap.
+acquire_provider_lease
+if [ "$PROVIDER_LEASE_ACQUIRED" -eq 1 ]; then
+  trap release_provisional_provider_lease EXIT
+fi
 
 # Claude Code 的 minimal/safe/config-source 模式可能跳过 local PreToolUse hook。
 # 用 shlex 解析 wrapper 后的完整 command；无法证明含 claude 或 local settings 也 fail-closed。
@@ -684,36 +800,6 @@ if [ "$INSTALL_GUARD_MODE" = "hook" ] && \
     echo "ERROR: Claude Code command cannot prove local PreToolUse hook enforcement: $hook_disable_reason; fix the command, pass --allow-prompt-only-install-guard, or this non-bare disable (--safe-mode/--setting-sources/missing token) requires explicit --allow-prompt-only-install-guard (fail-closed)" >&2
     exit 64
   fi
-fi
-
-backend_command_token_missing() {
-  python3 - "$WORKER_BACKEND" "$COMMAND" <<'PY'
-import os, shlex, sys
-backend, command = sys.argv[1:]
-try:
-    basenames = {os.path.basename(token).lower() for token in shlex.split(command, posix=True)}
-except ValueError:
-    print("unparseable command")
-    raise SystemExit(0)
-accepted = {
-    "codebuddy": {"codebuddy"},
-    "qoderwork-cn": {"qoderclicn"},
-    "qoderclicn": {"qoderclicn"},
-}.get(backend, set())
-if accepted and not (basenames & accepted):
-    print(f"command exposes none of the expected executable tokens: {sorted(accepted)}")
-    raise SystemExit(0)
-raise SystemExit(1)
-PY
-}
-if [ "$INSTALL_GUARD_MODE" = "hook" ] && \
-   { [ "$WORKER_BACKEND" = "codebuddy" ] || [ "$WORKER_BACKEND" = "qoderwork-cn" ] || [ "$WORKER_BACKEND" = "qoderclicn" ]; } && \
-   backend_reason=$(backend_command_token_missing); then
-  if [ "$ALLOW_PROMPT_ONLY_INSTALL_GUARD" -ne 1 ]; then
-    echo "ERROR: $WORKER_BACKEND command cannot prove the configured backend is launched: $backend_reason (fail-closed)" >&2
-    exit 64
-  fi
-  INSTALL_GUARD_MODE="prompt_only_degraded"
 fi
 
 run() {
@@ -803,12 +889,12 @@ detect_orca_mode() {
 orca_worktree_create() {
   local name="$1" base_branch="$2"
   if [ "$DRY_RUN" -eq 1 ]; then
-    printf 'ORCA_RUN: orca worktree create --name %q --no-parent --base-branch %q --json\n' "$name" "$base_branch"
+    printf 'ORCA_RUN: orca worktree create --name %q --no-parent --base-branch %q --setup inherit --json\n' "$name" "$base_branch"
     echo "orca_worktree_id_placeholder"
     return 0
   fi
   local out worktree_id
-  out=$(orca_cli worktree create --name "$name" --no-parent --base-branch "$base_branch" --json 2>&1) || {
+  out=$(orca_cli worktree create --name "$name" --no-parent --base-branch "$base_branch" --setup inherit --json 2>&1) || {
     echo "ERROR: orca worktree create 失败: $out" >&2
     exit 64
   }
@@ -1161,12 +1247,18 @@ write_metadata() {
     --arg worker_backend "$WORKER_BACKEND" \
     --arg pm_harness "$PM_HARNESS" \
     --arg pm_harness_source "$PM_HARNESS_SOURCE" \
+    --argjson pm_harness_chain "$PM_HARNESS_CHAIN_JSON" \
     --argjson pm_allowed_worker_backends "$(printf '%s\n' $PM_ALLOWED_WORKER_BACKENDS | jq -R . | jq -s .)" \
     --arg worker_backend_canonical "$WORKER_BACKEND_CANONICAL" \
+    --arg worker_command_sha256 "$WORKER_COMMAND_SHA256" \
     --arg runtime_profile "$RUNTIME_PROFILE" \
     --arg api_provider "$API_PROVIDER" \
     --arg model "$MODEL" \
     --arg provider_slot "$PROVIDER_SLOT" \
+    --arg provider_lease_file "$PROVIDER_LEASE_FILE" \
+    --arg provider_lease_root "$PROVIDER_LEASE_ROOT" \
+    --arg provider_lease_limit "$PROVIDER_LEASE_LIMIT" \
+    --arg provider_lease_key "$PROVIDER_LEASE_KEY" \
     --arg env_isolation "$ENV_ISOLATION" \
     --arg wave_id "$WAVE_ID" \
     --arg wave_worker_id "$WAVE_WORKER_ID" \
@@ -1226,6 +1318,7 @@ write_metadata() {
         harness_authority: {
           pm_harness: $pm_harness,
           evidence_source: $pm_harness_source,
+          ancestry: $pm_harness_chain,
           allowed_worker_backends: $pm_allowed_worker_backends,
           worker_backend: $worker_backend_canonical
         },
@@ -1234,8 +1327,15 @@ write_metadata() {
         api_provider: $api_provider,
         model: $model,
         provider_slot: $provider_slot,
+        provider_lease: {
+          file: $provider_lease_file,
+          root: $provider_lease_root,
+          provider: $provider_lease_key,
+          max_concurrency: ($provider_lease_limit | if . == "" then null else tonumber end)
+        },
         env_isolation: $env_isolation,
-        command: $command
+        command: $command,
+        command_sha256: $worker_command_sha256
       },
       wave: {
         id: $wave_id,
@@ -1707,6 +1807,10 @@ if [ "$ORCA_MODE" = "auto" ]; then
   fi
 else
   run tmux new-session -d -s "$SESSION" -c "$WORKTREE" "$COMMAND"
+fi
+
+if [ "$DRY_RUN" -eq 0 ]; then
+  finalize_provider_lease
 fi
 
 # Trust-auto + Permission-auto: headless CLI workers need trust-folder permission

--- a/skills/multi-agent-orchestration/scripts/test-dependency-install-guard.sh
+++ b/skills/multi-agent-orchestration/scripts/test-dependency-install-guard.sh
@@ -352,7 +352,7 @@ if bash "$SCRIPT_DIR/spawn-worker.sh" \
   not_ok "backend label without matching executable token fails closed"
   tmux kill-session -t "$session-fake-codebuddy" 2>/dev/null || true
 else
-  if grep -qF "cannot prove the configured backend is launched" /tmp/dependency-install-fake-backend.out; then
+  if grep -qF "worker backend/command identity mismatch" /tmp/dependency-install-fake-backend.out; then
     ok "backend label without matching executable token fails closed"
   else
     cat /tmp/dependency-install-fake-backend.out >&2 || true
@@ -361,7 +361,7 @@ else
 fi
 rm -f /tmp/dependency-install-fake-backend.out
 
-for disabled_command in "claude '--safe-mode'" "claude --setting-sources project" "bash wrapper.sh"; do
+for disabled_command in "claude '--safe-mode'" "claude --setting-sources project"; do
   slug=$(printf '%s' "$disabled_command" | tr -cd 'a-zA-Z' | cut -c1-18)
   if bash "$SCRIPT_DIR/spawn-worker.sh" \
     --project "$spawn_repo" --branch "feat/$slug" --session "$session-$slug" \
@@ -380,9 +380,11 @@ done
 rm -f /tmp/dependency-install-disabled.out
 
 degraded_session="$session-degraded"
+printf '%s\n' '#!/usr/bin/env bash' 'sleep 30' > "$tmp_root/codex"
+chmod +x "$tmp_root/codex"
 if bash "$SCRIPT_DIR/spawn-worker.sh" \
   --project "$spawn_repo" --branch feat/degraded --session "$degraded_session" \
-  --worker-backend codex --command "sleep 30" \
+  --worker-backend codex --command "$tmp_root/codex" \
   --allow-prompt-only-install-guard "项目 T159 明确接受无 hook 的提示级降级" \
   --no-trust-auto --no-permission-auto \
   >/tmp/dependency-install-degraded.out 2>&1; then

--- a/skills/multi-agent-orchestration/scripts/test-harness-backend-policy.sh
+++ b/skills/multi-agent-orchestration/scripts/test-harness-backend-policy.sh
@@ -47,9 +47,11 @@ expect_deny codex custom
 
 # Exercise real ancestry detection through executables named as weak harnesses.
 ln -s /bin/bash "$TMP_ROOT/codebuddy"
+ln -s /bin/bash "$TMP_ROOT/codex"
+ln -s /bin/bash "$TMP_ROOT/claude"
 ln -s /bin/bash "$TMP_ROOT/qoderclicn"
 mkdir -p "$TMP_ROOT/non-orca-project"
-if "$TMP_ROOT/codebuddy" -c 'bash "$1" --project "$2" --pm-harness codebuddy --worker-backend codebuddy; :' _ \
+if ORCA_CLI_COMMAND=/usr/bin/false "$TMP_ROOT/codebuddy" -c 'bash "$1" --project "$2" --pm-harness codebuddy --worker-backend codebuddy; :' _ \
   "$SCRIPT_DIR/harness-backend-policy.sh" "$TMP_ROOT/non-orca-project" >/dev/null 2>&1; then
   printf 'PASS ancestry allow: codebuddy -> codebuddy\n'
   pass=$((pass + 1))
@@ -58,7 +60,7 @@ else
   fail=$((fail + 1))
 fi
 weak_rc=0
-"$TMP_ROOT/codebuddy" -c 'bash "$1" --project "$2" --pm-harness claude-code --worker-backend codex; rc=$?; :; exit "$rc"' _ \
+ORCA_CLI_COMMAND=/usr/bin/false "$TMP_ROOT/codebuddy" -c 'bash "$1" --project "$2" --pm-harness claude-code --worker-backend codex; rc=$?; :; exit "$rc"' _ \
   "$SCRIPT_DIR/harness-backend-policy.sh" "$TMP_ROOT/non-orca-project" >/dev/null 2>&1 || weak_rc=$?
 if [ "$weak_rc" -eq 64 ]; then
   printf 'PASS ancestry deny: codebuddy cannot assert claude-code or dispatch codex\n'
@@ -67,12 +69,40 @@ else
   printf 'FAIL ancestry deny: codebuddy escalation exit=%s\n' "$weak_rc" >&2
   fail=$((fail + 1))
 fi
-if "$TMP_ROOT/qoderclicn" -c 'bash "$1" --project "$2" --pm-harness qoderwork-cn --worker-backend qoderwork-cn; :' _ \
+if ORCA_CLI_COMMAND=/usr/bin/false "$TMP_ROOT/qoderclicn" -c 'bash "$1" --project "$2" --pm-harness qoderwork-cn --worker-backend qoderwork-cn; :' _ \
   "$SCRIPT_DIR/harness-backend-policy.sh" "$TMP_ROOT/non-orca-project" >/dev/null 2>&1; then
   printf 'PASS ancestry allow: qoderwork-cn -> qoderwork-cn\n'
   pass=$((pass + 1))
 else
   printf 'FAIL ancestry allow: qoderwork-cn -> qoderwork-cn\n' >&2
+  fail=$((fail + 1))
+fi
+
+# A weak outer Harness cannot regain stronger authority by starting a nested
+# strong CLI. The effective permission is the intersection of every ancestor.
+nested_rc=0
+ORCA_CLI_COMMAND=/usr/bin/false PATH="$TMP_ROOT:$PATH" "$TMP_ROOT/codebuddy" -c '
+  codex -c '\''bash "$1" --project "$2" --pm-harness codex --worker-backend claude-code; rc=$?; :; exit "$rc"'\'' _ "$1" "$2"
+  rc=$?; :; exit "$rc"
+' _ "$SCRIPT_DIR/harness-backend-policy.sh" "$TMP_ROOT/non-orca-project" >/dev/null 2>&1 || nested_rc=$?
+if [ "$nested_rc" -eq 64 ]; then
+  printf 'PASS ancestry intersection: codebuddy -> codex cannot dispatch claude-code\n'
+  pass=$((pass + 1))
+else
+  printf 'FAIL ancestry intersection: nested escalation exit=%s\n' "$nested_rc" >&2
+  fail=$((fail + 1))
+fi
+
+strong_nested_out=""
+if strong_nested_out=$(ORCA_CLI_COMMAND=/usr/bin/false PATH="$TMP_ROOT:$PATH" "$TMP_ROOT/claude" -c '
+  codex -c '\''bash "$1" --project "$2" --pm-harness codex --worker-backend codebuddy; rc=$?; :; exit "$rc"'\'' _ "$1" "$2"
+  rc=$?; :; exit "$rc"
+' _ "$SCRIPT_DIR/harness-backend-policy.sh" "$TMP_ROOT/non-orca-project" 2>&1) \
+  && printf '%s' "$strong_nested_out" | grep -q 'allowed=claude-code codex codebuddy qoderwork-cn'; then
+  printf 'PASS ancestry intersection: strong nested chain keeps the four-backend set\n'
+  pass=$((pass + 1))
+else
+  printf 'FAIL ancestry intersection: strong chain unexpectedly denied: %s\n' "$strong_nested_out" >&2
   fail=$((fail + 1))
 fi
 
@@ -82,7 +112,7 @@ git -C "$blocked_repo" init -q
 git -C "$blocked_repo" -c user.name=Smoke -c user.email=smoke@example.invalid \
   commit --allow-empty -q -m init
 blocked_rc=0
-"$TMP_ROOT/codebuddy" -c '
+ORCA_CLI_COMMAND=/usr/bin/false "$TMP_ROOT/codebuddy" -c '
   bash "$1" --project "$2" --branch feat/blocked-escalation --session blocked-escalation \
     --worker-backend codex --command "sleep 1" \
     --allow-prompt-only-install-guard "policy fault injection" --no-orca-mode
@@ -95,6 +125,24 @@ if [ "$blocked_rc" -eq 64 ] \
   pass=$((pass + 1))
 else
   printf 'FAIL spawn side-effect gate: exit=%s branch/worktree may exist\n' "$blocked_rc" >&2
+  fail=$((fail + 1))
+fi
+
+
+label_mismatch_rc=0
+ORCA_CLI_COMMAND=/usr/bin/false PATH="$TMP_ROOT:$PATH" "$TMP_ROOT/codebuddy" -c '
+  bash "$1" --project "$2" --branch feat/label-mismatch --session label-mismatch \
+    --worker-backend codebuddy --command codex \
+    --allow-prompt-only-install-guard "identity mismatch must never degrade" \
+    --no-orca-mode --dry-run
+' _ "$SCRIPT_DIR/spawn-worker.sh" "$blocked_repo" >/dev/null 2>&1 || label_mismatch_rc=$?
+if [ "$label_mismatch_rc" -eq 64 ] \
+  && ! git -C "$blocked_repo" show-ref --verify --quiet refs/heads/feat/label-mismatch \
+  && [ ! -e "$blocked_repo/.claude/worktrees/tmux-feat-label-mismatch" ]; then
+  printf 'PASS backend/command binding: codebuddy label cannot launch codex even with degraded install guard\n'
+  pass=$((pass + 1))
+else
+  printf 'FAIL backend/command binding: mismatch exit=%s branch/worktree may exist\n' "$label_mismatch_rc" >&2
   fail=$((fail + 1))
 fi
 

--- a/skills/multi-agent-orchestration/scripts/test-provider-lease.sh
+++ b/skills/multi-agent-orchestration/scripts/test-provider-lease.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+LEASE="$SCRIPT_DIR/provider-lease.py"
+
+first=$(python3 "$LEASE" acquire --root "$TMP_ROOT/leases" --provider provider-a \
+  --backend codex --session worker-a --project "$TMP_ROOT/project" --max 1 --owner-pid $$)
+first_file=$(printf '%s' "$first" | jq -r '.lease_file')
+[ -f "$first_file" ]
+
+if python3 "$LEASE" acquire --root "$TMP_ROOT/leases" --provider provider-a \
+  --backend claude-code --session worker-b --project "$TMP_ROOT/project" --max 1 --owner-pid $$ \
+  >/dev/null 2>&1; then
+  echo "FAIL: provider limit did not block the second lease" >&2
+  exit 1
+fi
+echo "PASS: provider limit blocks the second active lease"
+
+if python3 "$LEASE" acquire --root "$TMP_ROOT/leases" --provider provider-other \
+  --backend codex --session worker-a --project "$TMP_ROOT/project" --max 3 --owner-pid $$ \
+  >/dev/null 2>&1; then
+  echo "FAIL: the same session acquired a second provider lease" >&2
+  exit 1
+fi
+echo "PASS: session identity is unique across the repository lease root"
+
+python3 "$LEASE" finalize --root "$TMP_ROOT/leases" --lease-file "$first_file" --session worker-a \
+  --transport tmux --resource-handle lease-test-missing-session >/dev/null
+python3 "$LEASE" acquire --root "$TMP_ROOT/leases" --provider provider-a \
+  --backend claude-code --session worker-b --project "$TMP_ROOT/project" --max 1 --owner-pid $$ \
+  >/dev/null
+echo "PASS: stale finalized tmux lease is reclaimed from liveness evidence"
+
+second_file=$(find "$TMP_ROOT/leases" -name '*.json' -type f | head -1)
+if python3 "$LEASE" release --root "$TMP_ROOT/leases" --lease-file "$second_file" --session wrong-session --resource-settled >/dev/null 2>&1; then
+  echo "FAIL: mismatched session released another worker's lease" >&2
+  exit 1
+fi
+echo "PASS: exact session binding protects lease release"
+
+python3 "$LEASE" release --root "$TMP_ROOT/leases" --lease-file "$second_file" --session worker-b \
+  --resource-settled --owner-pid $$ >/dev/null
+[ ! -e "$second_file" ]
+echo "PASS: exact lease release succeeds"
+
+outside="$TMP_ROOT/outside.json"
+printf '%s\n' '{"schema":"multi-agent-orchestration.provider-lease.v1","session":"worker-b"}' > "$outside"
+if python3 "$LEASE" release --root "$TMP_ROOT/leases" --lease-file "$outside" --session worker-b --resource-settled >/dev/null 2>&1; then
+  echo "FAIL: untrusted lease path escaped the registry root" >&2
+  exit 1
+fi
+[ -f "$outside" ]
+echo "PASS: worker-controlled lease paths cannot escape the trusted registry root"
+
+live=$(python3 "$LEASE" acquire --root "$TMP_ROOT/leases" --provider provider-live \
+  --backend codex --session live-session --project "$TMP_ROOT/project" --max 1 --owner-pid $$)
+live_file=$(printf '%s' "$live" | jq -r '.lease_file')
+tmux new-session -d -s provider-lease-live-smoke 'sleep 30'
+python3 "$LEASE" finalize --root "$TMP_ROOT/leases" --lease-file "$live_file" \
+  --session live-session --transport tmux --resource-handle provider-lease-live-smoke >/dev/null
+if python3 "$LEASE" release --root "$TMP_ROOT/leases" --lease-file "$live_file" \
+  --session live-session --resource-settled >/dev/null 2>&1; then
+  echo "FAIL: live resource was released from quota" >&2
+  tmux kill-session -t provider-lease-live-smoke 2>/dev/null || true
+  exit 1
+fi
+tmux kill-session -t provider-lease-live-smoke
+python3 "$LEASE" release --root "$TMP_ROOT/leases" --lease-file "$live_file" \
+  --session live-session --resource-settled >/dev/null
+echo "PASS: active-resource liveness blocks premature quota release"
+
+stale=$(python3 "$LEASE" acquire --root "$TMP_ROOT/leases" --provider provider-b \
+  --backend codex --session stale --project "$TMP_ROOT/project" --max 1 --owner-pid 99999999)
+stale_file=$(printf '%s' "$stale" | jq -r '.lease_file')
+python3 "$LEASE" acquire --root "$TMP_ROOT/leases" --provider provider-b \
+  --backend codex --session replacement --project "$TMP_ROOT/project" --max 1 --owner-pid $$ \
+  >/dev/null
+[ ! -e "$stale_file" ]
+echo "PASS: dead provisional lease is reclaimed"
+
+echo "PROVIDER_LEASE_TEST_OK"

--- a/skills/multi-agent-orchestration/scripts/test-worker-command-policy.sh
+++ b/skills/multi-agent-orchestration/scripts/test-worker-command-policy.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+VALIDATOR="$SCRIPT_DIR/validate-worker-command.py"
+RENDERER="$SCRIPT_DIR/render-runtime-profile.sh"
+TRUSTED_WRAPPER="$SCRIPT_DIR/claude-provider-env.sh"
+PROMPT_FILE="$TMP_ROOT/prompt.md"
+printf 'worker command policy test\n' > "$PROMPT_FILE"
+
+pass=0
+fail=0
+
+allow() {
+  local backend="$1" command="$2" label="$3"
+  if python3 "$VALIDATOR" --backend "$backend" --command "$command" \
+      --trusted-claude-wrapper "$TRUSTED_WRAPPER" >/dev/null; then
+    printf 'PASS allow: %s\n' "$label"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL expected allow: %s\n' "$label" >&2
+    fail=$((fail + 1))
+  fi
+}
+
+deny() {
+  local backend="$1" command="$2" label="$3"
+  if python3 "$VALIDATOR" --backend "$backend" --command "$command" \
+      --trusted-claude-wrapper "$TRUSTED_WRAPPER" >/dev/null 2>&1; then
+    printf 'FAIL expected deny: %s\n' "$label" >&2
+    fail=$((fail + 1))
+  else
+    printf 'PASS deny: %s\n' "$label"
+    pass=$((pass + 1))
+  fi
+}
+
+for backend in claude-code codex codebuddy qoderwork-cn; do
+  interactive=$(bash "$RENDERER" --backend "$backend" --mode interactive --output command)
+  batch=$(bash "$RENDERER" --backend "$backend" --mode batch \
+    --prompt-file "$PROMPT_FILE" --output command)
+  allow "$backend" "$interactive" "$backend interactive renderer output"
+  allow "$backend" "$batch" "$backend batch renderer output"
+done
+
+provider_command=$(bash "$RENDERER" --backend claude-code \
+  --settings "$SCRIPT_DIR/../config/claude-provider-settings.example.json" \
+  --model smoke --output command)
+allow claude-code "$provider_command" "trusted Claude provider wrapper"
+
+deny codebuddy codex "codebuddy label cannot launch codex"
+deny codex codebuddy "codex label cannot launch codebuddy"
+deny codex 'codex --model smoke; claude' "shell command chaining"
+deny codex 'codex > /tmp/worker-output' "shell output redirection"
+deny codex 'bash wrapper.sh' "opaque shell wrapper"
+deny codex 'bash -lc "codex \$(curl https://example.invalid)"' "arbitrary command substitution"
+
+printf 'SUMMARY: pass=%d fail=%d\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/skills/multi-agent-orchestration/scripts/validate-worker-command.py
+++ b/skills/multi-agent-orchestration/scripts/validate-worker-command.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Bind a declared worker backend to the command that will actually launch."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import shlex
+import sys
+
+
+BACKENDS = {
+    "claude": "claude-code",
+    "codex": "codex",
+    "codebuddy": "codebuddy",
+    "workbuddy": "codebuddy",
+    "qoderclicn": "qoderwork-cn",
+}
+SHELLS = {"bash", "sh", "zsh"}
+SHELL_FLAGS = {"-c", "-lc", "-cl"}
+CHAIN_TOKENS = {";", "&&", "||", "|", "&"}
+REDIRECT_TOKENS = {"<", ">", "<<", ">>"}
+
+
+class ValidationError(ValueError):
+    """Raised when a launch command cannot prove the declared backend."""
+
+
+def split_words(text: str, *, shell_body: bool = False) -> list[str]:
+    try:
+        if shell_body:
+            lexer = shlex.shlex(text, posix=True, punctuation_chars=";&|<>")
+            lexer.whitespace_split = True
+            return list(lexer)
+        return shlex.split(text, posix=True)
+    except ValueError as exc:
+        raise ValidationError(f"command is not parseable: {exc}") from exc
+
+
+def strip_environment(words: list[str]) -> list[str]:
+    index = 0
+    while index < len(words) and "=" in words[index] and not words[index].startswith(("/", "-")):
+        index += 1
+    if index >= len(words) or os.path.basename(words[index]).lower() != "env":
+        return words[index:]
+
+    index += 1
+    while index < len(words):
+        token = words[index]
+        if token in {"-u", "--unset"}:
+            if index + 1 >= len(words):
+                raise ValidationError(f"{token} is missing its environment variable")
+            index += 2
+        elif token.startswith("--unset=") or ("=" in token and not token.startswith(("/", "-"))):
+            index += 1
+        elif token == "--":
+            index += 1
+            break
+        elif token.startswith("-"):
+            raise ValidationError(f"unsupported env launcher option: {token}")
+        else:
+            break
+    return words[index:]
+
+
+def validate_safe_command_substitutions(command: str) -> None:
+    if "`" in command:
+        raise ValidationError("backtick command substitution is not an accepted worker launcher")
+    starts = [match.start() for match in re.finditer(r"\$\(", command)]
+    for start in starts:
+        end = command.find(")", start + 2)
+        if end < 0:
+            raise ValidationError("unterminated command substitution")
+        body = command[start + 2 : end]
+        words = split_words(body)
+        if len(words) != 2 or os.path.basename(words[0]).lower() != "cat":
+            raise ValidationError("only the renderer's single-file $(cat PROMPT_FILE) substitution is accepted")
+
+
+def command_backend(
+    words: list[str],
+    *,
+    expected: str,
+    trusted_claude_wrapper: str,
+    depth: int = 0,
+    shell_body: bool = False,
+) -> str:
+    if depth > 3:
+        raise ValidationError("nested shell launch depth exceeds the supported limit")
+    words = strip_environment(words)
+    if not words:
+        raise ValidationError("command has no executable")
+    if shell_body and CHAIN_TOKENS.intersection(words):
+        raise ValidationError("shell command chaining is not an accepted worker launcher")
+    if shell_body and REDIRECT_TOKENS.intersection(words):
+        redirect_indices = [index for index, token in enumerate(words) if token in REDIRECT_TOKENS]
+        if len(redirect_indices) != 1 or words[redirect_indices[0]] != "<" or redirect_indices[0] != len(words) - 2:
+            raise ValidationError("only the renderer's final single-file stdin redirect is accepted")
+        redirect_target = words[-1]
+        if not os.path.isabs(redirect_target):
+            raise ValidationError("renderer stdin redirect must use an absolute prompt file")
+        words = words[: redirect_indices[0]]
+
+    executable = words[0]
+    basename = os.path.basename(executable).lower()
+    actual = BACKENDS.get(basename)
+    if actual is not None:
+        return actual
+
+    if basename in SHELLS:
+        if len(words) >= 3 and words[1] in SHELL_FLAGS:
+            return command_backend(
+                split_words(words[2], shell_body=True),
+                expected=expected,
+                trusted_claude_wrapper=trusted_claude_wrapper,
+                depth=depth + 1,
+                shell_body=True,
+            )
+        if expected == "claude-code" and len(words) >= 2:
+            wrapper = os.path.realpath(words[1])
+            if wrapper == os.path.realpath(trusted_claude_wrapper) and "--" in words[2:]:
+                marker = words.index("--", 2)
+                return command_backend(
+                    words[marker + 1 :],
+                    expected=expected,
+                    trusted_claude_wrapper=trusted_claude_wrapper,
+                    depth=depth + 1,
+                )
+        raise ValidationError(f"untrusted or opaque shell wrapper cannot prove backend identity: {executable}")
+
+    raise ValidationError(f"executable is not a configured worker backend: {executable}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--backend", required=True, choices=sorted(set(BACKENDS.values())))
+    parser.add_argument("--command", required=True)
+    parser.add_argument("--trusted-claude-wrapper", required=True)
+    args = parser.parse_args()
+
+    try:
+        validate_safe_command_substitutions(args.command)
+        actual = command_backend(
+            split_words(args.command, shell_body=True),
+            expected=args.backend,
+            trusted_claude_wrapper=args.trusted_claude_wrapper,
+            shell_body=True,
+        )
+        if actual != args.backend:
+            raise ValidationError(
+                f"declared backend {args.backend} does not match executable backend {actual}"
+            )
+    except ValidationError as exc:
+        print(str(exc))
+        return 64
+
+    print(hashlib.sha256(args.command.encode("utf-8")).hexdigest())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 结果

- 完整 Harness 祖先链按最小权限取白名单交集，弱宿主嵌套强 CLI 不能恢复高权限
- 将 `--worker-backend` 与真实启动命令绑定，拒绝标签伪装、命令链和不透明 wrapper
- 新增跨 worktree provider 原子租约，绑定 tmux/Orca terminal 的真实生命周期
- Orca 显式继承 setup 策略并保留门禁优先的两阶段启动；普通终端继续使用 tmux
- 当前派发 backend 收口为 Claude Code、Codex、CodeBuddy、QoderWork CN

## 验证

- `test-dependency-install-guard.sh`: 48/48
- `test-harness-backend-policy.sh`: 26/26
- `test-worker-command-policy.sh`: 15/15
- `test-provider-lease.sh`: PASS
- Sentinel、tmux、Orca worker/control-plane smoke: PASS
- Skill quick validate: PASS
- Harness failure audit: PASS
- ShellCheck error-level: PASS
- Orca 1.4.180 真实无模型 lifecycle：worktree/terminal/metadata/lease/read/close/clean 闭环通过

## 已知验证边界

`instruction_stability_gate` 仍为 `NOT_VERIFIED`：缺少正式约束合同、三轮候选绑定产物与 evaluator receipt，已登记本地 Task-039，不将本次行为验证扩大为长期稳定性证明。

Refs: Task-038 / DEC-119