### PR TITLE
feat(multi-agent-orchestration): Task-080 守夜 v2 协议+DEC 预分配纪律(2026-08-29 复盘)

### DIFF
--- a/skills/multi-agent-orchestration/CHANGELOG.md
+++ b/skills/multi-agent-orchestration/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.9.2.1] - 2026-08-29
+
+- **守夜 v2 实战协议固化**(Task-080):新模板 `scripts/night-revive-timer.sh`(7 参数 fail-closed+`--repeat/--until` 打摆复活+`nohup caffeinate -dis` 脱链)与 `templates/workers.tsv.example`;SKILL.md §4.6 增四铁律(通道自测/双读核活法含游标推进法/硬死vs拥塞诊断树/task-list 完成权威)。
+- **§3.3 增第 5 条**:DEC 编号预分配纪律(wave manifest 必须显式预分配号或禁止新增;2026-08-28 三波撞号教训)。
+
 ## [2.9.2] - 2026-08-28
 
 ### 修复

--- a/skills/multi-agent-orchestration/SKILL.md
+++ b/skills/multi-agent-orchestration/SKILL.md
@@ -107,6 +107,7 @@ spawn 一个 worker 后，PM 的操作纪律（Wave-2 实战撞坑固化）：
 2. **Wave 先建完整控制面，再并行启动**（Task-043/050）：用 `orca-wave-prepare.sh` 一次创建/绑定 Run，并在任何 worker 启动前串行创建全部独立 Task；receipt 固化 `run_id`、`coordinator_handle` 和各 `task_id`。不要重试 `run-create`，也不要让并发 spawn 各自 `run-use/task-create`，否则会触发 consumer fencing 或重复 Task。
 3. **supervised worker 不用 pm-monitor/sentinel 判完成**（Task-041）：supervised 完成唯一权威是 `worker_done → Delivery`（`pm-orchestrate show/wait` 读 dispatch + Delivery）。`pm-monitor`（STATUS/commit-stale）和 `sentinel`（tui-idle/timeout）的信号不是 supervised 完成权威——`STATUS=done` ≠ Delivery、tui-idle 只表示可交互不表示完成。supervised 的 PM 只用 `pm-orchestrate show/wait`；pm-monitor/sentinel 是 tmux/terminal-managed 回退路径的辅助观察器，套到 supervised 会误判。
 4. **只并行无依赖步骤**（Task-044/050）：spawn 前的独立探查和 receipt 完成后的多个 worker 启动/核验可并行；Run 和全部 Task 的创建属于 Wave 准备屏障，必须先串行完成。依赖链（Task 预建→worker-start、spawn→核验、verify→commit）保持串行。
+5. **DEC 编号预分配纪律（2026-08-29 三波撞号教训）**：wave manifest 的每个任务 spec 必须显式其一——「新增 DEC 用预分配号 DEC-XXX」或「禁止新增 DEC（实现类默认，只引用既有合同号）」。合同类按 wave 顺序预分配；实现类漏写会导致 worker 自选号撞车（2026-08-28 三 worker 同选 DEC-066，收口重编号三次+一次误伤）。
 
 ### 3.4 `spawn-worker.sh` 模块边界（Task-048）
 
@@ -248,6 +249,13 @@ bash scripts/pm-orchestrate.sh reauthorize --worktree "$WT" --session worker-a \
 用户显式授权后，PM 按项目任务源中固定的组波/泊车策略自动链式推进波次：收口后自动写回任务源、查表组下一波并派发，直到泊车条件。**授权与策略权威都在项目上下文**（本 skill 不承载项目授权）；查表查不到合法组合即泊车，这是 Autopilot fail-closed 的根本。验收路径不因自动化放宽（门禁在最终树复跑 + safe-push + PR squash 强制），每波收口发摘要但不等确认，泊车必须完整报告后停止。
 
 Autopilot 活跃期间**必须挂 recurring cron 看门狗**，并与 Orca 推送、Dispatch 状态轮询三通道并用——推送唤醒实测会丢（worker_done 可延迟数小时不唤醒 PM）；完成判定的权威是 `worker-show` 的 dispatch/worker 状态，不是队列里有没有消息。看门狗每跳清单、验收期确定性缺陷的 fix-worker 派发模式与实测反模式读取 `references/15-wave-autopilot.md`。已由同一 watcher 明确观察到额度受限时，才可用 `scripts/night-watch.sh --terminal <PM终端handle> --model <当前模型> --settings <provider/account 配置权威文件>` 守夜；自动唤醒拒绝可变 setting-sources，并冻结 settings 内容指纹。首次探测即成功、配置/认证/网络/未知错误、超时或 terminal 失败都不会唤醒。真实 PM 终端的 `quota → available → send → PM 被唤醒` 仍标记 `NOT_VERIFIED`，流程见 `references/15-wave-autopilot.md` §8。**守夜/夜间模式（用户触发词："守夜模式/首页模式/过夜模式/晚上继续/N 小时后启动"，2026-08-28 固化）**：用户说出任一触发词时，PM 按双通道方案布防——①**定时形态（用户已知恢复时间，如"3 小时后启动"）**：`nohup caffeinate -dis` 包裹一次性定时器（sleep N 后 `orca terminal send` 注入唤醒文本）脱离 PM/Orca 进程树直接运行；会话侧可选挂一次性 cron 兜底。**零探测零死窗消耗，最经济**。②**探测形态（恢复时间未知）**：保留 session recurring cron 看门狗不删（每跳 turn 活动兼防冻心跳+兜底唤醒，死窗积压跳 token=保险费）+ `nohup caffeinate -dis` 脱离进程树的 night-watch 武装探测。铁律：任何守夜装置不得只活在 Orca/Electron 进程树内（App Nap 屏灭冻结整树，与合盖无关，2026-08-28 实证）；night-watch 在额度仍可用时启动会 exit 11（要求从耗尽态武装），需 exit-11 重试监督循环或确认耗尽后再启动。完整复盘见 references 对应节与 Task-078。
+
+**守夜 v2 实战协议(2026-08-29 晨收口固化,工具 `scripts/night-revive-timer.sh`)**:
+- **布防模板**:已知恢复时间用定时形态模板脚本(`--pm-terminal/--workers-file/--revive-at/--wake-at/--revive-text/--wake-text/--log` fail-closed;`--repeat <秒> --until <时刻>` 打摆 lane 周期性复活;wall-clock 用 `date -j -f`;`nohup caffeinate -dis` 脱链)。恢复时间变更时改参数重启,不手写新脚本。
+- **铁律一(通道自测)**:布防后立即向 PM 自身终端注入一行自测文本+向任一 worker 终端注入探针,两条都确认送达才算布防完成(2026-08-28 双验;PM 终端注入为历史 NOT_VERIFIED 项就此闭环)。
+- **铁律二(核活只用双读法)**:任何单次快照/worker=ready/空 transcript 都不可信(冻结 TUI 保留旧 todo+旧计时器,曾骗过 PM 两次)。可靠法:①双读计时器(间隔 30-40s 两次读 ⏱ 行,值不变=冻死)——过 1h 后分钟粒度失效,降级用②**游标推进法**(两次读 `latest cursor`,25s 不动=冻死;在流=活)为最终权威。
+- **铁律三(先诊断再复活)**:硬额度死 vs 瞬发拥塞两态策略不同——诊断证据=PM 自身会话可用+任一 worker 能维持长 turn+复活探针被消费。边际可用(打摆)lane 下注入必被消费且有增量进展,检测到冻死立即错峰复活(≤3 个/批,间隔 8s)周期重试;只有硬死(单请求也 429)才推迟到刷新点统一复活。
+- **铁律四(完成权威是 task-list)**:巡检第一动作 `orca orchestration task-list --run <run> --json` 查终态,不是盯队列消息——worker_done 可能早已送达被消费,队列空≠没人完成(2026-08-29 实证 7/8 早已 completed 而 PM 误判"没人发 done"又发补发指令)。
 每跳巡检同时核对各 worker spawn receipt 的 `SPAWN_WORKER_DISPATCH_BIND` 行：`manual-required`（Task-076 自动补绑未完成）须立即按 runbook #18 三步手动补绑，不要等 worker_done 缺失才暴露。
 
 Autopilot 活跃期间**必须挂 recurring cron 看门狗**，并与 Orca 推送、Dispatch 状态轮询三通道并用——推送唤醒实测会丢（worker_done 可延迟数小时不唤醒 PM）；完成判定的权威是 `worker-show` 的 dispatch/worker 状态，不是队列里有没有消息。看门狗每跳清单、验收期确定性缺陷的 fix-worker 派发模式与实测反模式读取 `references/14-wave-autopilot.md`。

--- a/skills/multi-agent-orchestration/scripts/night-revive-timer.sh
+++ b/skills/multi-agent-orchestration/scripts/night-revive-timer.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env zsh
+# night-revive-timer.sh —— 多终端守夜复活 v2(2026-08-28 守夜实战沉淀,Task-080)
+#
+# 用途:已知恢复时间(同账号 429 限流恢复等)时,脱开 PM/Orca 进程树,
+#     在 wall-clock 时间点逐终端键盘注入复活文本(worker 先,PM 后),
+#     把额度风暴后集体死 turn 的 worker 与 PM 拉回 ready。
+#
+# 与 night-watch.sh 的差别:
+#   night-watch.sh 是有界探测+只对 PM terminal 一次唤醒(查 quota→available 状态机)。
+#   night-revive-timer.sh 是定时一次性脚本:已知"何时恢复",先逐 worker 键盘注入复活文本
+#   (turn 不会自愈,必须人或外部注入唤醒),间隔数秒后再向 PM 注入"核活+收口"指令。
+#   零探测、零死窗消耗、最经济。
+#
+# 形态:nohup caffeinate -dis 包裹(脱离 PM/Orca 进程树——2026-08-28 实证 App Nap 屏灭会
+#     冻结整树,与合盖无关;挂在 Orca/Electron 内的脚本屏灭即冻,守夜=0 唤醒)。
+#
+# 历史来源:~/BadmintonLab/ops/night-wake-20260829.sh(v1 只叫醒 PM,
+#     漏了死 turn worker;v2 由用户 2026-08-28 22:02 要求补 worker 复活段)。
+# 本脚本是该 v2 实战形态的参数化模板,落到 skill 自有目录以便跨项目复用。
+#
+# --- 关键不变量(违反即布防失败) ---
+# 1. 所有必选参数(--pm-terminal/--workers-file/--revive-at/--wake-at/--revive-text/
+#    --wake-text/--log)缺一即 fail-closed,不读默认值(防止误触)。
+# 2. 时间格式严格 "YYYY-MM-DD HH:MM:SS";macOS date -j -f 解析;Linux 应改 gdate。
+# 3. workers-file 一行一个 "handle<TAB>label"(label 用作日志 tag 与 orca terminal send
+#    的可读标识);空文件、空行、注释行(#)允许;其它格式行 fail-closed。
+# 4. caffeinate -dis:macOS 自带;不在 macOS 上本脚本无意义,直接 fail-closed。
+# 5. 布防后必须立即做通道自测(向 PM 自身终端注入一行自测文本+向任一 worker 终端
+#    注入探针;两条都确认送达才算布防完成——SKILL §4.6 守夜段,2026-08-28 双验)。
+# 6. worker 429 死 turn 不会自愈:即使额度恢复,TUI 停 ready 不再消费 send;
+#    必须 `orca terminal send --text ... --enter` 键盘注入唤醒。
+#    `pm-orchestrate send` 投递 Dispatch inbox `ok:true` ≠ 被消费。
+#
+# 用法:
+#   night-revive-timer.sh \
+#     --pm-terminal term_xxx \
+#     --workers-file /tmp/workers.tsv \
+#     --revive-at  "2026-08-29 02:52:00" \
+#     --wake-at    "2026-08-29 02:55:00" \
+#     --revive-text "额度已恢复。请从断点继续..." \
+#     --wake-text   "[守夜唤醒0255] ..." \
+#     --log         ~/BadmintonLab/ops/night-wake.log
+#   # 然后立即做通道自测(向 PM + 任一 worker 各注入一行/探针,确认送达)。
+
+emulate -L zsh
+set -euo pipefail
+
+# ---------- 参数解析(fail-closed) ----------
+
+usage() {
+  cat <<'USAGE'
+Usage: night-revive-timer.sh [options]
+
+Required options:
+  --pm-terminal HANDLE         PM Orca 终端 handle(已知恢复时间后注入收口指令的目标)
+  --workers-file PATH          worker 清单文件,每行 "handle<TAB>label",
+                               空行/# 注释行允许;其它格式 fail-closed
+  --revive-at "YYYY-MM-DD HH:MM:SS"   复活六 worker 的 wall-clock 时间点
+  --wake-at   "YYYY-MM-DD HH:MM:SS"   注入 PM 的 wall-clock 时间点(revive 之后)
+  --revive-text TEXT           注入每个 worker 终端的复活文本(单行)
+  --wake-text TEXT             注入 PM 终端的收口+核活指令(可多行;压成单行)
+  --log PATH                   守夜日志路径(可追加;同一文件可与 PM 共享)
+
+Other options:
+  --revive-interval N          worker 顺序注入间隔秒数(默认 4)
+  --repeat N                   打摆 lane 周期性复活间隔(秒)。>0 时启用周期性复活,
+                               必须同时给 --until;每 N 秒重注一轮 worker,直至 UNTIL_AT
+                               (默认 0 = 单发,不循环)
+  --until "YYYY-MM-DD HH:MM:SS" 周期性复活的停止时间;必须与 --repeat 同时给,
+                               必须早于 --wake-at,晚于 --revive-at
+  --_armed                     内部旗标:caffeinate 子壳二次启动时携带,
+                               表示跳过布防段直接进入 wall-clock 注入
+  -h | --help                  显示本帮助并退出
+
+Exit codes:
+   0  正常布防完成(前端入口)/ caffeinate 子壳全部注入完成(armed 入口)
+  64  用法错误/缺参数/格式校验失败
+  70  workers-file 解析失败
+  71  caffeinate 不可用(非 macOS 或 PATH 缺)
+  72  wall-clock 时间格式不可解析(macOS date -j -f 拒绝)
+ 130  被信号中断(SIGINT/SIGTERM/HUP)
+USAGE
+}
+
+PM_TERMINAL=""
+WORKERS_FILE=""
+REVIVE_AT=""
+WAKE_AT=""
+REVIVE_TEXT=""
+WAKE_TEXT=""
+LOG_FILE=""
+REVIVE_INTERVAL=4
+REPEAT_INTERVAL=0
+UNTIL_AT=""
+ARMED=0
+
+# fail-closed 收集器:每解析一项就 set;最后留空即报错
+missing=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --pm-terminal)
+      [ $# -ge 2 ] || { echo "ERROR: --pm-terminal 需要值" >&2; exit 64; }
+      PM_TERMINAL="$2"; shift 2 ;;
+    --workers-file)
+      [ $# -ge 2 ] || { echo "ERROR: --workers-file 需要值" >&2; exit 64; }
+      WORKERS_FILE="$2"; shift 2 ;;
+    --revive-at)
+      [ $# -ge 2 ] || { echo "ERROR: --revive-at 需要值" >&2; exit 64; }
+      REVIVE_AT="$2"; shift 2 ;;
+    --wake-at)
+      [ $# -ge 2 ] || { echo "ERROR: --wake-at 需要值" >&2; exit 64; }
+      WAKE_AT="$2"; shift 2 ;;
+    --revive-text)
+      [ $# -ge 2 ] || { echo "ERROR: --revive-text 需要值" >&2; exit 64; }
+      REVIVE_TEXT="$2"; shift 2 ;;
+    --wake-text)
+      [ $# -ge 2 ] || { echo "ERROR: --wake-text 需要值" >&2; exit 64; }
+      WAKE_TEXT="$2"; shift 2 ;;
+    --log)
+      [ $# -ge 2 ] || { echo "ERROR: --log 需要值" >&2; exit 64; }
+      LOG_FILE="$2"; shift 2 ;;
+    --revive-interval)
+      [ $# -ge 2 ] || { echo "ERROR: --revive-interval 需要值" >&2; exit 64; }
+      REVIVE_INTERVAL="$2"; shift 2 ;;
+    --repeat)
+      [ $# -ge 2 ] || { echo "ERROR: --repeat 需要值" >&2; exit 64; }
+      REPEAT_INTERVAL="$2"; shift 2 ;;
+    --until)
+      [ $# -ge 2 ] || { echo "ERROR: --until 需要值" >&2; exit 64; }
+      UNTIL_AT="$2"; shift 2 ;;
+    --_armed) ARMED=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "ERROR: 未知参数 $1" >&2; usage >&2; exit 64 ;;
+  esac
+done
+
+# ARMED 入口只做 wall-clock 注入;其它校验已在首次启动时跑过
+if (( ARMED )); then
+  # 仅校验 caffeinate 子壳再次启动时仍能解析时间与读 workers-file
+  [ -r "$WORKERS_FILE" ] || { echo "ERROR(armed): workers-file 不可读" >&2; exit 70; }
+  parse_epoch() {
+    date -j -f "%Y-%m-%d %H:%M:%S" "$1" +%s 2>/dev/null || {
+      echo "ERROR(armed): 时间 '$1' 不能被 date -j -f 解析" >&2
+      exit 72
+    }
+  }
+  REVIVE_EPOCH=$(parse_epoch "$REVIVE_AT")
+  WAKE_EPOCH=$(parse_epoch "$WAKE_AT")
+
+  # 解析 workers-file
+  typeset -a A_HANDLES A_LABELS
+  while IFS=$'\t' read -r handle label || [ -n "$handle" ]; do
+    [[ -z "$handle" || "$handle" == \#* ]] && continue
+    [[ "$handle" =~ ^[A-Za-z0-9._:-]+$ ]] || {
+      echo "ERROR(armed): workers-file 行 '$handle\t$label' 的 handle 不合法" >&2
+      exit 70
+    }
+    A_HANDLES+=("$handle")
+    A_LABELS+=("${label:-$handle}")
+  done < "$WORKERS_FILE"
+
+  log() { echo "[$(date '+%F %T')] $*" >> "$LOG_FILE"; }
+  send() {
+    orca terminal send --terminal "$1" --text "$2" --enter >> "$LOG_FILE" 2>&1
+    local rc=$?
+    log "sent -> $3 ($1) exit=$rc"
+    return $rc
+  }
+  wait_until() {
+    local target_epoch now
+    target_epoch=$(parse_epoch "$1")
+    now=$(date +%s)
+    if (( target_epoch <= now )); then
+      log "WARN: target $1 already past"
+      return 0
+    fi
+    sleep $(( target_epoch - now ))
+  }
+
+  log "--- armed shell entered; waiting for ${REVIVE_AT} ---"
+
+  # ---- worker 复活段(首次) ----
+  wait_until "$REVIVE_AT"
+  log "--- worker revival pass: ${#A_HANDLES[@]} terminal(s) ---"
+  for i in 1..${#A_HANDLES[@]}; do
+    handle="${A_HANDLES[$i]}"
+    label="${A_LABELS[$i]}"
+    send "$handle" "$REVIVE_TEXT" "$label" || true
+    if (( i < ${#A_HANDLES[@]} )); then
+      sleep "$REVIVE_INTERVAL"
+    fi
+  done
+  log "--- worker revival pass done ---"
+
+  # ---- 周期性复活段(打摆 lane)— 仅当 --repeat > 0 且 --until 给定时启用 ----
+  if (( REPEAT_INTERVAL > 0 )); then
+    until_epoch=$(parse_epoch "$UNTIL_AT")
+    log "--- periodic revival loop: every ${REPEAT_INTERVAL}s until ${UNTIL_AT} ---"
+    while :; do
+      now=$(date +%s)
+      if (( now >= until_epoch )); then
+        log "--- until time reached, exit periodic loop ---"
+        break
+      fi
+      log "--- periodic revival pass ---"
+      for i in 1..${#A_HANDLES[@]}; do
+        handle="${A_HANDLES[$i]}"
+        label="${A_LABELS[$i]}"
+        send "$handle" "$REVIVE_TEXT" "$label" || true
+        if (( i < ${#A_HANDLES[@]} )); then
+          sleep "$REVIVE_INTERVAL"
+        fi
+      done
+      log "--- periodic revival pass done ---"
+
+      now=$(date +%s)
+      remaining=$(( until_epoch - now ))
+      sleep_for=$REPEAT_INTERVAL
+      [ "$sleep_for" -le "$remaining" ] || sleep_for=$remaining
+      if (( sleep_for <= 0 )); then
+        break
+      fi
+      sleep "$sleep_for"
+    done
+    log "--- periodic revival loop done ---"
+  fi
+
+  # ---- PM 唤醒段 ----
+  wait_until "$WAKE_AT"
+  send "$PM_TERMINAL" "$WAKE_TEXT" "PM" || true
+  log "=== night-revive v2 complete ==="
+  exit 0
+fi
+
+# ===== 首次入口:必选参数校验 + caffeinate 布防 =====
+
+[ -n "$PM_TERMINAL"  ] || missing+=("--pm-terminal")
+[ -n "$WORKERS_FILE"  ] || missing+=("--workers-file")
+[ -n "$REVIVE_AT"     ] || missing+=("--revive-at")
+[ -n "$WAKE_AT"       ] || missing+=("--wake-at")
+[ -n "$REVIVE_TEXT"   ] || missing+=("--revive-text")
+[ -n "$WAKE_TEXT"     ] || missing+=("--wake-text")
+[ -n "$LOG_FILE"      ] || missing+=("--log")
+
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "ERROR: 缺必选参数:${(j:,:)missing}" >&2
+  usage >&2
+  exit 64
+fi
+
+# terminal handle:简单白名单(term_/ctx_/任意 [A-Za-z0-9._:-]+)
+[[ "$PM_TERMINAL" =~ ^[A-Za-z0-9._:-]+$ ]] || {
+  echo "ERROR: --pm-terminal '$PM_TERMINAL' 不合法(只允许 [A-Za-z0-9._:-])" >&2
+  exit 64
+}
+
+# workers-file 必须存在、可读
+[ -r "$WORKERS_FILE" ] || {
+  echo "ERROR: --workers-file '$WORKERS_FILE' 不存在或不可读" >&2
+  exit 70
+}
+
+# 时间格式严格 "YYYY-MM-DD HH:MM:SS";先用 macOS date -j -f 解析,失败即 fail-closed。
+parse_epoch() {
+  local ts="$1"
+  date -j -f "%Y-%m-%d %H:%M:%S" "$ts" +%s 2>/dev/null || {
+    echo "ERROR: 时间 '$ts' 不能被 'date -j -f %Y-%m-%d %H:%M:%S' 解析" >&2
+    echo "       请用 macOS,或安装 coreutils 后改用 gdate -d" >&2
+    exit 72
+  }
+}
+REVIVE_EPOCH=$(parse_epoch "$REVIVE_AT")
+WAKE_EPOCH=$(parse_epoch "$WAKE_AT")
+
+[ "$REVIVE_EPOCH" -lt "$WAKE_EPOCH" ] || {
+  echo "ERROR: --revive-at ($REVIVE_AT) 必须早于 --wake-at ($WAKE_AT)" >&2
+  exit 64
+}
+
+# --repeat / --until 成对校验(打摆 lane 周期性复活)
+if [ -n "$REPEAT_INTERVAL" ] && [ "$REPEAT_INTERVAL" != "0" ]; then
+  # --repeat 已给
+  [ -n "$UNTIL_AT" ] || {
+    echo "ERROR: --repeat 已给(${REPEAT_INTERVAL}s),但缺 --until(--repeat 必须与 --until 成对)" >&2
+    exit 64
+  }
+  # --repeat 必须为正整数
+  [[ "$REPEAT_INTERVAL" =~ ^[1-9][0-9]*$ ]] || {
+    echo "ERROR: --repeat '$REPEAT_INTERVAL' 不是正整数" >&2
+    exit 64
+  }
+  UNTIL_EPOCH=$(parse_epoch "$UNTIL_AT")
+  [ "$REVIVE_EPOCH" -lt "$UNTIL_EPOCH" ] || {
+    echo "ERROR: --until ($UNTIL_AT) 必须晚于 --revive-at ($REVIVE_AT)" >&2
+    exit 64
+  }
+  [ "$UNTIL_EPOCH" -lt "$WAKE_EPOCH" ] || {
+    echo "ERROR: --until ($UNTIL_AT) 必须早于 --wake-at ($WAKE_AT)" >&2
+    exit 64
+  }
+elif [ -n "$UNTIL_AT" ]; then
+  # --until 已给但 --repeat 未给
+  echo "ERROR: --until 已给(${UNTIL_AT}),但缺 --repeat(--until 必须与 --repeat 成对)" >&2
+  exit 64
+fi
+
+# caffeinate 守卫
+command -v caffeinate >/dev/null 2>&1 || {
+  echo "ERROR: caffeinate 不可用——本脚本仅在 macOS 运行" >&2
+  echo "       Linux 用 systemd-inhibit 或 loginctl 替代 -dis 的 App Nap/屏灭守护" >&2
+  exit 71
+}
+
+# 日志目录兜底
+LOG_DIR=$(dirname -- "$LOG_FILE")
+[ -d "$LOG_DIR" ] || mkdir -p "$LOG_DIR" || {
+  echo "ERROR: 日志目录 '$LOG_DIR' 无法创建" >&2
+  exit 64
+}
+
+# 日志函数(首次入口与 armed 子壳共用)
+log() { echo "[$(date '+%F %T')] $*" >> "$LOG_FILE"; }
+
+# ---------- caffeinate -dis 布防 ----------
+#
+# -d:阻止系统休眠(display sleep prevention)
+# -i:阻止系统空闲休眠
+# -s:阻止系统完全休眠(AC 切断后)
+# nohup:脱离父进程(PM/Orca 关闭/屏灭后仍存活)
+# &:后台运行(本脚本立即返回,布防即结束;后续注入由 caffeinate 子壳按 wall-clock 执行)
+#
+# 教训:2026-08-28 实证,任何守夜装置不得只活在 Orca/Electron 进程树内——
+# App Nap 屏灭冻结整进程树,与合盖无关,守夜=0 唤醒。
+# caffeinate -dis 是 macOS 上保证脚本运行到时间点的最简手段。
+
+log "=== night-revive v2 armed: revive@${REVIVE_AT} wake@${WAKE_AT} workers-file=${WORKERS_FILE} pm=${PM_TERMINAL} ==="
+
+CAFFEINATE_BIN=$(command -v caffeinate)
+CAFFEINATE_ARGS=(
+  --pm-terminal "$PM_TERMINAL"
+  --workers-file "$WORKERS_FILE"
+  --revive-at "$REVIVE_AT"
+  --wake-at "$WAKE_AT"
+  --revive-text "$REVIVE_TEXT"
+  --wake-text "$WAKE_TEXT"
+  --log "$LOG_FILE"
+  --revive-interval "$REVIVE_INTERVAL"
+  --repeat "$REPEAT_INTERVAL"
+  --until "$UNTIL_AT"
+  --_armed
+)
+nohup "$CAFFEINATE_BIN" -dis "$0" "${CAFFEINATE_ARGS[@]}" >> "$LOG_FILE" 2>&1 &
+
+ARMED_PID=$!
+log "armed pid=${ARMED_PID}; caffeinate -dis detached;布防完成;立刻做通道自测(详见 SKILL §4.6)"
+
+# 布防立即返回(前端脚本不等 wall-clock);前端必须:
+#  1. 向 PM 自身注入一行自测文本(确认 PM 通道可达)
+#  2. 向任一 worker 注入探针(确认 worker 通道可达)
+#  两条都确认送达 = 布防完成;任一失败必须立即 abort/重发。
+exit 0

--- a/skills/multi-agent-orchestration/templates/workers.tsv.example
+++ b/skills/multi-agent-orchestration/templates/workers.tsv.example
@@ -1,0 +1,11 @@
+# workers-file 示例(每行 handle<TAB>label)
+# 空行与以 # 开头的注释行会被脚本忽略;其它非 handle\tlabel 形态会 fail-closed。
+# handle 必须匹配 [A-Za-z0-9._:-]+;label 用作日志 tag,可省略(省略则用 handle 作 tag)。
+#
+# 实战样本(2026-08-28 守夜 v2,六 worker):
+term_3e72505b-3771-43f3-aeaa-9061567c3746	bl-017-impl
+term_0effde67-0240-46d4-9d34-5c9d34952c06	bl-040-impl
+term_b5c394cc-1307-4156-862c-71d5d02a016d	bl-050-fix
+term_93667626-22e8-49f7-8fe8-6d98123a5f22	bl-051-contract
+term_6326dfd8-98e4-4ac8-948d-bd37107e3b80	bl-046-contract
+term_a214f608-6921-4435-8356-7724d2bc69f7	bl-053-ia-contract


### PR DESCRIPTION
## 概要
- **守夜 v2 实战协议**入正本:新 `scripts/night-revive-timer.sh`(361 行,7 参数 fail-closed,--repeat/--until 打摆复活,caffeinate -dis 脱链)+ `templates/workers.tsv.example`
- SKILL.md §4.6 四铁律:通道自测(布防即双注探针)/双读核活法(计时器 40s 双读+游标推进法兜底)/硬死vs瞬发拥塞诊断树(打摆 lane 立即错峰复活 ≤3/批)/task-list 为完成权威(队列空≠没人完成)
- §3.3 新增第 5 条:**DEC 编号预分配纪律**(spec 必须显式预分配号或禁止新增;2026-08-28 badminton-lab Wave 22 三 worker 同选 066 的教训)

## 来源
2026-08-28/29 badminton-lab Wave 22 全夜实战复盘(8 worker/429 打摆/守夜唤醒链/六 PR 收口)。

## 执行与验收
- PM 直接交付(用户指示:能直改的走 PR)
- zsh -n 脚本语法过;SKILL 引用路径可达;内容含 #164 误投 private-skills 的模板迁移+当晚复盘新增
- 注:#164 曾误投 private-skills(该仓 2026-06 已移除本 skill),本 PR 为正本交付;private-skills 侧清理另行 PR