### PR TITLE
feat(multi-agent-orchestration): spawn 后 Dispatch 绑定自检与三步自动补绑(Task-076,CHANGELOG 2.9.1)

### DIFF
--- a/skills/multi-agent-orchestration/CHANGELOG.md
+++ b/skills/multi-agent-orchestration/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [2.9.1] - 2026-08-27
+
+### 修复
+
+- **spawn 后 Dispatch 绑定静默缺失的自动检测与补绑（Task-076）**：2026-08-27 三波实战（badminton-lab Wave17 bl-011-resume / Wave18 bl-012-contract / Wave19 双 worker）中，`orca-supervised-register.sh` 的 worker-start 成功拉起 TUI 并注入任务，但 Orca 不识别终端内 agent（`agent_unconfigured` / no recognized agent 家族）导致 Dispatch 未绑——Task 停 [ready]、`dispatch-show --task` 为空、worker_done 无通道，此前只能靠 PM 人肉发现并按 runbook #18 三步补绑。现在 worker-start 后主动 `dispatch-show --task` 核对；receipt 与 dispatch-show 均为空时自动执行补绑三步（无 `--inject` 的 dispatch 建绑定 → 从响应/preamble 提取真实 ctx id，多 id 歧义宁拒不猜 → 单行 terminal send 注入 worker_done/ask 精确命令形式，多行文本会在 TUI 提前回车），并以 `ORCAREG_DISPATCH_BIND=ok|manual-required` 汇报；`manual-required` 不再以 exit 1 阻断 spawn（terminal/任务注入已生效），改为显式告警 + WARN 打印手动三步。
+- `spawn-worker-launch.sh` 消费绑定结果：SPAWN 输出新增 `SPAWN_WORKER_DISPATCH_BIND: ok|manual-required` 行；METADATA `session.orca.supervised` 新增 `dispatch_bind` 字段，`manual-required` 时仍写入 run/task/coordinator（PM 手动补绑的输入），空 `dispatch_id` 下 pm-orchestrate 自动按 terminal-managed 路由。
+
+### 同步
+
+- SKILL.md §3 硬约束与 §4.6 看门狗各补一行（DISPATCH_BIND 行纳入 spawn receipt/每跳巡检）；`references/13` §10 METADATA 契约示例补 `dispatch_bind` 字段。
+- `test-spawn-worker-orca.sh` 新增 4 个 Task-076 用例（`ORCA_CLI_COMMAND` fake CLI 子进程跑 register）：健康路径不触发补绑、dispatch-show 空自动补绑 ok（含无 `--inject` 与单行注入断言）、补绑失败 manual-required 不阻断、绑定成功但注入失败仍 manual-required；`test-spawn-worker-launch.sh` 断言 METADATA 新契约并新增 manual-required 不阻断 + run/task 保留用例。
+
 ## [2.9.0] - 2026-08-27
 
 ### 新增

--- a/skills/multi-agent-orchestration/SKILL.md
+++ b/skills/multi-agent-orchestration/SKILL.md
@@ -67,6 +67,7 @@ PM 在业务实现前完成：
 - 轻量模式下不同 worker 必须占用互不重叠的文件夹；可能写同一目录时回到 worktree 模式。
 - Worker 验证命令不是安装授权。缺工具时报告阻塞，除非 PM 传入精确 `--allow-install-command` 和 `--install-authorization-source`。
 - Worker 自报、STATUS、UI 卡片、TUI idle、heartbeat 和 timeout 都不能单独证明业务完成。
+- supervised spawn 收尾自检 dispatch 绑定（Task-076）：worker-start 后主动 `dispatch-show --task` 核对；为空时按 runbook #18 自动三步补绑（无 `--inject` 的 dispatch 建绑定 → 从 preamble 提取真实 ctx id → 单行 terminal send 注入 worker_done/ask 命令形式），SPAWN 输出必须含 `SPAWN_WORKER_DISPATCH_BIND: ok|manual-required`；`manual-required` 不阻断 spawn 但属显式告警，PM 须按同三步手动补绑。
 
 Issue 分组细则读取 `references/12-issue-grouping.md`；并发与真实踩坑读取 `references/10-parallel-lessons.md`。
 
@@ -245,7 +246,7 @@ bash scripts/pm-orchestrate.sh reauthorize --worktree "$WT" --session worker-a \
 
 用户显式授权后，PM 按项目任务源中固定的组波/泊车策略自动链式推进波次：收口后自动写回任务源、查表组下一波并派发，直到泊车条件。**授权与策略权威都在项目上下文**（本 skill 不承载项目授权）；查表查不到合法组合即泊车，这是 Autopilot fail-closed 的根本。验收路径不因自动化放宽（门禁在最终树复跑 + safe-push + PR squash 强制），每波收口发摘要但不等确认，泊车必须完整报告后停止。
 
-Autopilot 活跃期间**必须挂 recurring cron 看门狗**，并与 Orca 推送、Dispatch 状态轮询三通道并用——推送唤醒实测会丢（worker_done 可延迟数小时不唤醒 PM）；完成判定的权威是 `worker-show` 的 dispatch/worker 状态，不是队列里有没有消息。看门狗每跳清单、验收期确定性缺陷的 fix-worker 派发模式与实测反模式读取 `references/15-wave-autopilot.md`。已由同一 watcher 明确观察到额度受限时，才可用 `scripts/night-watch.sh --terminal <PM终端handle> --model <当前模型> --settings <provider/account 配置权威文件>` 守夜；自动唤醒拒绝可变 setting-sources，并冻结 settings 内容指纹。首次探测即成功、配置/认证/网络/未知错误、超时或 terminal 失败都不会唤醒。真实 PM 终端的 `quota → available → send → PM 被唤醒` 仍标记 `NOT_VERIFIED`，流程见 `references/15-wave-autopilot.md` §8。
+Autopilot 活跃期间**必须挂 recurring cron 看门狗**，并与 Orca 推送、Dispatch 状态轮询三通道并用——推送唤醒实测会丢（worker_done 可延迟数小时不唤醒 PM）；完成判定的权威是 `worker-show` 的 dispatch/worker 状态，不是队列里有没有消息。看门狗每跳清单、验收期确定性缺陷的 fix-worker 派发模式与实测反模式读取 `references/15-wave-autopilot.md`。已由同一 watcher 明确观察到额度受限时，才可用 `scripts/night-watch.sh --terminal <PM终端handle> --model <当前模型> --settings <provider/account 配置权威文件>` 守夜；自动唤醒拒绝可变 setting-sources，并冻结 settings 内容指纹。首次探测即成功、配置/认证/网络/未知错误、超时或 terminal 失败都不会唤醒。真实 PM 终端的 `quota → available → send → PM 被唤醒` 仍标记 `NOT_VERIFIED`，流程见 `references/15-wave-autopilot.md` §8。每跳巡检同时核对各 worker spawn receipt 的 `SPAWN_WORKER_DISPATCH_BIND` 行：`manual-required`（Task-076 自动补绑未完成）须立即按 runbook #18 三步手动补绑，不要等 worker_done 缺失才暴露。
 
 ## 5. tmux 回退
 

--- a/skills/multi-agent-orchestration/references/13-orca-cli-worker.md
+++ b/skills/multi-agent-orchestration/references/13-orca-cli-worker.md
@@ -202,6 +202,7 @@ Orca terminal 对 `--command` 是开放的，但 `spawn-worker.sh` 只允许 Cla
         "coordinator_handle": "term_pm_xxx",
         "task_id": "task_xxx",
         "dispatch_id": "ctx_xxx",
+        "dispatch_bind": "ok",
         "contract": "orca.orchestration.contract.v1",
         "completion_authority": "worker_done",
         "terminal_ownership": "external"
@@ -211,4 +212,4 @@ Orca terminal 对 `--command` 是开放的，但 `spawn-worker.sh` 只允许 Cla
 }
 ```
 
-无 `supervised` 子块就只能按 terminal-managed 处理。Handle 是 runtime-scoped；Run/Task/Dispatch 是结构化协调身份，不要互相替代。
+无 `supervised` 子块就只能按 terminal-managed 处理。`dispatch_bind`（Task-076）记录 spawn 收尾自检结果：`ok` 或 `manual-required`（自动补绑未完成，dispatch_id 可为空——空时 pm-orchestrate 按 terminal-managed 路由，run/task id 是 PM 手动三步补绑的输入）。Handle 是 runtime-scoped；Run/Task/Dispatch 是结构化协调身份，不要互相替代。

--- a/skills/multi-agent-orchestration/scripts/orca-supervised-register.sh
+++ b/skills/multi-agent-orchestration/scripts/orca-supervised-register.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # Register an existing Orca agent terminal into one supervised Run/Task/Dispatch.
 # worker-start is the only prompt injector on this path.
+#
+# Task-076：worker-start 成功后的 Dispatch 绑定自检与自动补绑。
+# Run/Task/worker-start 阶段失败仍然 exit 1 fail-loud；仅「dispatch 绑定缺失」
+# （worker-start 成功、receipt 与 dispatch-show 均无 id）改为自动补绑三步，
+# 并以 ORCAREG_DISPATCH_BIND=ok|manual-required 显式汇报，manual-required
+# 不再以 exit 1 阻断 spawn（terminal/任务注入已生效，阻断只会制造半活 worker）。
 
 set -euo pipefail
 
@@ -139,30 +145,96 @@ if ! start_out=$(worker_start_once); then
   fi
 fi
 
-# Prefer the mutation receipt. dispatch-show is a read-only exact recovery if a
-# runtime version omits the dispatch id from worker-start's response.
-DISPATCH_ID=$(printf '%s' "$start_out" | jq -r '
+# Task-076：worker-start 成功后的 Dispatch 绑定自检。
+# 2026-08-27 三波实战（badminton-lab Wave17/18/19）中，worker-start 拉起 TUI 并注入
+# 任务，但 Orca 不识别终端内 agent（agent_unconfigured / no recognized agent 家族）
+# 导致 Dispatch 未绑——Task 停 [ready]、dispatch-show --task 为空、worker_done 无通道。
+# 该缺口此前只能靠 PM 人肉发现并按 runbook #18 三步补绑；现在 spawn 收尾主动核对，
+# 为空时自动补绑，并把结果以 ORCAREG_DISPATCH_BIND=ok|manual-required 汇报给调用方。
+DISPATCH_BIND="ok"
+receipt_id=$(printf '%s' "$start_out" | jq -r '
   .result.dispatch.id
   // .result.worker.dispatch.id
   // .result.dispatchId
   // .result.worker.dispatchId
-  // empty' 2>/dev/null)
-if [ -z "$DISPATCH_ID" ]; then
-  dispatch_out=$(orca_cli orchestration dispatch-show --task "$TASK_ID" --json 2>&1) || {
-    echo "ERROR: worker-start succeeded but dispatch-show failed: $dispatch_out" >&2; exit 1; }
-  DISPATCH_ID=$(printf '%s' "$dispatch_out" | jq -r '
+  // empty' 2>/dev/null || true)
+# 主动只读核对（旧 runtime 缺 dispatch-show 子命令时容错为空，不阻断）。
+show_out=$(orca_cli orchestration dispatch-show --task "$TASK_ID" --json 2>&1) || show_out=""
+show_id=$(printf '%s' "$show_out" | jq -r '
+  .result.dispatch.id
+  // .result.dispatch.dispatchId
+  // .result.dispatchId
+  // empty' 2>/dev/null || true)
+if [ -n "$show_id" ]; then
+  DISPATCH_ID="$show_id"
+  if [ -n "$receipt_id" ] && [ "$receipt_id" != "$show_id" ]; then
+    echo "WARN: worker-start receipt dispatch ($receipt_id) differs from dispatch-show ($show_id); using dispatch-show as canonical" >&2
+  fi
+elif [ -n "$receipt_id" ]; then
+  DISPATCH_ID="$receipt_id"
+  echo "ORCAREG_DISPATCH_SHOW_EMPTY: dispatch-show 未回显 id，按 worker-start mutation receipt 采信: $receipt_id" >&2
+else
+  # 绑定缺失：按 runbook #18 自动补绑三步。
+  # ① dispatch 无 --inject 建绑定并返回 preamble（agent 不被识别时 --inject 会直接报错）
+  # ② 从响应/preamble 提取真实 ctx id ③ 单行 terminal send 注入 worker_done/ask 命令形式
+  echo "ORCAREG_DISPATCH_MISSING: worker-start 成功但 dispatch 绑定缺失（receipt 与 dispatch-show 均为空）；执行 runbook #18 三步自动补绑" >&2
+  rebind_out=""
+  rebind_out=$(orca_cli orchestration dispatch --task "$TASK_ID" --to "$TERMINAL_HANDLE" \
+    --run "$RUN_ID" --return-preamble 2>&1) || rebind_out=""
+  if [ -n "$rebind_out" ]; then
+    printf 'ORCAREG_DISPATCH_REBIND_RECEIPT: %s\n' "$rebind_out" >&2
+  fi
+  rebind_id=$(printf '%s' "$rebind_out" | jq -r '
     .result.dispatch.id
     // .result.dispatch.dispatchId
     // .result.dispatchId
-    // empty' 2>/dev/null)
+    // .result.worker.dispatch.id
+    // empty' 2>/dev/null || true)
+  if [ -z "$rebind_id" ]; then
+    # 响应可能不是 JSON（--return-preamble 文本形态）：从 preamble 提取 ctx id；
+    # 出现多个不同 ctx id 时视为歧义，宁拒不猜（PM 手动裁定）。
+    rebind_id=$(printf '%s' "$rebind_out" | grep -oE 'ctx_[A-Za-z0-9_-]+' | sort -u | sed -n '1p' || true)
+    rebind_unique=$(printf '%s' "$rebind_out" | grep -oE 'ctx_[A-Za-z0-9_-]+' | sort -u | wc -l | tr -d ' ' || true)
+    if [ "${rebind_unique:-0}" -gt 1 ]; then
+      echo "WARN: 补绑响应含 ${rebind_unique} 个不同 ctx id，拒绝猜测" >&2
+      rebind_id=""
+    fi
+  fi
+  verify_out=$(orca_cli orchestration dispatch-show --task "$TASK_ID" --json 2>&1) || verify_out=""
+  verify_id=$(printf '%s' "$verify_out" | jq -r '
+    .result.dispatch.id
+    // .result.dispatch.dispatchId
+    // .result.dispatchId
+    // empty' 2>/dev/null || true)
+  if [ -n "$verify_id" ]; then
+    DISPATCH_ID="$verify_id"
+  elif [ -n "$rebind_id" ]; then
+    DISPATCH_ID="$rebind_id"
+    echo "ORCAREG_DISPATCH_BIND_BY_RECEIPT: dispatch-show 二次核对仍未回显，按补绑响应采信: $rebind_id" >&2
+  else
+    DISPATCH_ID=""
+  fi
+  if [ -n "$DISPATCH_ID" ]; then
+    # 第三步：单行注入 worker_done/ask 精确命令形式。
+    # 必须单行：多行文本会在 TUI 里被提前回车逐行提交。
+    printf -v inject_text \
+      '[dispatch-bind 自动补绑] task_id=%s dispatch_id=%s。完成时精确执行一次: orca orchestration send --from %s --type worker_done --subject "worker 完成" --body "三句内摘要" --task-id %s --dispatch-id %s --outcome succeeded --files-modified "改动文件路径列表"。阻塞时: orca orchestration ask --from %s --question "阻塞问题" --timeout-ms 600000。其余仍按已注入任务执行。' \
+      "$TASK_ID" "$DISPATCH_ID" "$TERMINAL_HANDLE" "$TASK_ID" "$DISPATCH_ID" "$TERMINAL_HANDLE"
+    if orca_cli terminal send --terminal "$TERMINAL_HANDLE" --text "$inject_text" --enter --json >/dev/null 2>&1; then
+      echo "ORCAREG_DISPATCH_INJECTED: 已向 $TERMINAL_HANDLE 单行注入 worker_done/ask 命令形式" >&2
+    else
+      DISPATCH_BIND="manual-required"
+      echo "WARN: dispatch 已补绑($DISPATCH_ID)但命令形式注入失败；PM 需手动单行 terminal send 注入 worker_done 命令形式" >&2
+    fi
+  else
+    DISPATCH_BIND="manual-required"
+    echo "WARN: 自动补绑失败（dispatch mutation 无 id 且 dispatch-show 复核为空）。spawn 不阻断，但 worker_done 无通道。PM 手动三步补绑: ① orca orchestration dispatch --task $TASK_ID --to $TERMINAL_HANDLE --run $RUN_ID --return-preamble（不带 --inject，agent 不被识别时 --inject 会直接报错） ② 从返回 preamble 提取真实 ctx id ③ orca terminal send --terminal $TERMINAL_HANDLE --text \"<单行 worker_done/ask 命令形式>\" --enter（必须单行）。" >&2
+  fi
 fi
-[ -n "$DISPATCH_ID" ] || {
-  echo "ERROR: worker-start succeeded but no dispatch id was recoverable; inspect task $TASK_ID" >&2
-  exit 1
-}
 
-echo "ORCAREG_WORKER_REGISTERED: dispatch=$DISPATCH_ID" >&2
+echo "ORCAREG_WORKER_REGISTERED: dispatch=${DISPATCH_ID:-none} bind=$DISPATCH_BIND" >&2
 printf 'ORCAREG_RUN_ID=%s\n' "$RUN_ID"
 printf 'ORCAREG_COORDINATOR_HANDLE=%s\n' "$COORDINATOR_HANDLE"
 printf 'ORCAREG_TASK_ID=%s\n' "$TASK_ID"
 printf 'ORCAREG_DISPATCH_ID=%s\n' "$DISPATCH_ID"
+printf 'ORCAREG_DISPATCH_BIND=%s\n' "$DISPATCH_BIND"

--- a/skills/multi-agent-orchestration/scripts/spawn-worker-launch.sh
+++ b/skills/multi-agent-orchestration/scripts/spawn-worker-launch.sh
@@ -43,7 +43,7 @@ launch_worker_session() {
     # 但调用方不能把它误当成已编排 worker。
     if [ "$ORCA_SUPERVISED" -eq 1 ] && [ -n "$ORCA_TERMINAL_HANDLE" ]; then
       if [ "$DRY_RUN" -eq 1 ]; then
-        printf 'ORCA_RUN: reuse/create Run %q; coordinator=%q; task=%q; worker-start --terminal <handle> --worktree id:<worktree>\n' \
+        printf 'ORCA_RUN: reuse/create Run %q; coordinator=%q; task=%q; worker-start --terminal <handle> --worktree id:<worktree>; dispatch-bind self-check (Task-076: dispatch-show 核对, 为空时 runbook #18 三步自动补绑)\n' \
           "${ORCA_RUN_ID:-new-wave-run}" "${ORCA_COORDINATOR_HANDLE:-bind-once}" "${ORCA_TASK_ID:-create-from-spec:$TASK_SPEC}"
       else
         reg_helper="$SCRIPT_DIR/orca-supervised-register.sh"
@@ -73,12 +73,23 @@ launch_worker_session() {
             ORCA_SUPERVISED_COORDINATOR_HANDLE=$(printf '%s\n' "$reg_out" | sed -n 's/^ORCAREG_COORDINATOR_HANDLE=//p')
             ORCA_SUPERVISED_TASK_ID=$(printf '%s\n' "$reg_out" | sed -n 's/^ORCAREG_TASK_ID=//p')
             ORCA_SUPERVISED_DISPATCH_ID=$(printf '%s\n' "$reg_out" | sed -n 's/^ORCAREG_DISPATCH_ID=//p')
-            if [ -n "$ORCA_SUPERVISED_DISPATCH_ID" ] && [ -f "$METADATA_FILE" ]; then
+            # Task-076：dispatch 绑定自检结果（旧版 helper 无此 KV 时回退 ok，向后兼容）。
+            ORCA_SUPERVISED_DISPATCH_BIND=$(printf '%s\n' "$reg_out" | sed -n 's/^ORCAREG_DISPATCH_BIND=//p')
+            [ -n "$ORCA_SUPERVISED_DISPATCH_BIND" ] || ORCA_SUPERVISED_DISPATCH_BIND="ok"
+            printf 'SPAWN_WORKER_DISPATCH_BIND: %s\n' "$ORCA_SUPERVISED_DISPATCH_BIND" >&2
+            if [ "$ORCA_SUPERVISED_DISPATCH_BIND" != "ok" ]; then
+              # 不阻断 spawn（terminal/任务注入已生效），但显式告警代替静默缺失。
+              echo "WARN: dispatch 绑定自动补绑未完成(manual-required)：worker 已启动且任务已注入，但 worker_done 无通道。PM 按 runbook #18 三步手动补绑：① orca orchestration dispatch --task $ORCA_SUPERVISED_TASK_ID --to $ORCA_TERMINAL_HANDLE --run $ORCA_SUPERVISED_RUN_ID --return-preamble（不带 --inject）② 从 preamble 提取真实 ctx id ③ 单行 terminal send 注入 worker_done/ask 命令形式（必须单行）" >&2
+            fi
+            # dispatch_id 在 manual-required 时可为空：仍写入 supervised 块（run/task/coordinator
+            # 是 PM 手动补绑的输入），pm-orchestrate 对空 dispatch_id 自动按 terminal-managed 路由。
+            if [ -f "$METADATA_FILE" ]; then
               tmp_meta=$(mktemp)
               jq --arg run "$ORCA_SUPERVISED_RUN_ID" --arg coordinator "$ORCA_SUPERVISED_COORDINATOR_HANDLE" \
                 --arg task "$ORCA_SUPERVISED_TASK_ID" --arg disp "$ORCA_SUPERVISED_DISPATCH_ID" \
-                '.session.orca.supervised = {run_id: $run, coordinator_handle: $coordinator, task_id: $task, dispatch_id: $disp, contract: "orca.orchestration.contract.v1", completion_authority: "worker_done", terminal_ownership: "external"}' "$METADATA_FILE" > "$tmp_meta" && mv "$tmp_meta" "$METADATA_FILE"
-              echo "SPAWN_WORKER_ORCA_SUPERVISED_DONE: dispatch=$ORCA_SUPERVISED_DISPATCH_ID run=$ORCA_SUPERVISED_RUN_ID task=$ORCA_SUPERVISED_TASK_ID" >&2
+                --arg bind "$ORCA_SUPERVISED_DISPATCH_BIND" \
+                '.session.orca.supervised = {run_id: $run, coordinator_handle: $coordinator, task_id: $task, dispatch_id: $disp, dispatch_bind: $bind, contract: "orca.orchestration.contract.v1", completion_authority: "worker_done", terminal_ownership: "external"}' "$METADATA_FILE" > "$tmp_meta" && mv "$tmp_meta" "$METADATA_FILE"
+              echo "SPAWN_WORKER_ORCA_SUPERVISED_DONE: dispatch=${ORCA_SUPERVISED_DISPATCH_ID:-none} run=$ORCA_SUPERVISED_RUN_ID task=$ORCA_SUPERVISED_TASK_ID bind=$ORCA_SUPERVISED_DISPATCH_BIND" >&2
             fi
           else
             echo "SPAWN_WORKER_ORCA_SUPERVISED_FAILED: helper 退出非 0；保留 terminal 供 PM 检查，但不冒充 supervised worker" >&2

--- a/skills/multi-agent-orchestration/scripts/test-spawn-worker-launch.sh
+++ b/skills/multi-agent-orchestration/scripts/test-spawn-worker-launch.sh
@@ -150,15 +150,55 @@ printf '%s\n' \
   'printf "ORCAREG_COORDINATOR_HANDLE=term-pm\n"' \
   'printf "ORCAREG_TASK_ID=task-worker\n"' \
   'printf "ORCAREG_DISPATCH_ID=ctx-worker\n"' \
+  'printf "ORCAREG_DISPATCH_BIND=ok\n"' \
   > "$SCRIPT_DIR/orca-supervised-register.sh"
 printf '%s\n' '{"session":{"orca":{"terminal_handle":""}}}' > "$METADATA_FILE"
 launch_worker_session
 assert_eq "$ORCA_SUPERVISED_RUN_ID:$ORCA_SUPERVISED_COORDINATOR_HANDLE:$ORCA_SUPERVISED_TASK_ID:$ORCA_SUPERVISED_DISPATCH_ID" \
   "run-wave:term-pm:task-worker:ctx-worker" "supervised registration exports exact lifecycle ids"
-if jq -e '.session.orca.supervised == {run_id:"run-wave",coordinator_handle:"term-pm",task_id:"task-worker",dispatch_id:"ctx-worker",contract:"orca.orchestration.contract.v1",completion_authority:"worker_done",terminal_ownership:"external"}' "$METADATA_FILE" >/dev/null; then
+if jq -e '.session.orca.supervised == {run_id:"run-wave",coordinator_handle:"term-pm",task_id:"task-worker",dispatch_id:"ctx-worker",dispatch_bind:"ok",contract:"orca.orchestration.contract.v1",completion_authority:"worker_done",terminal_ownership:"external"}' "$METADATA_FILE" >/dev/null; then
   ok "supervised lifecycle contract is patched into metadata"
 else
   bad "supervised lifecycle contract is patched into metadata"
+fi
+
+# Task-076：dispatch 绑定 manual-required 不阻断 spawn，METADATA 保留 run/task 供 PM 手动补绑。
+reset_launch_case
+ORCA_MODE="auto"
+ORCA_SUPERVISED=1
+ORCA_RUN_ID="run-wave"
+ORCA_COORDINATOR_HANDLE="term-pm"
+ORCA_TASK_ID="task-worker"
+SCRIPT_DIR="$CASE_ROOT/register-manual"
+mkdir -p "$SCRIPT_DIR"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf "ORCAREG_RUN_ID=run-wave\n"' \
+  'printf "ORCAREG_COORDINATOR_HANDLE=term-pm\n"' \
+  'printf "ORCAREG_TASK_ID=task-worker\n"' \
+  'printf "ORCAREG_DISPATCH_ID=\n"' \
+  'printf "ORCAREG_DISPATCH_BIND=manual-required\n"' \
+  > "$SCRIPT_DIR/orca-supervised-register.sh"
+printf '%s\n' '{"session":{"orca":{"terminal_handle":""}}}' > "$METADATA_FILE"
+set +e
+manual_out=$(launch_worker_session 2>&1)
+manual_rc=$?
+set -e
+assert_eq "$manual_rc" "0" "manual-required dispatch bind does not block spawn"
+if printf '%s\n' "$manual_out" | grep -Fq 'SPAWN_WORKER_DISPATCH_BIND: manual-required'; then
+  ok "manual-required prints explicit SPAWN_WORKER_DISPATCH_BIND line"
+else
+  bad "manual-required prints explicit SPAWN_WORKER_DISPATCH_BIND line"
+fi
+if printf '%s\n' "$manual_out" | grep -Fq 'return-preamble'; then
+  ok "manual-required warning carries the runbook rebind recipe"
+else
+  bad "manual-required warning carries the runbook rebind recipe"
+fi
+if jq -e '.session.orca.supervised.dispatch_id == "" and .session.orca.supervised.dispatch_bind == "manual-required" and .session.orca.supervised.task_id == "task-worker"' "$METADATA_FILE" >/dev/null; then
+  ok "manual-required metadata keeps run/task ids with empty dispatch"
+else
+  bad "manual-required metadata keeps run/task ids with empty dispatch"
 fi
 
 reset_launch_case

--- a/skills/multi-agent-orchestration/scripts/test-spawn-worker-orca.sh
+++ b/skills/multi-agent-orchestration/scripts/test-spawn-worker-orca.sh
@@ -372,5 +372,171 @@ else
   bad "entrypoint delegates Orca helpers without retaining definitions"
 fi
 
+# --- Task-076：supervised dispatch 绑定自检与自动补绑 ---
+# 以 ORCA_CLI_COMMAND 指向 fake CLI，子进程运行 orca-supervised-register.sh，
+# mock「worker-start 成功但 dispatch-show 为空」的实战事故形态。
+FAKE_ORCA_BIN="$CASE_ROOT/fake-orca"
+FAKE_ORCA_STATE="$CASE_ROOT/fake-orca-state"
+FAKE_ORCA_LOG="$CASE_ROOT/fake-orca-calls.log"
+FAKE_ORCA_SENDS="$CASE_ROOT/fake-orca-sends.log"
+# fake CLI 作为 register 子进程的孙进程运行，状态/日志路径必须导出
+export FAKE_ORCA_STATE FAKE_ORCA_LOG FAKE_ORCA_SENDS
+cat > "$FAKE_ORCA_BIN" <<'SH'
+#!/usr/bin/env bash
+# fake orca CLI：由 $FAKE_ORCA_STATE 状态文件驱动 canned 响应
+state="${FAKE_ORCA_STATE:?}"
+printf '%s\n' "$*" >> "${FAKE_ORCA_LOG:?}"
+case "$1 $2" in
+  "orchestration run-create")
+    printf '%s\n' '{"result":{"run":{"id":"run-1","coordinator_handle":"term-pm"}}}' ;;
+  "orchestration task-create")
+    printf '%s\n' '{"result":{"task":{"id":"task-1"}}}' ;;
+  "orchestration worker-start")
+    if [ -f "$state/worker-start-has-dispatch" ]; then
+      printf '%s\n' '{"result":{"worker":{"dispatch":{"id":"ctx-healthy"}}}}'
+    else
+      # 实战事故形态：worker-start 成功（TUI 拉起、任务注入）但响应无 dispatch id
+      printf '%s\n' '{"result":{"worker":{"started":true}}}'
+    fi ;;
+  "orchestration dispatch-show")
+    if [ -f "$state/worker-start-has-dispatch" ]; then
+      printf '%s\n' '{"result":{"dispatch":{"id":"ctx-healthy"}}}'
+    elif [ -f "$state/rebound" ]; then
+      printf '%s\n' "{\"result\":{\"dispatch\":{\"id\":\"$(cat "$state/dispatch-id" 2>/dev/null || echo ctx-auto)\"}}}"
+    else
+      printf '%s\n' '{"result":{}}'
+    fi ;;
+  "orchestration dispatch")
+    if [ -f "$state/dispatch-fails" ]; then
+      echo "ERROR: dispatch mutation failed" >&2
+      exit 1
+    fi
+    printf '%s\n' "ctx-auto" > "$state/dispatch-id"
+    touch "$state/rebound"
+    # 混合形态：JSON + preamble 文本（真实 --return-preamble 可能非纯 JSON）
+    printf '%s\n' '{"result":{"dispatch":{"id":"ctx-auto"},"preamble":"live preamble dispatch_id=ctx-auto task=task-1"}}' ;;
+  "terminal send")
+    if [ -f "$state/inject-fails" ]; then
+      echo "ERROR: terminal send failed" >&2
+      exit 1
+    fi
+    printf '%s\n' "$*" >> "$FAKE_ORCA_SENDS"
+    printf '%s\n' '{"result":{"ok":true}}' ;;
+  *) exit 1 ;;
+esac
+SH
+chmod +x "$FAKE_ORCA_BIN"
+
+reset_dispatch_case() {
+  rm -rf "$FAKE_ORCA_STATE"
+  mkdir -p "$FAKE_ORCA_STATE"
+  : > "$FAKE_ORCA_LOG"
+  : > "$FAKE_ORCA_SENDS"
+}
+
+run_register_helper() {
+  ORCA_CLI_COMMAND="$FAKE_ORCA_BIN" \
+    bash "$SCRIPT_DIR/orca-supervised-register.sh" \
+    --worktree-id "repo-1::worker" \
+    --terminal-handle "term-worker" \
+    --task-spec "do the thing" "$@"
+}
+
+# 用例 1（健康路径）：worker-start receipt 即含 dispatch id → 自检直接 ok，不触发补绑
+reset_dispatch_case
+touch "$FAKE_ORCA_STATE/worker-start-has-dispatch"
+set +e
+run_register_helper > "$CASE_ROOT/t76-healthy.out" 2> "$CASE_ROOT/t76-healthy.err"
+healthy_rc=$?
+set -e
+assert_eq "$healthy_rc" "0" "Task-076 healthy registration exits 0"
+assert_eq "$(sed -n 's/^ORCAREG_DISPATCH_ID=//p' "$CASE_ROOT/t76-healthy.out")" "ctx-healthy" \
+  "Task-076 healthy path keeps canonical dispatch id"
+assert_eq "$(sed -n 's/^ORCAREG_DISPATCH_BIND=//p' "$CASE_ROOT/t76-healthy.out")" "ok" \
+  "Task-076 healthy path reports bind ok"
+if grep -Eq 'dispatch .*--return-preamble' "$FAKE_ORCA_LOG"; then
+  bad "Task-076 healthy path must not trigger rebind mutation"
+else
+  ok "Task-076 healthy path must not trigger rebind mutation"
+fi
+if grep -Fq 'dispatch-show' "$FAKE_ORCA_LOG"; then
+  ok "Task-076 self-check actively calls dispatch-show after worker-start"
+else
+  bad "Task-076 self-check actively calls dispatch-show after worker-start"
+fi
+
+# 用例 2（实战事故形态）：receipt 与 dispatch-show 均空 → 三步自动补绑成功
+reset_dispatch_case
+set +e
+run_register_helper > "$CASE_ROOT/t76-rebind.out" 2> "$CASE_ROOT/t76-rebind.err"
+rebind_rc=$?
+set -e
+assert_eq "$rebind_rc" "0" "Task-076 auto rebind registration exits 0"
+assert_eq "$(sed -n 's/^ORCAREG_DISPATCH_ID=//p' "$CASE_ROOT/t76-rebind.out")" "ctx-auto" \
+  "Task-076 auto rebind recovers real ctx id"
+assert_eq "$(sed -n 's/^ORCAREG_DISPATCH_BIND=//p' "$CASE_ROOT/t76-rebind.out")" "ok" \
+  "Task-076 auto rebind reports bind ok"
+rebind_call=$(grep -E 'dispatch .*--return-preamble' "$FAKE_ORCA_LOG" | head -1)
+if [ -n "$rebind_call" ]; then
+  ok "Task-076 rebind dispatch mutation is invoked"
+else
+  bad "Task-076 rebind dispatch mutation is invoked"
+fi
+if printf '%s' "$rebind_call" | grep -Fq -- '--inject'; then
+  bad "Task-076 rebind must not pass --inject (agent-unrecognized runbook rule)"
+else
+  ok "Task-076 rebind must not pass --inject (agent-unrecognized runbook rule)"
+fi
+if grep -Fq 'ORCAREG_DISPATCH_MISSING' "$CASE_ROOT/t76-rebind.err"; then
+  ok "Task-076 missing binding is reported loudly, never silent"
+else
+  bad "Task-076 missing binding is reported loudly, never silent"
+fi
+send_lines=$(wc -l < "$FAKE_ORCA_SENDS" | tr -d ' ')
+assert_eq "$send_lines" "1" "Task-076 rebind injects exactly one single-line send"
+if grep -Fq 'ctx-auto' "$FAKE_ORCA_SENDS" && grep -Fq -- '--type worker_done' "$FAKE_ORCA_SENDS" \
+  && grep -Fq -- '--task-id task-1' "$FAKE_ORCA_SENDS" && grep -Fq -- '--from term-worker' "$FAKE_ORCA_SENDS" \
+  && grep -Fq -- 'orchestration ask' "$FAKE_ORCA_SENDS"; then
+  ok "Task-076 injected line carries dispatch id and worker_done/ask command forms"
+else
+  bad "Task-076 injected line carries dispatch id and worker_done/ask command forms"
+fi
+
+# 用例 3（补绑 mutation 失败）：manual-required + 显式告警 + 不阻断（exit 0）
+reset_dispatch_case
+touch "$FAKE_ORCA_STATE/dispatch-fails"
+set +e
+run_register_helper > "$CASE_ROOT/t76-manual.out" 2> "$CASE_ROOT/t76-manual.err"
+manual_rc=$?
+set -e
+assert_eq "$manual_rc" "0" "Task-076 failed rebind does not block spawn (exit 0)"
+assert_eq "$(sed -n 's/^ORCAREG_DISPATCH_BIND=//p' "$CASE_ROOT/t76-manual.out")" "manual-required" \
+  "Task-076 failed rebind reports manual-required"
+assert_eq "$(sed -n 's/^ORCAREG_DISPATCH_ID=//p' "$CASE_ROOT/t76-manual.out")" "" \
+  "Task-076 failed rebind leaves dispatch id empty"
+if grep -Fq 'return-preamble' "$CASE_ROOT/t76-manual.err"; then
+  ok "Task-076 manual-required warning prints the three-step recipe"
+else
+  bad "Task-076 manual-required warning prints the three-step recipe"
+fi
+if [ -s "$FAKE_ORCA_SENDS" ]; then
+  bad "Task-076 failed rebind must not inject protocol line"
+else
+  ok "Task-076 failed rebind must not inject protocol line"
+fi
+
+# 用例 4（绑定成功但注入失败）：dispatch id 已知，bind 仍判 manual-required
+reset_dispatch_case
+touch "$FAKE_ORCA_STATE/inject-fails"
+set +e
+run_register_helper > "$CASE_ROOT/t76-inject.out" 2> "$CASE_ROOT/t76-inject.err"
+inject_rc=$?
+set -e
+assert_eq "$inject_rc" "0" "Task-076 injection failure does not block spawn (exit 0)"
+assert_eq "$(sed -n 's/^ORCAREG_DISPATCH_ID=//p' "$CASE_ROOT/t76-inject.out")" "ctx-auto" \
+  "Task-076 injection failure still exports recovered dispatch id"
+assert_eq "$(sed -n 's/^ORCAREG_DISPATCH_BIND=//p' "$CASE_ROOT/t76-inject.out")" "manual-required" \
+  "Task-076 injection failure reports manual-required"
+
 printf 'spawn-worker Orca helper tests: %s passed, %s failed\n' "$passed" "$failed"
 [ "$failed" -eq 0 ]


### PR DESCRIPTION
## Task-076 交付(worker skill-task076)

- orca-supervised-register.sh:worker-start 后主动 dispatch-show 自检;receipt 与 dispatch-show 均空→按 runbook#18 三步自动补绑(无 --inject dispatch→preamble 提取真实 ctx id→单行注入);ORCAREG_DISPATCH_BIND=ok|manual-required,manual-required 不阻断 spawn
- spawn-worker-launch.sh:输出 SPAWN_WORKER_DISPATCH_BIND 行;METADATA.supervised 增 dispatch_bind 字段
- SKILL.md §3/§4.6、references/13、CHANGELOG 2.9.1 同步
- 用例:orca 套件 +4(健康路径不触发/自动补绑 ok/补绑失败 manual-required 不阻断/注入失败仍导出 id),launch 套件 +manual-required 契约断言
- PM 代跑验证:bash -n ×4 全 0;test-spawn-worker-orca 62/62;test-spawn-worker-launch 20/20
- NOT_VERIFIED:真实 Orca spawn 的 DISPATCH_BIND 行观察留 badminton-lab 下一波首 worker 实测(今晚 dispatch 缺口连现 4 次为本任务背景)