### PR TITLE
fix(multi-agent-orchestration): route_suggest 自动补选补上 provider env 注入 (2.9.4)

### DIFF
--- a/skills/multi-agent-orchestration/CHANGELOG.md
+++ b/skills/multi-agent-orchestration/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.9.4] - 2026-08-29
+
+### 修复
+
+- **route_suggest 自动补选不注入 provider env（实测抓出）**：补选只填 API_PROVIDER（lease 计数 + METADATA），worker 仍是裸 `claude` 继承用户全局默认 provider——与 lease 计数的 lane 不一致，且实测 MiniMax 后端对继承配置报 400 modelCode 不存在。现在补选成功且命令为 backend 默认值（用户未显式 `--command`）时，`route_suggest_wrap_command` 用 `claude-provider-env.sh` 自动包装：注入 `config/<provider>.settings.json` 的 env + `--model`（取 settings 的 `env.ANTHROPIC_MODEL`）+ `--permission-mode auto`；settings 缺失/model 解析失败保持裸命令（fail-open 不阻断 spawn）。新增 stderr 标记行 `ROUTE_SUGGEST_ENV`。端到端实测：L0 补选 minimax-M3 → worker 以 MiniMax-M3[1M] 真实完成文件创建任务。
+- 测试 16→23 断言（wrap 四场景：注入/显式命令不包装/settings 缺失保持裸命令/非 claude-code 跳过 + 接线顺序断言）；修复 helper 内 `$model（`全角标点在 set -u 下 unbound 的经典坑（memory 已有先例）。
+
+
 ## [2.9.3] - 2026-08-29
 
 ### 新增

--- a/skills/multi-agent-orchestration/scripts/spawn-worker-route-suggest.sh
+++ b/skills/multi-agent-orchestration/scripts/spawn-worker-route-suggest.sh
@@ -35,3 +35,34 @@ PY
   fi
   return 0
 }
+
+# v2.9.4：自动补选的 provider 必须同时注入运行 env。spawn-worker 的设计里
+# provider env 注入本是 PM 职责（eval render-runtime-profile 生成 --command），
+# 自动补选路径没有这层——补选后裸 claude 继承用户全局默认 provider，与 lease
+# 计数的 lane 不一致（2026-08-29 实测：补选 minimax-M3 但裸 claude 走全局
+# 配置，MiniMax 后端报 400 modelCode 不存在）。修复：命令为 backend 默认值
+# （用户未显式 --command）时，用 claude-provider-env.sh 包装注入
+# config/$API_PROVIDER.settings.json 的 env + --model。settings 缺失或 model
+# 解析失败保持裸命令（fail-open，行为回到修复前，不阻断 spawn）。
+route_suggest_wrap_command() {
+  [ -n "${API_PROVIDER:-}" ] || return 0
+  [ "${COMMAND_WAS_DEFAULT:-0}" = "1" ] || return 0
+  [ "${WORKER_BACKEND_CANONICAL:-}" = "claude-code" ] || return 0
+  local wrapper="$SCRIPT_DIR/claude-provider-env.sh"
+  local settings="$SCRIPT_DIR/../config/$API_PROVIDER.settings.json"
+  [ -f "$wrapper" ] && [ -f "$settings" ] || return 0
+  local model
+  model=$(python3 - "$settings" <<'PY' 2>/dev/null
+import json, sys
+try:
+    cfg = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(1)
+print((cfg.get("env") or {}).get("ANTHROPIC_MODEL", ""))
+PY
+) || model=""
+  [ -n "$model" ] || return 0
+  COMMAND="bash '$wrapper' --settings '$settings' --model '$model' -- $COMMAND --permission-mode auto"
+  echo "ROUTE_SUGGEST_ENV: provider=${API_PROVIDER} settings=${API_PROVIDER}.settings.json model=${model}（默认命令自动包装 provider env）" >&2
+  return 0
+}

--- a/skills/multi-agent-orchestration/scripts/spawn-worker.sh
+++ b/skills/multi-agent-orchestration/scripts/spawn-worker.sh
@@ -293,6 +293,10 @@ if [ -z "$COMMAND" ]; then
     zcode) COMMAND="python3 '$SCRIPT_DIR/zcode-worker-driver.py'" ;;
     *) echo "ERROR: no default command for backend=$WORKER_BACKEND_CANONICAL" >&2; exit 64 ;;
   esac
+  # v2.9.4：标记命令来自 backend 默认值（用户未显式 --command）——route_suggest
+  # 自动补选 provider 后据此决定是否安全地包装 provider env（见
+  # spawn-worker-route-suggest.sh route_suggest_wrap_command）。
+  COMMAND_WAS_DEFAULT=1
   echo "SPAWN_WORKER_COMMAND_DEFAULT: backend=$WORKER_BACKEND_CANONICAL command=$COMMAND"
 fi
 
@@ -321,6 +325,9 @@ source "$SCRIPT_DIR/spawn-worker-route-suggest.sh"
 # lease 消费 API_PROVIDER 之前自动补选（fail-open：route_suggest 任何失败不
 # 改道、不阻断 spawn；显式 --api-provider 永远优先）。
 route_suggest_autofill_provider
+# v2.9.4：补选出的 provider 注入运行 env（仅默认命令时包装，显式 --command
+# 的 env 由 PM 的 runtime profile 负责，不重复注入）。
+route_suggest_wrap_command
 
 # shellcheck source=spawn-worker-provider-lease.sh
 source "$SCRIPT_DIR/spawn-worker-provider-lease.sh"

--- a/skills/multi-agent-orchestration/scripts/tests/test-spawn-worker-route-suggest.sh
+++ b/skills/multi-agent-orchestration/scripts/tests/test-spawn-worker-route-suggest.sh
@@ -197,5 +197,65 @@ else
   bad "autofill runs before provider lease consumes API_PROVIDER (autofill=$autofill_line lease=$lease_line)"
 fi
 
+# ── route_suggest_wrap_command（v2.9.4：补选 provider 注入运行 env）────────
+# fixture：假 scripts/ 目录（含假 wrapper）+ config/prov-a1.settings.json。
+FAKE_SCRIPTS="$CASE_ROOT/fake-scripts"
+mkdir -p "$FAKE_SCRIPTS" "$CASE_ROOT/config"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$FAKE_SCRIPTS/claude-provider-env.sh"
+cat > "$CASE_ROOT/config/prov-a1.settings.json" <<'JSON'
+{"env": {"ANTHROPIC_MODEL": "mod-a1"}}
+JSON
+
+reset_wrap_case() {
+  SCRIPT_DIR="$FAKE_SCRIPTS"
+  API_PROVIDER="${1:-prov-a1}"
+  COMMAND_WAS_DEFAULT="${2:-1}"
+  WORKER_BACKEND_CANONICAL="${3:-claude-code}"
+  COMMAND="claude"
+}
+
+# 场景 W1：默认命令 + 补选 provider → COMMAND 被包装（settings+model 注入）。
+reset_wrap_case
+route_suggest_wrap_command 2>"$CASE_ROOT/w1.err"
+if [[ "$COMMAND" == *"config/prov-a1.settings.json"* ]] \
+   && [[ "$COMMAND" == *"model 'mod-a1'"* ]] \
+   && [[ "$COMMAND" == *"-- claude --permission-mode auto"* ]]; then
+  ok "wrap injects settings and model into default command"
+else
+  bad "wrap injects settings and model into default command (COMMAND=$COMMAND)"
+fi
+grep -Fq 'ROUTE_SUGGEST_ENV: provider=prov-a1' "$CASE_ROOT/w1.err" \
+  && ok "wrap emits ROUTE_SUGGEST_ENV marker" \
+  || bad "wrap emits ROUTE_SUGGEST_ENV marker"
+
+# 场景 W2：显式 --command（COMMAND_WAS_DEFAULT=0）→ 不包装。
+reset_wrap_case prov-a1 0
+route_suggest_wrap_command 2>/dev/null
+assert_eq "$COMMAND" "claude" "explicit command is never wrapped"
+
+# 场景 W3：settings 缺失 → 保持裸命令（fail-open）。
+reset_wrap_case prov-missing
+route_suggest_wrap_command 2>/dev/null
+assert_eq "$COMMAND" "claude" "missing settings keeps bare command"
+
+# 场景 W4：非 claude-code backend → 不包装。
+reset_wrap_case prov-a1 1 codex
+route_suggest_wrap_command 2>/dev/null
+assert_eq "$COMMAND" "claude" "non-claude-code backend skips wrap"
+
+# 静态接线断言：主脚本必须调用 wrap（在 autofill 之后）。
+if grep -Eq '^route_suggest_wrap_command$' "$SPAWN_WORKER"; then
+  ok "entrypoint invokes route_suggest_wrap_command"
+else
+  bad "entrypoint invokes route_suggest_wrap_command"
+fi
+wrap_line=$(grep -En '^route_suggest_wrap_command$' "$SPAWN_WORKER" | head -1 | cut -d: -f1)
+if [ -n "$wrap_line" ] && [ -n "$autofill_line" ] && [ "$wrap_line" -gt "$autofill_line" ]; then
+  ok "wrap runs after autofill"
+else
+  bad "wrap runs after autofill (wrap=$wrap_line autofill=$autofill_line)"
+fi
+
+
 printf 'spawn-worker route-suggest tests: %s passed, %s failed\n' "$passed" "$failed"
 [ "$failed" -eq 0 ]


### PR DESCRIPTION
## 摘要

端到端实测（真实 spawn 一个简单任务）抓出 PR #110 的断点：route_suggest 自动补选只填 API_PROVIDER（lease 计数 + METADATA 记录），worker 仍是裸 \`claude\`——继承用户全局默认 provider，与补选 lane 不一致，且实测 MiniMax 后端对继承配置报 400 modelCode 不存在。

- 新增 \`route_suggest_wrap_command\`：补选成功 + 命令为 backend 默认值（未显式 \`--command\`）时，用 \`claude-provider-env.sh\` 包装注入 \`config/<provider>.settings.json\` 的 env + \`--model\`（取 settings 的 ANTHROPIC_MODEL）+ \`--permission-mode auto\`
- fail-open：settings 缺失 / model 解析失败 → 保持裸命令，不阻断 spawn
- 新增 stderr 标记行 \`ROUTE_SUGGEST_ENV: provider=... model=...\`
- 顺修：helper 内 \`$model（\` 全角标点在 set -u 下 unbound 的经典坑

## 测试计划

- [x] test-spawn-worker-route-suggest.sh 16→23 断言全绿（wrap 四场景 + 接线顺序）
- [x] spawn-worker 系列 6/6 回归
- [x] **端到端实测**：L0 无 --api-provider 派发 → ROUTE_SUGGEST_AUTO(minimax-M3) + ROUTE_SUGGEST_ENV(MiniMax-M3[1M]) → worker 以 MiniMax 通道真实完成文件创建任务（done.txt 落地）

## Agent 归属

- Claude Code 主会话实施（用户在场驱动端到端验证），Git author 杨卫薪 <yangweixin@yangweixin.law>

## 风险

- 仅影响"自动补选 + 默认命令"路径；显式 --command / 显式 --api-provider 行为零变化；settings 缺失时 fail-open 回到修复前行为