### PR TITLE
fix(multi-agent-orchestration): keep dry-run side-effect free

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 | 日期       | 类型   | Skill                                                                 | 版本    | 更新要点                                                                                                                                                                                                                                       |
 | :--------- | :----- | :-------------------------------------------------------------------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 2026-08-14 | 改名   | [skill-publish-sync](skills/skill-publish-sync/)                       | v1.7.2  | `clawhub-sync` 更名为 `skill-publish-sync`；原名仅反映三平台之一（ClawHub），与多平台定位名实不符；目录、frontmatter、slug、`git-batch-commit` 探测路径与 reference 文件一并更新，已发布记录及其它 skill 不受影响 |
-| 2026-08-14 | 更新   | [multi-agent-orchestration](skills/multi-agent-orchestration/)         | v2.6.1  | 将 spawn-worker 的 flags、Orca、metadata、provider lease 与 launch 边界渐进拆成 5 个可直接测试的模块；入口由 1,944 行降至 1,131 行，保持既有 CLI 与生命周期语义 |
+| 2026-08-14 | 更新   | [multi-agent-orchestration](skills/multi-agent-orchestration/)         | v2.6.2  | 修复带空格 worker command 的 `--dry-run` 仍创建 Session Context 并写入 `launch.sh`；预演现在只输出最终 wrapper 计划，不产生文件副作用 |
 | 2026-08-13 | 更新   | [video-screenshot](skills/video-screenshot/)                           | v0.8.1  | 新增非破坏性证据线索包：OCR 多锚点与无文字图像主体共同排序，不保存 OCR/实体原文；默认 24 张、4 页弱模型联系表只作封闭分类和泛化概括；归档仅保存元数据，reference 统一实际输出目录与视觉只减不增边界 |
 | 2026-08-13 | 更新   | [contract-copilot](skills/contract-copilot/)                           | v1.6.3  | 增加 DOCX 全量解包预检与 OOXML 命名空间/元素白名单，拒绝越界路径、符号链接、隐藏文本、伪装命名空间和畸形结构；明确审查计划及扩展计划均为每次运行动态生成的产物 |
 | 2026-08-13 | 更新   | [skill-manager](skills/skill-manager/)                                 | v1.7.2  | 项目同时存在多个 Agent 配置目录时优先使用 `.claude/skills` 单一来源；补充 `.codebuddy` 全局根识别，避免从 CodeBuddy 配置目录调用时误装到嵌套目标 |
@@ -627,7 +627,7 @@
 <td>工具·Agent协作</td>
 <td style="word-break:break-word">Orca-first 多 Agent 本地编排，支持 Wave receipt、worktree/terminal UI、Run/Task/Dispatch、worker transcript、严格 lifecycle 结算、四后端总控、Harness 层级门禁与 tmux 回退</td>
 <td style="text-align:center">MIT</td>
-<td style="text-align:center">v2.6.1</td>
+<td style="text-align:center">v2.6.2</td>
 <td style="text-align:center"><a href="https://github.com/cat-xierluo/legal-skills/releases/download/v2026.08.06/multi-agent-orchestration-1.20.5.zip">下载 v1.20.5</a></td>
 <td></td>
 </tr>

--- a/skills/multi-agent-orchestration/CHANGELOG.md
+++ b/skills/multi-agent-orchestration/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.6.2] - 2026-08-14
+
+### 修复
+
+- 修复带空格 worker command 的 `--dry-run` 仍创建 Session Context 并写入 `launch.sh` 的副作用；预演现在只报告最终 wrapper 路径与命令，不创建目录、文件或执行权限。
+- 保持非 dry-run 的 `launch.sh` 内容、tmux/Orca transport 和 supervised 注册路径不变。
+
+### 验证
+
+- `test-spawn-worker-launch.sh` 从 11 个扩展到 16 个断言，新增 helper 与真实入口的 dry-run 零写入检查；完整生命周期、权限、Wave、settle、Sentinel、tmux 和 Orca 回归通过。
+
 ## [2.6.1] - 2026-08-14
 
 ### 改进

--- a/skills/multi-agent-orchestration/SKILL.md
+++ b/skills/multi-agent-orchestration/SKILL.md
@@ -3,7 +3,7 @@ name: multi-agent-orchestration
 description: 本技能应在用户要求并行推进多个任务、开启多个 worker/agent、使用 Orca Run/Task/Dispatch 或 tmux 独立 session、让 PM 通过 UI/会话转录实时巡检并统一调度 Claude Code、Codex、CodeBuddy、QoderWork 等 CLI，或要求防止 PM 直接实现逃逸时使用。触发词包括“并行推进”“开多个 worker”“Orca 编排”“supervised worker”“PM 总控”“独立 session”“多 agent 并行”“分派任务”。不要用于单个短任务、纯任务状态同步，或 Git 分支/提交/PR/merge 规则。
 license: MIT
 metadata:
-  version: "2.6.1"
+  version: "2.6.2"
   homepage: https://github.com/cat-xierluo/legal-skills
   author: 杨卫薪律师（微信ywxlaw）
 ---

--- a/skills/multi-agent-orchestration/scripts/spawn-worker-launch.sh
+++ b/skills/multi-agent-orchestration/scripts/spawn-worker-launch.sh
@@ -11,9 +11,13 @@ launch_worker_session() {
   # 通用:codebuddy(qoderclicn)/ qoder / 任何含空格路径或特殊字符的 COMMAND 都受益。
   if [[ "$COMMAND" == *' '* ]]; then
     LAUNCH_SH="$WORKTREE/.claude/agent-sessions/$SESSION/launch.sh"
-    mkdir -p "$(dirname "$LAUNCH_SH")"
-    printf '#!/bin/bash\n# spawn-worker 自动生成:绕过 tmux command 解析(路径空格/特殊字符)\n# 原始 COMMAND 在 bash -c 下正确解析 %%q 转义(tmux 的 command parser 会吃反斜杠)\nexec bash -c %q\n' "$COMMAND" > "$LAUNCH_SH"
-    chmod +x "$LAUNCH_SH"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      printf 'SPAWN_WORKER_DRY_RUN_LAUNCH_SH: path=%q command=%q\n' "$LAUNCH_SH" "$COMMAND"
+    else
+      mkdir -p "$(dirname "$LAUNCH_SH")"
+      printf '#!/bin/bash\n# spawn-worker 自动生成:绕过 tmux command 解析(路径空格/特殊字符)\n# 原始 COMMAND 在 bash -c 下正确解析 %%q 转义(tmux 的 command parser 会吃反斜杠)\nexec bash -c %q\n' "$COMMAND" > "$LAUNCH_SH"
+      chmod +x "$LAUNCH_SH"
+    fi
     COMMAND="bash $(printf '%q' "$LAUNCH_SH")"
   fi
 

--- a/skills/multi-agent-orchestration/scripts/test-spawn-worker-launch.sh
+++ b/skills/multi-agent-orchestration/scripts/test-spawn-worker-launch.sh
@@ -89,6 +89,24 @@ case "$COMMAND" in
 esac
 
 reset_launch_case
+SESSION="dry-run-worker-session"
+COMMAND="codebuddy --permission-mode acceptEdits"
+DRY_RUN=1
+dry_run_plan=$(launch_worker_session)
+DRY_SESSION_CONTEXT="$WORKTREE/.claude/agent-sessions/$SESSION"
+LAUNCH_SH="$DRY_SESSION_CONTEXT/launch.sh"
+if [ ! -e "$DRY_SESSION_CONTEXT" ]; then
+  ok "dry-run spaced command does not write Session Context"
+else
+  bad "dry-run spaced command does not write Session Context"
+fi
+if printf '%s\n' "$dry_run_plan" | grep -Fq 'SPAWN_WORKER_DRY_RUN_LAUNCH_SH:'; then
+  ok "dry-run spaced command reports the planned launch wrapper"
+else
+  bad "dry-run spaced command reports the planned launch wrapper"
+fi
+
+reset_launch_case
 ORCA_MODE="auto"
 printf '%s\n' '{"session":{"orca":{"terminal_handle":""}}}' > "$METADATA_FILE"
 launch_worker_session
@@ -153,6 +171,39 @@ set +e
 missing_helper_rc=$?
 set -e
 assert_eq "$missing_helper_rc" "1" "missing supervised helper fails loud after terminal creation"
+
+E2E_PROJECT="$CASE_ROOT/dry-run-project"
+E2E_BIN="$CASE_ROOT/dry-run-bin"
+E2E_SESSION="dry-run-e2e"
+mkdir -p "$E2E_PROJECT" "$E2E_BIN"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'if [ "${1:-}" = "has-session" ]; then exit 1; fi' \
+  'exit 0' \
+  > "$E2E_BIN/tmux"
+chmod +x "$E2E_BIN/tmux"
+set +e
+e2e_output=$(PATH="$E2E_BIN:$PATH" bash "$REAL_SCRIPT_DIR/spawn-worker.sh" \
+  --project "$E2E_PROJECT" \
+  --no-worktree \
+  --no-orca-mode \
+  --session "$E2E_SESSION" \
+  --worker-backend codebuddy \
+  --command 'codebuddy --permission-mode acceptEdits' \
+  --dry-run 2>&1)
+e2e_rc=$?
+set -e
+assert_eq "$e2e_rc" "0" "entrypoint accepts a dry-run spaced command"
+if [ ! -e "$E2E_PROJECT/.claude/agent-sessions/$E2E_SESSION" ]; then
+  ok "entrypoint dry-run leaves Session Context absent"
+else
+  bad "entrypoint dry-run leaves Session Context absent"
+fi
+if printf '%s\n' "$e2e_output" | grep -Fq 'SPAWN_WORKER_DRY_RUN_LAUNCH_SH:'; then
+  ok "entrypoint dry-run exposes the planned wrapper"
+else
+  bad "entrypoint dry-run exposes the planned wrapper"
+fi
 
 if grep -Fq 'source "$SCRIPT_DIR/spawn-worker-launch.sh"' "$REAL_SCRIPT_DIR/spawn-worker.sh" \
   && ! grep -q '^launch_worker_session() {' "$REAL_SCRIPT_DIR/spawn-worker.sh"; then


### PR DESCRIPTION
## 摘要

- 完成 Task-055，修复带空格 worker command 的 --dry-run 仍创建 Session Context 并写入 launch.sh
- dry-run 继续输出最终 wrapper 路径与命令，但不创建目录、文件或执行权限
- 非 dry-run 的 launch.sh 内容和 tmux/Orca transport 保持不变；版本升级到 v2.6.2

## 验证

- 失败测试先复现：11 pass / 2 fail
- 修复后 launch 测试：16/16，包含 helper 与真实 spawn-worker.sh 入口零写入断言
- 完整 multi-agent-orchestration 回归及 Sentinel、tmux、Orca smoke 通过
- Skill 快速校验通过；安全扫描 critical/high 均为 0
- HARNESS_REVIEW_VERIFIED：6 个正常检查 + 2 个故障注入

## 已知边界

- instruction stability 仍为 NOT_VERIFIED；该项需要独立的外部 evaluator、签名合同和至少三轮 held-out 评测，不属于本修复范围