### PR TITLE
docs(multi-agent-orchestration): 固定 Autopilot 持久化整改基线

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 
 | 日期       | 类型   | Skill                                                                 | 版本    | 更新要点                                                                                                                                                                                                                                       |
 | :--------- | :----- | :-------------------------------------------------------------------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-08-26 | 更新   | [multi-agent-orchestration](skills/multi-agent-orchestration/)         | v2.8.1  | **Wave Autopilot 持久性边界与整改基线**：明确 session recurring cron 只提供 L1 live-session fast path；新增跨会话 runtime ledger、PM lease/fencing、幂等 reconcile、durable scheduler/soft park、shared-context 单写者和八项故障注入设计，并分别标记 L2 controller 与 L3 scheduler 未实现状态 |
 | 2026-08-26 | 更新   | [md2word](skills/md2word/)                                             | v1.3.5  | **全书本地图片路径修复**：`--book` 在合并前按各章 Markdown 自己的目录重定位 Markdown/HTML 本地相对图片，含空格、URL 编码和可选标题的路径均可嵌入；单章与远程图片行为不变 |
 | 2026-08-25 | 新增   | [industry-research-report](skills/industry-research-report/)           | v0.7.0 | **行业法律调研报告（获客端）**：**v0.7.0 全面精简版式（Less is more：页眉只留报告编号、页脚只留页码，砍掉横线/kicker/多列冗余装饰）**；输入 industry/region/focus/depth，输出精排 A4 PDF 行业法律调研报告；蓝皮书体例（深蓝 #1B3C59 + 金色 #D4AF37 + 白色页面）+ 4 个封面变体（顶金带+底金边+REPORT NO. 徽章工艺感）+ 5 个律师常见调色板；**v0.6.2 书籍连续流改造**（DEC-IR-019）：放弃杂志固定画布裁切，改 @page margin box 跨页 header/footer + 章节自然流动不截断 + 大边距（天头80px/地脚60px/左右56px≈21/16/15mm）；**v0.6.1 杂志Studio book-style 排版优化**（加大字号 IR 22/12pt + 行高 2.0）；**v0.6.0 三连环视觉修复**（封面 CSS 注入 / px 单位 / 按 H2 拆章）；**v0.5.0 report_kind 字段 + 正文设计系统差异化路由**（IR 蓝皮书感 vs WB 通讯感，12 维度全表）；内置 report-profile.md 个性化配置 + 首启向导；行业特定信源映射内置 20 个高频行业；数据源走企查查 MCP + 网络检索 5 级信源优先级；md 基底 → jinja2 → Playwright + Chrome headless，一键出精排 A4 PDF |
 | 2026-08-25 | 新增   | [weekly-legal-briefing](skills/weekly-legal-briefing/)                 | v0.6.0 | **定时法律研报（留存端）**：**v0.6.0 继承 v0.7.0 精简版式（页眉页脚只留编号/页码）**；配置一次，定期自动生成行业/法律研报草稿（如"科技型制造企业 周报"）；**v0.5.2 书籍连续流继承**（Skill 1 v0.6.2：@page margin box 跨页 header/footer + 章节自然流动不裁切 + 大边距）；**v0.5.0 三连环视觉修复同步**；**v0.4.0 新增 2 个专属轻量封面 (W1-minimal / W2-tag-bar) + 正文设计系统强烈差异化**（字号小 + 灰色细线 + 单栏目录，与 IR 蓝皮书感拉开）；白名单信源制（白名单外默认丢弃）+ 案例必带案号 + 案号裁判文书网回查；输出文件一律带 `_DRAFT` 标记，**永不自动外发**（硬约束，发布动作物理上留给人工）；渲染管线 symlink 复用 industry-research-report，避免双份维护；附 WorkBuddy / OpenClaw cron / GitHub Actions 三平台部署说明 |
@@ -41,7 +42,6 @@
 | 2026-08-24 | 更新   | [lecture-review](skills/lecture-review/)                               | v1.2.1 | **讲课复盘三轮迭代**：v1.1.0 新增 deck 课件对照（六段 → 七段：实讲/半讲/跳过/挪位回收/主动宣判五枚举 + min/页双口径）；v1.2.0 高级模式课程结构复盘（评人/评课分离 + 双向比对三方向）；v1.2.1 产物落点约定（七段报告/review.md/stats.json/profile 落点表 + 评课不进讲师档案）；脚本 `analyze_stats.py` 新增 `--deck` 课件解析与 `self_check` 三个候选生成器（module_distribution / near_dup_pages / title_term_index），references/metrics.md 同步补「课件对照」节；`references/structural-review-template.md` 沉淀九节+附录的高级模式复盘骨架 |
 | 2026-08-24 | 新增   | [lecture-review v1.0.0](skills/lecture-review/)                        | v1.0.0 | **讲课表现复盘**：通读 raw 转录稿动态发现主讲口癖/节奏/句式与结构信号（时间分配/承诺回收/互动密度），预设词表仅作对比锚点；脚本统一口径出数字（讲师隔离+归属污染核验、最长优先去重叠、双格式时间戳、剔幻灯片 URL）；讲师档案跨场次闭环（watchlist 下场复查）；ASR 吞语气音盲区显式声明；经双盲基线测试（RED→GREEN）验证 |
 | 2026-08-22 | 新增   | [elements-complaint-generator](skills/elements-complaint-generator/)   | v0.13.4 | **要素式起诉状生成器**：基于最高法法〔2025〕82 号 67 类官方模板，从律师已写好的常规起诉状自动生成要素式 Word 文书。113 棵 OOXML 模板树全量入库（git 可 diff），68/68 案由精调（含知产行政/执行全家族/海事/环资/行政/国赔），通用勾选机制+多当事人扩容+法人块渲染+批量模式，格式像素级保真（lxml 跨 run 精确替换），e2e 28 产物+68 树冒烟+45 答辩冒烟全绿 |
-| 2026-08-14 | 更新   | [pdf-processor](skills/pdf-processor/)                                 | v2.12.0 | 改善 PDF Expert 复制正文换行：Paddle 正文段落字号只向下统一并保留原坐标与横向框宽；新增显式 clean.md 输出，代表性四页样本换行由 120 降至 62 |
 </details>
 
 ## 📋 项目概述
@@ -625,9 +625,9 @@
 <tr>
 <td><a href="skills/multi-agent-orchestration/"><strong>multi-agent-orchestration</strong></a></td>
 <td>工具·Agent协作</td>
-<td style="word-break:break-word">Orca-first 多 Agent 本地编排，支持 Wave receipt、worktree/terminal UI、Run/Task/Dispatch、worker transcript、严格 lifecycle 结算、四后端总控、Harness 层级门禁与 tmux 回退</td>
+<td style="word-break:break-word">Orca-first 多 Agent 本地编排，支持 Wave receipt、worktree/terminal UI、Run/Task/Dispatch、worker transcript、严格 lifecycle 结算、四后端总控、Harness 层级门禁、Wave Autopilot live-session 快路径与跨会话持久化设计</td>
 <td style="text-align:center">MIT</td>
-<td style="text-align:center">v2.6.2</td>
+<td style="text-align:center">v2.8.1</td>
 <td style="text-align:center"><a href="https://github.com/cat-xierluo/legal-skills/releases/download/v2026.08.06/multi-agent-orchestration-1.20.5.zip">下载 v1.20.5</a></td>
 <td></td>
 </tr>

--- a/skills/multi-agent-orchestration/CHANGELOG.md
+++ b/skills/multi-agent-orchestration/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.7.1] - 2026-08-26
+
+### 改进
+
+- 内部上下文同步：`references/09-parallel-lessons.md` 新增 G39（badminton-lab Wave 4）——同账号多 claude-code worker 的 5 小时限流同时触发；429 打断 turn 后 TUI 停在 idle，`pm-orchestrate send` 投递 Dispatch inbox 叫不醒（`ok:true` ≠ 被消费），须用 `orca terminal send --text ... --enter` 键盘注入唤醒；判活看 `peek` transcript 时间戳与当前的差值而非 tail 文本。SKILL.md §7 增补对应唤醒指引一句。纯文档变更，无脚本改动，全部脚本 `bash -n` 通过。
+
 ## [2.7.0] - 2026-08-25
 
 ### 新增

--- a/skills/multi-agent-orchestration/CHANGELOG.md
+++ b/skills/multi-agent-orchestration/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.8.0] - 2026-08-26
+
+### 新增
+
+- Wave Autopilot 模式（Task-062，`DEC-125`）：`references/14-wave-autopilot.md` + SKILL.md §4.6。用户显式授权后，PM 按项目任务源固定策略自动链式推进波次直到泊车。核心机制：监控**三通道并用**（Orca 推送 + recurring cron 看门狗 + Dispatch 状态轮询；完成权威是 `worker-show` 的 dispatch/worker 状态而非队列消息——实测 worker_done 推送可延迟 6.6h 不唤醒 PM）；授权与组波/泊车策略权威留在项目上下文，skill 只定义机制与不变量；验收路径不因自动化放宽（最终树门禁复跑 + safe-push + PR squash）；泊车 fail-closed、每波摘要不阻断。含验收期确定性缺陷的 fix-worker 派发模式（新分支名 + `--base-ref origin/<原分支>` 避 worktree 撞车）与 8 条实测反模式清单。来源：badminton-lab Wave 4/5（PR #21—#25）完整生命周期实战。
+
 ## [2.7.1] - 2026-08-26
 
 ### 改进

--- a/skills/multi-agent-orchestration/CHANGELOG.md
+++ b/skills/multi-agent-orchestration/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.8.1] - 2026-08-26
+
+### 修复
+
+- 修正 v2.8.0 将 session recurring cron 暗示为足够持久状态的边界：cron 只属于 live PM session 的 fast path；项目任务源保存策略/意图，不保存当前 Wave owner、attempt、Dispatch/PR、retry 与 next action。没有 runtime ledger、PM lease/fencing、幂等 reconcile 和外部 scheduler 时，只能声明 `L1 / LIVE_SESSION_AUTOPILOT`。
+
+### 新增
+
+- 新增 `references/15-autopilot-durability.md`：定义 L0—L3 能力等级、Git common dir runtime schema、PM lease/fencing、幂等状态机与 reconcile、durable scheduler/soft park、shared-context 单写者、故障分类与八项恢复演练；登记 `Task-066`—`Task-068` 实施切片，并与同时登记的 live-session `Task-063`—`Task-065` 明确互补边界。
+- `SKILL.md` §4.6 与 `references/14-wave-autopilot.md` 分别增加 `AUTOPILOT_L2_CONTROLLER_NOT_IMPLEMENTED`、`AUTOPILOT_L3_SCHEDULER_NOT_IMPLEMENTED` 边界和升级路由，防止 Agent 把单会话运行手册扩大为跨会话无人值守能力，或在 L2 已交付后继续错误声明 controller 未实现。
+
 ## [2.8.0] - 2026-08-26
 
 ### 新增

--- a/skills/multi-agent-orchestration/SKILL.md
+++ b/skills/multi-agent-orchestration/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: multi-agent-orchestration
-description: 本技能应在用户要求并行推进多个任务、开启多个 worker/agent、使用 Orca Run/Task/Dispatch 或 tmux 独立 session、让 PM 通过 UI/会话转录实时巡检并统一调度 Claude Code、Codex、CodeBuddy、QoderWork 等 CLI，或要求防止 PM 直接实现逃逸时使用。触发词包括“并行推进”“开多个 worker”“Orca 编排”“supervised worker”“PM 总控”“独立 session”“多 agent 并行”“分派任务”。不要用于单个短任务、纯任务状态同步，或 Git 分支/提交/PR/merge 规则。
+description: 本技能应在用户要求并行推进多个任务、开启多个 worker/agent、使用 Orca Run/Task/Dispatch 或 tmux 独立 session、让 PM 通过 UI/会话转录实时巡检并统一调度 Claude Code、Codex、CodeBuddy、QoderWork 等 CLI，或要求防止 PM 直接实现逃逸时使用；用户授权 Wave Autopilot 后，PM 按项目任务源固定策略自动链式推进波次（组波/派单/验收/合并/泊车）。触发词包括“并行推进”“开多个 worker”“Orca 编排”“supervised worker”“PM 总控”“独立 session”“多 agent 并行”“分派任务”“自动推进”“Wave Autopilot”“自动组波/自动推进波次”。不要用于单个短任务、纯任务状态同步，或 Git 分支/提交/PR/merge 规则。
 license: MIT
 metadata:
-  version: "2.7.0"
+  version: "2.8.0"
   homepage: https://github.com/cat-xierluo/legal-skills
   author: 杨卫薪律师（微信ywxlaw）
 ---

--- a/skills/multi-agent-orchestration/SKILL.md
+++ b/skills/multi-agent-orchestration/SKILL.md
@@ -241,6 +241,12 @@ bash scripts/pm-orchestrate.sh reauthorize --worktree "$WT" --session worker-a \
 - 这是 supervised 正式 lifecycle（worker_done→Delivery→release→ack）的例外兜底，不是常规收尾——优先让 worker 正常发 `worker_done`。
 - 验证：`test-settle-liveness.sh` 覆盖响应字段矩阵；`test-settle-command.sh` 覆盖 mutation 顺序、失败保留、精确删除与持久审计。
 
+### 4.6 Wave Autopilot（用户授权的常设自动推进）
+
+用户显式授权后，PM 按项目任务源中固定的组波/泊车策略自动链式推进波次：收口后自动写回任务源、查表组下一波并派发，直到泊车条件。**授权与策略权威都在项目上下文**（本 skill 不承载项目授权）；查表查不到合法组合即泊车，这是 Autopilot fail-closed 的根本。验收路径不因自动化放宽（门禁在最终树复跑 + safe-push + PR squash 强制），每波收口发摘要但不等确认，泊车必须完整报告后停止。
+
+Autopilot 活跃期间**必须挂 recurring cron 看门狗**，并与 Orca 推送、Dispatch 状态轮询三通道并用——推送唤醒实测会丢（worker_done 可延迟数小时不唤醒 PM）；完成判定的权威是 `worker-show` 的 dispatch/worker 状态，不是队列里有没有消息。看门狗每跳清单、验收期确定性缺陷的 fix-worker 派发模式与实测反模式读取 `references/14-wave-autopilot.md`。
+
 ## 5. tmux 回退
 
 先按 backend 生成命令，再 spawn：
@@ -373,6 +379,7 @@ bash scripts/check-dependencies.sh --backend claude-code --backend codex --check
 - `references/11-issue-grouping.md`：Issue 分组、依赖链和 PR 粒度。
 - `references/12-orca-cli-worker.md`：Orca 双层模型、runtime、Run/Task/Dispatch 和恢复。
 - `references/13-pm-orchestrate.md`：PM 三模式统一控制入口。
+- `references/14-wave-autopilot.md`：Wave Autopilot 自动推进、三通道监控、看门狗清单与泊车语义。
 
 不要一次加载全部 references；按当前 backend、控制模式和故障类型读取。
 

--- a/skills/multi-agent-orchestration/SKILL.md
+++ b/skills/multi-agent-orchestration/SKILL.md
@@ -311,6 +311,8 @@ bash scripts/sentinel.sh --status-file "$CTX/STATUS.json" --tmux-session worker-
 
 Sentinel 是唤醒/观察器，不是 supervised lifecycle authority。发现偏题、阻塞、越界或验证失败时优先给原 worker 发窄纠偏；需要独立审阅时另派 reviewer。Sentinel 设计读取 `references/04-sentinel-design.md`。
 
+worker TUI 被限流或中断后停在 idle 时，`pm-orchestrate send`（supervised 走 Dispatch inbox）叫不醒它——用 `orca terminal send --terminal <handle> --text "..." --enter` 直接键盘注入；判活看 `peek` transcript 时间戳距当前的差值（G39）。
+
 ## 8. 收口
 
 PM 必须：

--- a/skills/multi-agent-orchestration/SKILL.md
+++ b/skills/multi-agent-orchestration/SKILL.md
@@ -3,7 +3,7 @@ name: multi-agent-orchestration
 description: 本技能应在用户要求并行推进多个任务、开启多个 worker/agent、使用 Orca Run/Task/Dispatch 或 tmux 独立 session、让 PM 通过 UI/会话转录实时巡检并统一调度 Claude Code、Codex、CodeBuddy、QoderWork 等 CLI，或要求防止 PM 直接实现逃逸时使用；用户授权 Wave Autopilot 后，PM 按项目任务源固定策略自动链式推进波次（组波/派单/验收/合并/泊车）。触发词包括“并行推进”“开多个 worker”“Orca 编排”“supervised worker”“PM 总控”“独立 session”“多 agent 并行”“分派任务”“自动推进”“Wave Autopilot”“自动组波/自动推进波次”。不要用于单个短任务、纯任务状态同步，或 Git 分支/提交/PR/merge 规则。
 license: MIT
 metadata:
-  version: "2.8.0"
+  version: "2.8.1"
   homepage: https://github.com/cat-xierluo/legal-skills
   author: 杨卫薪律师（微信ywxlaw）
 ---
@@ -188,7 +188,7 @@ bash scripts/spawn-worker.sh \
   --orca-task-id "$TASK_A_ID"
 ```
 
-`orca-wave-prepare.sh` 给每个 Task spec 前置不可省略的 `worker_done` 协议提醒；spec 内的 branch 名一律用**连字符形式**（Orca worktree `--name` 与 spawn 的 `safe_branch` 都会把 `/` 规范成 `-`，spec 写斜杠名会让 worker 隔离门禁误判 blocked——Wave 1 教训，manifest 含 `branch: x/y` 会被 `orca-wave-prepare.sh` fail-closed 拒绝）。`orca-supervised-register.sh` 直接复用 receipt，对 `worker-start` 显式传 `--from`，避免并发 rebinding；被 `task_not_startable` 拒绝时带 `--reset-failed` 可把前任 worker 提问/中止翻成 failed 的 Task 复位 ready 重试一次（Task-060）。单 worker 可不传 receipt，由 helper 创建 Run/Task。`worker-start` 是唯一任务注入器；supervised 路径不得再发送普通 prompt。注册失败保留 receipt 与 terminal 供精确恢复，但整个 spawn 返回非零。**并行 worker 会同时写共享文档时（CHANGELOG/DECISIONS/TASKS），PM 在各 spec 中预分配互不冲突的编号与槽位**（如 DEC-044/045 分派到不同 worker），合并冲突留给 PM 收口按既定模式解。
+`orca-wave-prepare.sh` 给每个 Task spec 前置不可省略的 `worker_done` 协议提醒；spec 内的 branch 名一律用**连字符形式**（Orca worktree `--name` 与 spawn 的 `safe_branch` 都会把 `/` 规范成 `-`，spec 写斜杠名会让 worker 隔离门禁误判 blocked——Wave 1 教训，manifest 含 `branch: x/y` 会被 `orca-wave-prepare.sh` fail-closed 拒绝）。`orca-supervised-register.sh` 直接复用 receipt，对 `worker-start` 显式传 `--from`，避免并发 rebinding；被 `task_not_startable` 拒绝时带 `--reset-failed` 可把前任 worker 提问/中止翻成 failed 的 Task 复位 ready 重试一次（Task-060）。单 worker 可不传 receipt，由 helper 创建 Run/Task。`worker-start` 是唯一任务注入器；supervised 路径不得再发送普通 prompt。注册失败保留 receipt 与 terminal 供精确恢复，但整个 spawn 返回非零。`CHANGELOG/DECISIONS/TASKS/AGENTS/ROADMAP` 等 shared context 默认由 PM/维护者单写：worker 只提交任务专属产物与结构化 writeback proposal，PM 验收后串行写回。DEC/Task 编号预分配只分配标识，不授权并行修改共享文档；历史冲突按 `references/15-autopilot-durability.md` 的 fail-closed 恢复边界处理。
 
 ### 4.5 Supervised 生命周期
 
@@ -246,6 +246,8 @@ bash scripts/pm-orchestrate.sh reauthorize --worktree "$WT" --session worker-a \
 用户显式授权后，PM 按项目任务源中固定的组波/泊车策略自动链式推进波次：收口后自动写回任务源、查表组下一波并派发，直到泊车条件。**授权与策略权威都在项目上下文**（本 skill 不承载项目授权）；查表查不到合法组合即泊车，这是 Autopilot fail-closed 的根本。验收路径不因自动化放宽（门禁在最终树复跑 + safe-push + PR squash 强制），每波收口发摘要但不等确认，泊车必须完整报告后停止。
 
 Autopilot 活跃期间**必须挂 recurring cron 看门狗**，并与 Orca 推送、Dispatch 状态轮询三通道并用——推送唤醒实测会丢（worker_done 可延迟数小时不唤醒 PM）；完成判定的权威是 `worker-show` 的 dispatch/worker 状态，不是队列里有没有消息。看门狗每跳清单、验收期确定性缺陷的 fix-worker 派发模式与实测反模式读取 `references/14-wave-autopilot.md`。
+
+**持久性边界**：recurring cron 只属于当前 PM 会话的低延迟 fast path；项目任务源保存策略与意图，不保存当前 Wave 的完整运行态。没有 runtime ledger、PM lease/fencing 与幂等 reconcile 时，只能声明 `L1 / LIVE_SESSION_AUTOPILOT`，并报告 `AUTOPILOT_L2_CONTROLLER_NOT_IMPLEMENTED`；没有外部 durable scheduler 时报告 `AUTOPILOT_L3_SCHEDULER_NOT_IMPLEMENTED`。用户要求跨会话接管、无人值守恢复或 soft park 自动恢复时，读取 `references/15-autopilot-durability.md`；不得用一个笼统状态混淆 L2 controller 与 L3 scheduler。
 
 ## 5. tmux 回退
 
@@ -380,6 +382,7 @@ bash scripts/check-dependencies.sh --backend claude-code --backend codex --check
 - `references/12-orca-cli-worker.md`：Orca 双层模型、runtime、Run/Task/Dispatch 和恢复。
 - `references/13-pm-orchestrate.md`：PM 三模式统一控制入口。
 - `references/14-wave-autopilot.md`：Wave Autopilot 自动推进、三通道监控、看门狗清单与泊车语义。
+- `references/15-autopilot-durability.md`：跨会话 runtime ledger、PM lease/fencing、reconcile、durable scheduler、soft park 与故障注入门禁。
 
 不要一次加载全部 references；按当前 backend、控制模式和故障类型读取。
 

--- a/skills/multi-agent-orchestration/references/09-parallel-lessons.md
+++ b/skills/multi-agent-orchestration/references/09-parallel-lessons.md
@@ -749,3 +749,11 @@ PM 合并 Wave PR 时，把 DEC 编号 race 视为常规冲突处理，不让 wo
 - **现象**：manifest spec 写 `branch: feat/bl-018-...`，spawn 侧 `safe_branch` 规范化成连字符后实际分支与 spec 文本不一致，三个 worker 的隔离门禁同时按 spec 比对误判 blocked，PM 紧急向三个终端广播纠偏。
 - **修复**：`orca-wave-prepare.sh` fail-closed 拒绝 spec 内 `branch[:=] x/y` 形态并列出 key；路径引用（如 `docs/plans`）不误报。spawn 侧 `safe_branch` 早已存在，缺口只在 PM 手写 spec 环节。
 - **教训**：**同一标识符（分支名）跨 PM 手写文本与工具规范化两处出现时，入口处必须校验一致性**，不能依赖 PM 记得"Orca 会规范化"。
+
+### G39. 同账号多 worker 同时撞 429 限额 + idle TUI：inbox send 叫不醒，要键盘注入（badminton-lab Wave 4，PM 侧）
+
+- **现象**：同一 Claude 账号的 3 个 claude-code supervised worker 同时撞 429「已达到 5 小时的使用上限」，CLI 重试循环能扛过重置点；但 429 风暴把 turn 打断后 TUI 停在 `ready`（idle）。PM 用 `pm-orchestrate send` 发「继续」返回 `ok:true`，三个终端均毫无反应（用户在 UI 里肉眼确认消息没到）。
+- **根因**：supervised 模式下 `pm-orchestrate send` 投递到 **Dispatch inbox**，不是终端 stdin；idle worker 不会主动拉 inbox，消息安静躺箱。CLI 返回的 ok 只证明投递成功，不证明被消费。
+- **修复**：`orca terminal send --terminal <handle> --text "..." --enter` 直接键盘注入，三个 worker 立即恢复工作（transcript 时间戳恢复跳动，数分钟内出现读文档/跑命令活动）。
+- **诊断要点**：terminal tail 停在 429 行 + `peek` 返回的 transcript `timestamp`（epoch ms）距 `date +%s000` 超过几分钟 = 需要注入；判活看时间戳差值，别信 tail 文本（缓冲可能是陈旧快照，恢复思考时 spinner 只原地刷新不产生新行）。
+- **教训**：send 的「成功」语义 = 投递成功 ≠ 唤醒成功；对 idle TUI 的唤醒必须走输入通道本身。另：同账号多 worker 的 5 小时限流是**同时**触发的——波次排期要把账号配额当共享资源，多 worker 长任务尽量错峰或分账号（provider lease 按 backend 计数，拦不住同账号配额）。

--- a/skills/multi-agent-orchestration/references/14-wave-autopilot.md
+++ b/skills/multi-agent-orchestration/references/14-wave-autopilot.md
@@ -1,0 +1,68 @@
+# Wave Autopilot：用户授权的波次自动推进
+
+适用：用户显式授权后，PM 在固定策略内自动执行「组波 → 派单 → 监控 → 验收 → 合并 → 写回 → 组下一波」，链式推进直到泊车条件。badminton-lab Wave 4—5（2026-08-26，PR #21—#25）为首次完整落地的两波 + 泊车实战，本参考全部内容与该实战一一对应。
+
+## 1. 授权合同（先决条件）
+
+- 必须有用户**显式授权**，并记录在**项目上下文**（项目 AGENTS.md/CLAUDE.md 一节 + 指向项目任务源的策略章节）；本 skill 不承载任何项目授权。
+- 授权至少固定：授权范围（哪些任务类型可自动派）、泊车条件、撤销方式（用户一句话）、回退条件（发生一次泊车外失误即回退逐波确认）。
+- **策略权威 = 项目任务源**（如 docs/TASKS.md 的策略节）：组波规则、泳道、晋级门禁、泊车清单全部落在项目文档里，PM 查表执行、不做自由判断。查表查不到合法组合本身就是泊车条件——这是 Autopilot 能 fail-closed 的根本。
+
+## 2. 生命周期与不变量
+
+```text
+组波（查表）→ spawn（receipt + verify-cmd 白名单 + --python-runtime-symlink）
+  → 监控（三通道，见 §3）→ worker_done / Dispatch 状态确认
+  → PM 独立验收（diff 范围对 fork point + 身份 + 门禁在最终树复跑）
+  → safe-push → PR → squash merge → 资源清理（lease/worktree/分支，MERGED 证据）
+  → 任务源写回 → 查表组下一波 or 泊车（完整报告后停止）
+```
+
+不变量：
+
+1. **验收路径不因自动化放宽**：门禁复跑（sync-merge 后最终树为准，G37）→ safe-push 全 range 身份核验 → PR → squash merge 强制；禁止直推 main，禁止以 worker 自报代替复跑。
+2. **透明不阻断**：每波收口向用户发波次摘要（交付/PR/验证证据/下一波构成），不要求确认；泊车必须完整报告并停止，不静默重试。
+3. **泊车 fail-closed**：任务开工需用户资产/环境/授权、PM 复跑门禁失败且纠偏路径用尽、同一 worker 连续两次不达标、合并冲突超出项目已固定冲突模式、队列无合法可派组合、用户显式喊停。
+
+## 3. 监控可靠性：三通道并用（实战核心教训）
+
+单一推送通道会丢。Autopilot 活跃期间必须同时具备三条通道：
+
+1. **Orca 推送唤醒**（主通道）：快，但**不可靠**——实测 worker_done 消息在队列里存在、对应系统唤醒从未送达，PM 停摆 6.6 小时直到用户人工戳。
+2. **recurring cron 看门狗**（强制）：session 级 recurring cron（建议 `4-59/20 * * * *` 这类避开整点/半点的间隔），每跳执行 §4 清单；泊车时 CronDelete 自删；7 天自动过期是天然兜底。session-only 即可（Autopilot 本就活在 PM 会话里，任务源是持久状态）。
+3. **Dispatch 状态轮询是完成权威**：`worker_done` 的 Delivery 可能不进 PM 待查队列（消息路由与 Dispatch 结算是两条路径）；`pm-orchestrate show` 的 `dispatch.status=completed` + `worker.state=succeeded/settled` 是可查证的完成事实。**队列无消息 ≠ 未完成；状态停滞 ≠ 完成**——两边都要主动查。
+
+## 4. 看门狗每跳清单
+
+1. `orca orchestration check --run <活跃run>`：有 pending worker_done/escalation → 立即走收口/处置。
+   - 报 `This coordinator terminal is bound to run_X` 时：先 `orca orchestration run-use --id <run> --from <PM terminal handle>` 重绑——fix 派发等新建 run 后 PM 终端绑定会漂移。
+2. 逐活跃 worker 执行 `pm-orchestrate show --worktree WT --session S`：`completed/succeeded/settled` → 走验收（**即使 check 队列为空**）。
+3. 判活：`pm-orchestrate peek` 返回的 transcript `timestamp`（epoch ms）与当前差值 > 30 分钟且非已知长任务 → 处置矩阵：
+   - TUI idle（worker ready）且工作未完 → 按 G39 键盘注入唤醒：`orca terminal send --terminal <handle> --text "..." --enter`（supervised 的 `pm-orchestrate send` 走 Dispatch inbox，idle worker 不拉取，`ok:true` ≠ 被消费）；
+   - 429 限流重试循环（同账号多 worker **同时**触发）→ 记录并等重置点，CLI 会自动恢复；turn 被打断停 idle 才需要注入；
+   - 进程死且 dispatch 卡 `dispatched` → `pm-orchestrate settle`（身份/审计/liveness 门禁见 SKILL §4.5）。
+4. 全部 wave 收口 + 队列查表无可派 → CronDelete 看门狗 → 发泊车报告。
+
+## 5. 组波查表规则（模板；具体值落项目策略节）
+
+只派 `READY`；`DRAFT` 先派「晋级合同」任务（docs-only：合同文档 + 决策记录 + 任务源晋级写回），晋级后进后续波次实现。泳道互斥、同泳道串行（上一任务合并进 origin/main 后才派下一个）。每波 ≤N worker（默认 3），文件所有权必须正交。并行任务共写共享文档（决策记录/任务源/CHANGELOG）时**编号预分配**防撞号。review/收口发现的缺口先登记新卡再入波。实现本身被用户输入卡住的任务（需真实样本/环境/授权）不烧晋级合同，直接泊车。
+
+## 6. 验收期确定性缺陷的处置（实战模式）
+
+PM 复跑门禁**确定性失败**（≥2 次同点，先排除 flake）→ 不放宽门禁、PM 不改业务代码：
+
+1. 诊断收窄：失败断言点、假设列表（按序验证）、允许所有权边界，写成精确 fix spec。
+2. 原 dispatch 已结算不复活：把失败分支 safe-push 到远端（身份门禁核验；**门禁失败不阻断 feature 分支推送**），新 fix worker 用**新分支名 + `--base-ref origin/<原分支>`** 派发。
+   - 禁止同分支名重新 spawn：Orca 会因 worktree 名撞车建 `<branch>-2` 空 worktree，spawn 的 branch gate 直接 GATE_FAILED；误火用 `settle --force` + `clean-worktree --execute` 清理。
+3. fix 交付按确定性复验：目标门禁**连续 3 次**通过 + 全量门禁，随主交付同一 PR 合并，PR 描述写明缺陷根因与修复归属。
+
+## 7. 反模式清单（全部实测踩坑）
+
+- 只依赖 Orca 推送唤醒、不挂 recurring 看门狗 → 6.6h 停摆。
+- 用 `No messages` 判定 worker 未完成 → Delivery 可能不进队列，完成权威在 Dispatch 状态。
+- PM 终端跨 run 不 `run-use` 重绑就 `check` → binding 报错，误判无消息。
+- 修复任务复用同分支名 spawn → `-2` 空 worktree + GATE_FAILED。
+- spawn 后手动补 `.runtime` 软链 → 与 worker 启动竞态，escalation 阻塞；spawn 时传 `--python-runtime-symlink`。
+- 验收 diff 对着当前 origin/main 而非 fork point → stale-base 假删除（G37）。
+- 收口清理遇 "external terminal close failed" 直接跳过 → 重试 clean-worktree（terminal 状态常在首次尝试后收敛）。
+- 把 Autopilot 策略写进 skill 或 PM 记忆而非项目任务源 → 授权与策略不可审计、换会话即漂移。

--- a/skills/multi-agent-orchestration/references/14-wave-autopilot.md
+++ b/skills/multi-agent-orchestration/references/14-wave-autopilot.md
@@ -1,6 +1,6 @@
 # Wave Autopilot：用户授权的波次自动推进
 
-适用：用户显式授权后，PM 在固定策略内自动执行「组波 → 派单 → 监控 → 验收 → 合并 → 写回 → 组下一波」，链式推进直到泊车条件。badminton-lab Wave 4—5（2026-08-26，PR #21—#25）为首次完整落地的两波 + 泊车实战，本参考全部内容与该实战一一对应。
+适用：用户显式授权后，PM 在固定策略内自动执行「组波 → 派单 → 监控 → 验收 → 合并 → 写回 → 组下一波」，链式推进直到泊车条件。badminton-lab Wave 4—5（2026-08-26，PR #21—#25）为首次完整落地的两波 + 泊车实战，§1—§7 与该实战一一对应；§8 是后续 Wave 6—7 持久化审计补充的能力边界。
 
 ## 1. 授权合同（先决条件）
 
@@ -29,7 +29,7 @@
 单一推送通道会丢。Autopilot 活跃期间必须同时具备三条通道：
 
 1. **Orca 推送唤醒**（主通道）：快，但**不可靠**——实测 worker_done 消息在队列里存在、对应系统唤醒从未送达，PM 停摆 6.6 小时直到用户人工戳。
-2. **recurring cron 看门狗**（强制）：session 级 recurring cron（建议 `4-59/20 * * * *` 这类避开整点/半点的间隔），每跳执行 §4 清单；泊车时 CronDelete 自删；7 天自动过期是天然兜底。session-only 即可（Autopilot 本就活在 PM 会话里，任务源是持久状态）。
+2. **recurring cron 看门狗**（强制）：session 级 recurring cron（建议 `4-59/20 * * * *` 这类避开整点/半点的间隔），每跳执行 §4 清单；泊车时删除自身。它是 live PM session 的低延迟 fast path，**不是跨会话持久性证明**；任务源保存策略/意图，不保存当前 Wave 的完整运行态。跨会话接管或无人值守要求读取 `references/15-autopilot-durability.md`。
 3. **Dispatch 状态轮询是完成权威**：`worker_done` 的 Delivery 可能不进 PM 待查队列（消息路由与 Dispatch 结算是两条路径）；`pm-orchestrate show` 的 `dispatch.status=completed` + `worker.state=succeeded/settled` 是可查证的完成事实。**队列无消息 ≠ 未完成；状态停滞 ≠ 完成**——两边都要主动查。
 
 ## 4. 看门狗每跳清单
@@ -45,7 +45,7 @@
 
 ## 5. 组波查表规则（模板；具体值落项目策略节）
 
-只派 `READY`；`DRAFT` 先派「晋级合同」任务（docs-only：合同文档 + 决策记录 + 任务源晋级写回），晋级后进后续波次实现。泳道互斥、同泳道串行（上一任务合并进 origin/main 后才派下一个）。每波 ≤N worker（默认 3），文件所有权必须正交。并行任务共写共享文档（决策记录/任务源/CHANGELOG）时**编号预分配**防撞号。review/收口发现的缺口先登记新卡再入波。实现本身被用户输入卡住的任务（需真实样本/环境/授权）不烧晋级合同，直接泊车。
+只派 `READY`；`DRAFT` 先派「晋级合同」任务：worker 只产出任务专属合同文档和结构化 writeback proposal，PM/维护者验收后串行写入决策记录和任务源，再进入后续波次实现。泳道互斥、同泳道串行（上一任务合并进 origin/main 后才派下一个）。每波 ≤N worker（默认 3），文件所有权必须正交。`TASKS/DECISIONS/AGENTS/ROADMAP` 等 shared context 默认只有一个 PM writer；DEC/Task 编号预分配只分配标识，不授权并发写共享文档。review/收口发现的缺口由 PM 登记新卡再入波。实现本身被用户输入卡住的任务（需真实样本/环境/授权）不烧晋级合同，直接泊车。
 
 ## 6. 验收期确定性缺陷的处置（实战模式）
 
@@ -66,3 +66,15 @@ PM 复跑门禁**确定性失败**（≥2 次同点，先排除 flake）→ 不�
 - 验收 diff 对着当前 origin/main 而非 fork point → stale-base 假删除（G37）。
 - 收口清理遇 "external terminal close failed" 直接跳过 → 重试 clean-worktree（terminal 状态常在首次尝试后收敛）。
 - 把 Autopilot 策略写进 skill 或 PM 记忆而非项目任务源 → 授权与策略不可审计、换会话即漂移。
+
+## 8. 当前能力边界与升级路径
+
+本文覆盖 `L1 / LIVE_SESSION_AUTOPILOT`：活跃 PM 会话内自动链式推进，session cron 补偿推送丢失。以下任一要求出现时，本文清单不够，必须进入持久控制面：
+
+- PM 会话退出/迁移后由新 PM 确定性接管；
+- 两个 PM 并发启动时防重复组波与 mutation；
+- 没有活跃聊天会话时仍由外部 scheduler 唤醒；
+- 429/额度重置后按 `retry_at` 自动 soft park/resume；
+- PR、Dispatch、worktree 与任务源漂移后自动对账写回。
+
+目标 runtime schema、PM lease/fencing、幂等 reconcile、shared-context 单写者和故障注入门禁见 `references/15-autopilot-durability.md`。Task-066 完成前必须标记 `AUTOPILOT_L2_CONTROLLER_NOT_IMPLEMENTED`；Task-067 完成前必须标记 `AUTOPILOT_L3_SCHEDULER_NOT_IMPLEMENTED`。不得把 session cron、Markdown 任务源或 provider lease 单独描述成持久控制器。

--- a/skills/multi-agent-orchestration/references/15-autopilot-durability.md
+++ b/skills/multi-agent-orchestration/references/15-autopilot-durability.md
@@ -1,0 +1,260 @@
+# Autopilot 持久化控制面：跨会话状态、租约、对账与恢复
+
+适用：项目已经按 `references/14-wave-autopilot.md` 跑通 live PM session 内的 Wave Autopilot，且用户要求“PM 会话退出、机器重启或换 Agent 后仍可恢复”“尽量少人工介入”时。本文定义目标控制面和验收，不表示对应 controller/scheduler 已经实现。
+
+当前发布边界：v2.8.1 只提供设计与任务合同。Task-066 完成并通过故障注入前报告 `AUTOPILOT_L2_CONTROLLER_NOT_IMPLEMENTED`；Task-067 完成并通过故障注入前报告 `AUTOPILOT_L3_SCHEDULER_NOT_IMPLEMENTED`。Task-066 交付 L2 后应停止报告前一个标记，但仍保留 L3 标记，直到外部 scheduler 真正交付。
+
+## 1. 为什么 reference 14 不等于持久控制器
+
+reference 14 已解决 live-session 的核心纪律：项目侧授权/策略、三通道监控、Dispatch 完成权威、最终树验收、safe-push/PR/squash、fix-worker 和 fail-closed 泊车。它仍依赖一个活着的 PM 会话理解策略、维护 recurring cron、记住当前 Wave 并执行下一步。
+
+以下机制都不能单独提供跨会话持久性：
+
+- 项目 `TASKS.md`：保存任务意图与状态，不保存当前 PM owner、attempt、Dispatch、PR、retry 时间和唯一 next action；
+- session recurring cron：会话关闭或迁移后不再是可靠调度源；
+- Orca Run/Task/Dispatch：保存执行事实，不知道项目任务源语义、PR 门禁和写回是否完成；
+- provider lease：限制 backend 并发，不阻止两个 PM 同时组同一 Wave；
+- Git worktree/branch：保存代码，不知道 worker 是否仍活跃或是否允许重派；
+- 消息队列：推送可能丢失，且消息存在与 Dispatch 结算是两条路径。
+
+因此需要一个薄控制面把这些事实对账成幂等状态转换，而不是继续增加自然语言提醒。
+
+## 2. 能力等级与声明边界
+
+| 等级 | 能力 | 最低证据 |
+|---|---|---|
+| `L0 / MANUAL_WAVE` | 每波由用户/PM 手动发车 | 项目任务源与单波验收 |
+| `L1 / LIVE_SESSION_AUTOPILOT` | 活跃 PM 会话内自动链式推进；session cron 补偿推送丢失 | reference 14 三通道 + 完整 Wave |
+| `L2 / CROSS_SESSION_RECOVERABLE` | 新 PM 能接管旧 Wave，不重复 mutation | runtime ledger + PM lease/fencing + reconcile 故障注入 |
+| `L3 / UNATTENDED_DURABLE` | 无活跃聊天会话时，外部 scheduler 可定时唤醒、恢复和 soft park/resume | L2 + durable scheduler + provider/reset/重启演练 |
+
+禁止从 `L1` 文档、一次 cron 触发或 happy-path Wave 推导 `L2/L3`。
+
+## 3. 事实源分层
+
+### 3.1 项目策略层（Git 跟踪）
+
+项目继续负责：
+
+- 用户授权范围、撤销方式与泊车条件；
+- 当前任务源、READY/DRAFT/依赖与泳道；
+- 每波最大并发、允许 backend/profile 与安全规则；
+- 项目测试门禁、PR/merge/写回规则；
+- 重要取舍与重新评估条件。
+
+通用 Skill 不复制项目授权，也不从 Roadmap 自由发明任务。
+
+### 3.2 运行状态层（Git common dir）
+
+推荐可信根：
+
+```text
+$(git rev-parse --git-common-dir)/orchestration/autopilot/
+├── state.json
+├── events.jsonl
+├── lease.json
+└── lock
+```
+
+理由：同仓所有 worktree 可见、不会进入 PR、能复用现有 provider lease 的路径/锁/原子写入安全惯例。普通项目文件、Session Context 与 worker worktree 都不是合适的单一 runtime root。
+
+运行态不得保存：Token、完整环境变量、settings 内容、用户媒体路径、案件/客户敏感信息、完整 transcript 或模型输出正文。
+
+### 3.3 外部事实层
+
+- Orca：Run、Task、Dispatch、worker/resource state；
+- Git：worktree、branch、fork point、commit、dirty state；
+- GitHub：PR、checks、review、mergedAt；
+- scheduler：last tick、next tick、job identity；
+- project task source：任务状态与允许的下一组合。
+
+controller 只做对账和受限 mutation，不把外部事实复制成另一个不可校验的真相。
+
+## 4. 最小 runtime schema
+
+```json
+{
+  "schema_version": 1,
+  "project_id": "<stable-repo-id>",
+  "policy_commit": "<git-oid>",
+  "wave_id": "wave-<n>",
+  "run_id": "run_<id>",
+  "state": "RUNNING",
+  "pm_owner": "<stable-owner-id>",
+  "fencing_token": 7,
+  "lease_expires_at": "<rfc3339>",
+  "last_tick_at": "<rfc3339>",
+  "last_event_id": "<monotonic-id>",
+  "items": [
+    {
+      "task_id": "<project-task-id>",
+      "attempt": 1,
+      "branch": "<branch>",
+      "worktree": "<resolved-path>",
+      "dispatch_id": "ctx_<id>",
+      "provider": "<backend/profile>",
+      "pr_number": null,
+      "last_heartbeat_at": "<rfc3339>",
+      "retry_at": null,
+      "next_action": "inspect_dispatch"
+    }
+  ],
+  "parking_code": null,
+  "parking_detail": null
+}
+```
+
+要求：
+
+- schema 版本化，未知未来版本 fail-closed；
+- JSON 通过临时文件 + fsync + atomic rename 写入；事件追加带单调 id；
+- 所有路径 resolve 后校验属于预期 repo/worktree root；
+- `policy_commit` 变化时先 reconcile，不沿用旧策略静默 spawn；
+- 每个外部 mutation 写入 attempt、before/after fact 与 fencing token，便于重放和去重。
+
+## 5. PM lease 与 fencing
+
+PM lease 与 provider lease 是两个维度：
+
+| Lease | 限制对象 | 保护的 mutation |
+|---|---|---|
+| provider lease | backend/profile 并发槽 | worker 资源创建与配额 |
+| PM lease | 单项目 Autopilot owner | 组波、spawn、push、merge、writeback、park/resume |
+
+规则：
+
+1. lease 获取/续期在同一 lock 下原子执行；
+2. 每次新 owner 接管递增 `fencing_token`；
+3. 所有 mutation 在执行前和提交后都核对 token；旧 owner 即使恢复也只能只读；
+4. lease 过期不等于旧 mutation 安全，接管者先 reconcile 外部事实；
+5. owner 身份必须稳定可审计，不能只用会变化的 pane title 或自然语言 Agent 名；
+6. 无法确认现 owner liveness 时，默认拒绝强抢；显式 force takeover 必须带 reason 并保留事件。
+
+## 6. 幂等状态机
+
+```text
+IDLE → PLANNING → DISPATCHING → RUNNING → VERIFYING
+     → MERGING → WRITEBACK → COMPLETE → IDLE
+
+任一活动态 → WAITING_PROVIDER_RESET → 原活动态
+任一活动态 → PARKED_SOFT → 条件/时间满足后恢复
+任一活动态 → PARKED_HARD → 用户/维护者显式恢复
+任一活动态 → ERROR_RECONCILE_REQUIRED
+```
+
+每个 `tick` 最多执行一个外部 mutation；mutation 后重新读取事实。不得用“已经发过命令”代替“外部事实已经收敛”。
+
+典型去重键：
+
+- spawn：`project_id + wave_id + task_id + attempt`；
+- push：immutable local OID + remote branch；
+- PR：head branch + base branch；
+- merge：PR number + mergedAt/mergeCommit；
+- writeback：task id + merge commit + policy commit；
+- park/resume：state transition id。
+
+## 7. reconcile 固定顺序
+
+启动、新会话接管、定时 tick 与异常恢复统一执行：
+
+1. 读取并验证项目策略、runtime schema 与 repo identity；
+2. 获取/续期 PM lease，确认 fencing token；
+3. 枚举 Orca active Run/Task/Dispatch 与 resource；
+4. 枚举 Git worktree/branch/dirty/commit 和 GitHub open/merged PR/checks；
+5. 对照项目任务源与已完成索引；
+6. 对每个 item 输出唯一 action；
+7. 若存在冲突/unknown，进入 `ERROR_RECONCILE_REQUIRED` 或 park，不做清理；
+8. 否则只执行一个 action，记录 event，再从步骤 1 重读。
+
+允许的 action 词汇至少包括：
+
+```text
+adopt | observe | settle | verify | push | open_pr | merge |
+writeback | retry_later | reject_duplicate | soft_park | hard_park | complete
+```
+
+## 8. durable scheduler 与 session cron
+
+- session recurring cron：低延迟 fast path，负责当前活跃 PM 的 10—20 分钟巡检；泊车/完成时自删；
+- external durable scheduler：`L3` 权威唤醒源，独立于聊天会话，按 project id 调用 `reconcile/tick`；
+- 两者可以同时触发，因为 PM lease/fencing 与幂等 tick 必须消除重复副作用；
+- scheduler 只负责唤醒，不绕过项目授权、不自己解释 Task 标题、不直接 merge；
+- 创建、更新、暂停、删除和通知策略必须有宿主正式 API/CLI 合同，不能把一段 raw cron 字符串当成集成完成。
+
+若宿主只能唤醒会话、不能无会话启动任务，则最高只能声明 `L2`，不得包装成 `L3`。
+
+## 9. Provider 限流与 soft park
+
+429/额度重置使用显式状态：
+
+- 记录受影响 provider/profile、attempt、观测时间、可靠的 `retry_at` 来源；
+- 若项目策略允许且文件所有权/任务合同不变，可切换合法 fallback；
+- 所有允许 provider 都不可用时进入 `WAITING_PROVIDER_RESET` 或 `PARKED_SOFT`，不反复 spawn 消耗资源；
+- 到期恢复前重新读取 provider/resource/Dispatch 状态，不能假设旧 turn 已终止；
+- 无可靠 reset 时间时 hard park 或请求用户，不编造时间；
+- 成本上限、外部发送授权或 Provider Key 缺失始终是项目权限门，不因 Autopilot 扩张。
+
+## 10. shared context 单写者
+
+共享任务源/决策/项目规则是全局资源。推荐合同：
+
+1. worker 只拥有任务专属代码、合同、研究和测试；
+2. worker 在 Delivery/PR 描述中输出结构化 writeback proposal：目标 task、建议状态、证据、决策候选、未验证项；
+3. PM 独立验收后，在同一 worker branch 追加单独 writeback commit，或开串行 docs-only PR；
+4. 同一项目同时最多一个 shared-context writer；
+5. DEC/Task 编号预分配仍保留，但只解决标识分配，不再被当成并发写授权；
+6. reconcile 检查“PR 已合并但 writeback 未发生”和“writeback 先于合并/证据”两类漂移。
+
+项目若明确允许某个 contract worker 直接写 shared context，必须把它当作该 Wave 唯一 shared-context writer，而不是与其他合同 worker 并行。
+
+## 11. 故障分类
+
+| 类别 | 默认处置 |
+|---|---|
+| 推送/消息丢失 | 主动查 Dispatch；不重派 |
+| PM lease 冲突 | 非 owner 只读；报告 owner/token/expiry |
+| worker dead + Dispatch 未结算 | 走正式 settle，保留审计；不自动删脏 worktree |
+| PR merged + writeback missing | 生成一次幂等 writeback |
+| task source complete + PR 未合并 | `ERROR_RECONCILE_REQUIRED`，人工判定 |
+| branch/worktree 重复 | 通过去重键 adopt 或拒绝；不创建 `-2` 猜测 worktree |
+| checks unknown/failed | fail-closed；不 merge |
+| 全 provider 429 | soft park/retry_at；无可靠时间则 hard park |
+| policy commit 变化 | 停止 mutation，重新规划/对账 |
+| runtime 损坏或未来 schema | 只读导出证据，hard park；不自动重建覆盖 |
+
+## 12. 验收演练
+
+Task-066/067 不能只以 unit test 或一次 happy path 关闭，至少运行：
+
+1. RUNNING 中 kill PM，新 PM 接管旧 Dispatch，无重复 spawn；
+2. 两个 PM 同时 acquire，只有一个可 mutation；旧 fencing token 被拒绝；
+3. 丢弃所有 worker_done 唤醒，scheduler 在一个周期内发现 completed；
+4. 全 provider 429，写 `retry_at`、soft park、到期只恢复未完成 item；
+5. PR 已 merged、writeback 未做，reconcile 只补一次；
+6. shared-context writer 冲突在 spawn/commit 前被拒绝；
+7. 脏 worktree、unknown checks、无法解析 runtime 均 fail-closed 且不删除；
+8. 新 clone/换机安装固定 Skill 版本，项目策略一致，本机绝对 symlink 不参与正确性。
+
+验收记录必须包含 runtime before/after、fencing token、外部事实快照、执行 action 与无重复副作用证明。
+
+## 13. 实施任务
+
+本次审计落盘期间，另一轮 badminton-lab Wave 7 复盘已先登记三个 live-session DRAFT；为避免编号覆盖，本持久化整改从 Task-066 起排号。三个既有方向与本文的关系如下，公开记录其边界，避免它们只存在于 ignored-only 本地任务源：
+
+| 既有 Task | 方向 | 与持久控制面的关系 |
+|---|---|---|
+| `Task-063` | 判活信号分级：transcript 时间戳高于文件/commit 变化和静态 provider 横幅 | 提供 live-session observation 语义；Task-066 的 reconcile 复用，不重复定义 |
+| `Task-064` | 额度窗口 playbook、idle 注入与当前会话 one-shot 再唤醒 | 提供 429 当前会话处置；Task-067 把 `retry_at`/resume 提升为跨会话持久状态 |
+| `Task-065` | shared-doc 冲突的程序化提取/拼装与断言 | 仅作为历史并发写回的恢复工具候选；本文默认仍是 PM 单写者，工具不得反向授权并发写 shared context |
+
+### Task-066 — 持久 runtime core（READY）
+
+实现 runtime schema、原子 ledger/event log、PM lease/fencing、只读 `status`、幂等 `reconcile/tick` 与故障测试。范围只到 `L2`；不创建外部 scheduler，不自由解释项目 Roadmap，不自动删除资源。
+
+### Task-067 — durable scheduler 与 soft park（DRAFT）
+
+依赖 Task-066、Task-064 的 live-session 额度窗口/再唤醒结论和至少一个宿主正式调度合同。实现外部定时唤醒、job identity、暂停/删除、通知、provider `retry_at`/fallback/soft park/resume；宿主无法无会话执行时必须降级声明 L2。Task-064 解决当前会话内的判活与 one-shot 再唤醒，Task-067 只负责把它提升为可跨会话恢复的持久状态，不重复实现同一 playbook。
+
+### Task-068 — 跨会话协议收敛与可移植性回归（DRAFT）
+
+等待 Task-063 的 live-session 判活信号分级与 Task-065 的 shared-doc 冲突工具边界固定后，把 cron 模板与 supervised Dispatch-first 完成权威对齐；增加静态 lint 防 `STATUS/Sentinel` 冒充结算、防“session-only 即 durable”声明；验证 Skill 固定版本可在新 clone/新 worktree 被发现，公开 reference 不依赖 ignored-only 决策或本机绝对链接。Task-065 若继续实现，只能作为历史并发写回的恢复/拼装工具，不能放宽本文的 PM 单写者默认。


### PR DESCRIPTION
## 背景

badminton-lab Wave 4—7 证明现有 Wave Autopilot 能在活跃 PM 会话内连续推进，也暴露了跨会话恢复、双 PM 防重入、429 定时恢复和 shared-context 并发写回缺口。

## 变更

- 纳入此前尚未进入 origin/main 的 v2.7.1 与 v2.8.0 基线。
- 新增 v2.8.1：明确 L1/L2/L3 能力边界。
- 新增公开 reference 15，固定 runtime ledger、PM lease/fencing、幂等 reconcile、durable scheduler、soft park 和八项故障注入。
- shared context 改为 PM/维护者单写，worker 只交付任务专属产物与 writeback proposal。
- 同步 README、CHANGELOG、Skill 元数据和 Task-066—068 公开边界。

## 验证

- skill-creator quick_validate：PASS
- 引用可达、代码围栏、版本同步与 stale-rule 语义扫描：PASS
- git diff --check：PASS
- 独立文档复核：PASS

## 未实现边界

本 PR 只沉淀设计和任务合同，不实现 L2 controller 或 L3 scheduler；对应标识继续保留。