### PR TITLE
docs(orchestration): SKILL §3.3 PM spawn 操作纪律（Task-041~044）

### DIFF
--- a/skills/multi-agent-orchestration/CHANGELOG.md
+++ b/skills/multi-agent-orchestration/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.5.2] - 2026-08-14
+
+### 改进
+
+- SKILL.md §3.3 新增「PM spawn 操作纪律」（Task-041~044，Wave-2 实战撞坑固化）：spawn 后不重复 send 完整 prompt（与 `worker-start` live preamble 重复，Task-042）；`run-create` 只调一次避免 `consumer_fenced`（Task-043）；supervised worker 不用 `pm-monitor`/`sentinel` 判完成（靠 `worker_done → Delivery`，Task-041）；spawn 前后独立 Bash 调用并行（Task-044）。
+
 ## [2.5.1] - 2026-08-14
 
 ### 修复

--- a/skills/multi-agent-orchestration/SKILL.md
+++ b/skills/multi-agent-orchestration/SKILL.md
@@ -101,7 +101,7 @@ spawn 一个 worker 后，PM 的操作纪律（Wave-2 实战撞坑固化）：
 
 1. **不主动 send 完整 task prompt**（Task-042）：`--orca-supervised` 的 worker 由 `worker-start` 注入 live preamble + TASK（唯一任务注入器，见 §4.4/4.5）。PM spawn 后再 send 完整 prompt 是重复投递，会让 worker 混淆/双重执行。长 prompt 写 `WORKER_PROMPT.md`（Session Context），terminal 只发短 Read 指令触发。
 2. **`run-create` / jq 提取只调一次**（Task-043）：一个 Wave 共用一个 Run，`pm-orchestrate run-create` 调一次拿 `run.id` 即定；**不要重试**——重试生成新 Run + 新 coordinator handle，旧 handle 立即 `consumer_fenced`。从 receipt `jq -r '.result.run.id'` 一次取定，整 Wave 复用。
-3. **supervised worker 不用 pm-monitor/sentinel 判完成**（Task-041）：supervised 完成靠 `worker_done → Delivery`（`pm-orchestrate show/wait` 读 dispatch + Delivery）。`pm-monitor`（STATUS/commit-stale）和 `sentinel`（tmux tui-idle/timeout）是 tmux-only 语义，套 supervised 会误判——supervised worker 不一定写 STATUS、`STATUS=done` ≠ Delivery、tui-idle 只表示可交互不表示完成。supervised 的 PM 只用 `pm-orchestrate show/wait`，pm-monitor/sentinel 仅作 tmux 回退路径的辅助。
+3. **supervised worker 不用 pm-monitor/sentinel 判完成**（Task-041）：supervised 完成唯一权威是 `worker_done → Delivery`（`pm-orchestrate show/wait` 读 dispatch + Delivery）。`pm-monitor`（STATUS/commit-stale）和 `sentinel`（tui-idle/timeout）的信号不是 supervised 完成权威——`STATUS=done` ≠ Delivery、tui-idle 只表示可交互不表示完成。supervised 的 PM 只用 `pm-orchestrate show/wait`；pm-monitor/sentinel 是 tmux/terminal-managed 回退路径的辅助观察器，套到 supervised 会误判。
 4. **spawn 前后 Bash 调用尽量并行**（Task-044）：spawn 前的探查（`orca status` / `worktree current` / `render-runtime-profile`）和 spawn 后的核验（METADATA/STATUS/lease）彼此独立的调用，放同一条 message 并行发出，不要串行——Wave-2 整轮 11 次串行 Bash ≈30s 纯 I/O 等待浪费。依赖链（spawn 依赖 render、commit 依赖 verify）才串行。
 
 ## 4. Orca-first 控制平面

--- a/skills/multi-agent-orchestration/SKILL.md
+++ b/skills/multi-agent-orchestration/SKILL.md
@@ -95,6 +95,15 @@ Issue 分组细则读取 `references/11-issue-grouping.md`；并发与真实踩�
 
 `clean-worktree.sh` 删 worktree 前安全 unlink 该软链（`[ -L ] && rm -f` 无尾斜杠，绝不跟随删主仓 `node_modules`）。install-guard 仍 `deny_by_default` 拦 `npm install/ci/add`，worker 不会误改主仓 `node_modules`。详见 `references/09-parallel-lessons.md` G28/G31。
 
+### 3.3 PM spawn 操作纪律（Task-041~044，Wave-2 实战）
+
+spawn 一个 worker 后，PM 的操作纪律（Wave-2 实战撞坑固化）：
+
+1. **不主动 send 完整 task prompt**（Task-042）：`--orca-supervised` 的 worker 由 `worker-start` 注入 live preamble + TASK（唯一任务注入器，见 §4.4/4.5）。PM spawn 后再 send 完整 prompt 是重复投递，会让 worker 混淆/双重执行。长 prompt 写 `WORKER_PROMPT.md`（Session Context），terminal 只发短 Read 指令触发。
+2. **`run-create` / jq 提取只调一次**（Task-043）：一个 Wave 共用一个 Run，`pm-orchestrate run-create` 调一次拿 `run.id` 即定；**不要重试**——重试生成新 Run + 新 coordinator handle，旧 handle 立即 `consumer_fenced`。从 receipt `jq -r '.result.run.id'` 一次取定，整 Wave 复用。
+3. **supervised worker 不用 pm-monitor/sentinel 判完成**（Task-041）：supervised 完成靠 `worker_done → Delivery`（`pm-orchestrate show/wait` 读 dispatch + Delivery）。`pm-monitor`（STATUS/commit-stale）和 `sentinel`（tmux tui-idle/timeout）是 tmux-only 语义，套 supervised 会误判——supervised worker 不一定写 STATUS、`STATUS=done` ≠ Delivery、tui-idle 只表示可交互不表示完成。supervised 的 PM 只用 `pm-orchestrate show/wait`，pm-monitor/sentinel 仅作 tmux 回退路径的辅助。
+4. **spawn 前后 Bash 调用尽量并行**（Task-044）：spawn 前的探查（`orca status` / `worktree current` / `render-runtime-profile`）和 spawn 后的核验（METADATA/STATUS/lease）彼此独立的调用，放同一条 message 并行发出，不要串行——Wave-2 整轮 11 次串行 Bash ≈30s 纯 I/O 等待浪费。依赖链（spawn 依赖 render、commit 依赖 verify）才串行。
+
 ## 4. Orca-first 控制平面
 
 ### 4.1 先读取版本匹配指南

--- a/skills/multi-agent-orchestration/references/09-parallel-lessons.md
+++ b/skills/multi-agent-orchestration/references/09-parallel-lessons.md
@@ -689,3 +689,11 @@ PM 合并 Wave PR 时，把 DEC 编号 race 视为常规冲突处理，不让 wo
   - **Orca supervised 比 tmux 多一层 lifecycle 死锁风险**：tmux worker 死了 PM 直接 kill session；Orca supervised worker 死了但没 worker_done，dispatch 卡住拖累整个收尾。需要 PM 侧的 force-settle 兜底。
 
 **关联**：G28（向上解析免费午餐）、G29 #2/#3/#4（install-guard 过严 + worker 自验缺失，未根治）、SKILL §3.1 spawn 协议、§8 supervised lifecycle、references/12 Orca worker。
+
+### G32. run-create 重试 → consumer_fenced（Task-043，Wave-2）
+
+**现象**：folia Wave-2 PM 调 `pm-orchestrate run-create` 两次（第一次拿 receipt 后又调一次"确认"），第二次生成新 Run + 新 coordinator handle。后续 `pm-orchestrate wait` 用第一次的 handle，Orca 返回 `consumer_fenced: This coordinator terminal is no longer bound to Run <id>`。
+
+**根因**：Orca supervised 的 consumer fencing = 最新 coordinator handle 胜出。一个 Wave 共用一个 Run，`run-create` 调一次即定；重试生成新 Run（即便 objective 相同），旧 handle 立即被新 Run 的 handle fence。
+
+**正确协议**：`pm-orchestrate run-create --objective TEXT` 调一次，从 receipt `jq -r '.result.run.id'` 一次取定 run_id，整 Wave 复用（`spawn-worker --orca-supervised --orca-run-id $run_id`）。不要重试 run-create；若需确认 receipt，读已拿到的 JSON，不重发命令。详见 SKILL §3.3 规则 2、§4.4。


### PR DESCRIPTION
Wave-2 实战撞坑固化为 SKILL 规范（§3.3 新增 4 条纪律）：
- **042** spawn 后不重复 send 完整 prompt（与 worker-start live preamble 重复）
- **043** run-create 只调一次避免 consumer_fenced
- **041** supervised 不用 pm-monitor/sentinel 判完成（靠 worker_done→Delivery）
- **044** spawn 前后独立 Bash 并行（Wave-2 整轮 11 次串行 ≈30s 浪费）

pm-monitor 脚本侧 supervised 提示留 follow-up（806 行主循环回归风险），文档已覆盖核心。

纯文档变更（SKILL.md §3.3 + CHANGELOG [2.5.2]），无脚本逻辑改动。