### PR TITLE
feat(svg-book-illustrator): v1.9.1 scan 逐项豁免台账(W1 裁决机械化)

### DIFF
--- a/skills/svg-book-illustrator/CHANGELOG.md
+++ b/skills/svg-book-illustrator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## [v1.9.1] - 2026-08-29
+
+### 新增
+
+- `scan_consistency.py --exemptions <台账.json>`(schema_version 1):**逐项豁免已裁决历史 findings**——键=(file, svg_index, rule_id),命中项不计入 findings/退出码/报告,汇总区单列「命中 N/M」;**未命中条目 stderr 报警**(对应 finding 已消失,台账漂移应清理);坏 JSON/缺字段/未登记 rule_id 一律 exit 2 fail-closed。整规则豁免被有意排除:新图违规永远照报。落地背景:书仓作者 2026-08-29 对 W1 两组历史余项(SYNTAX-05×58 / PADDING-01×85)裁决「接受登记」,本能力是该裁决的机械化载体。
+- 测试 +3(命中移除并上报 used / 未命中保留 finding 且 used 为空 / 坏 schema 与未知 rule_id fail-closed),套件 13/13 通过;全书端到端:348 findings → 205(hard 149→91),台账命中 143/143 无漂移。
+
 ## [v1.9.0] - 2026-08-28
 
 > **发布状态：候选。** 本地实现与 fixture 验证完成，待独立 PR / PM 验收后本地 FF merge；不得据此宣称已发布。

--- a/skills/svg-book-illustrator/SKILL.md
+++ b/skills/svg-book-illustrator/SKILL.md
@@ -2,7 +2,7 @@
 name: svg-book-illustrator
 homepage: https://github.com/cat-xierluo/legal-skills
 author: 杨卫薪律师（微信ywxlaw）
-version: "1.9.0"
+version: "1.9.1"
 license: MIT
 description: 书籍/文章 SVG 配图生成工具，专注于架构图、流程图、层次图等专业技术配图。当用户需要为书籍章节或正式文章生成配图、创建架构图/流程图/层次图，或提到"章节配图"、"书籍插图"、"架构图"、"流程图"时使用此技能。
 ---
@@ -201,7 +201,7 @@ python3 scripts/scan_consistency.py --book-root <书仓根目录> --report <报�
 - **身份**：`data-figure-id` 缺失（soft，历史不回填口径）/ 格式不安全 / `fig-template-*` 落稿 / 跨图重复
 - **sidecar 同步**：canonical 内联 SVG ↔ `manuscript/**/*_images/<stem>-svg-N.svg` 派生缓存内容一致（T261 口径）
 
-历史口径：对 v1.8.9 前历史书稿的 SYNTAX/IDENTITY 发现只登记不要求回改（与本 skill「不回改历史书稿」既有口径一致）。与 BLOCKED Task-001（producer 冲突）/ Task-002（shape containment）互不侵入：本 scan 不改 producer、不做包含几何判定。
+历史口径：对 v1.8.9 前历史书稿的 SYNTAX/IDENTITY 发现只登记不要求回改（与本 skill「不回改历史书稿」既有口径一致）。v1.9.1 新增 `--exemptions <台账.json>`:逐项豁免已裁决历史项(键=file/svg_index/rule_id),命中不计 findings、未命中报警防台账漂移、坏台账 fail-closed;整规则豁免被有意排除——新图违规永远照报。与 BLOCKED Task-001（producer 冲突）/ Task-002（shape containment）互不侵入：本 scan 不改 producer、不做包含几何判定。
 
 ---
 

--- a/skills/svg-book-illustrator/scripts/scan_consistency.py
+++ b/skills/svg-book-illustrator/scripts/scan_consistency.py
@@ -25,6 +25,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import math
 import re
 import sys
@@ -717,6 +718,59 @@ def build_report(files: list[FileScan], args_ns) -> str:
     return '\n'.join(lines)
 
 
+def load_exemptions(path: Path) -> dict[tuple[str, int, str], dict]:
+    """加载逐项豁免台账（JSON）。
+
+    schema_version 1：items: [{file, svg_index, rule_id, reason?, adjudicated?}]
+    键 = (file, svg_index, rule_id)；file 为 md 相对 book-root 路径，svg_index 0 基。
+    逐项豁免而非整规则豁免：新图违规永远照报，豁免只覆盖已裁决的历史项。
+    """
+    try:
+        data = json.loads(path.read_text(encoding='utf-8'))
+    except (OSError, json.JSONDecodeError) as e:
+        print(f'豁免台账不可读（fail-closed）：{path}：{e}', file=sys.stderr)
+        raise SystemExit(2)
+    if data.get('schema_version') != 1 or not isinstance(data.get('items'), list):
+        print(f'豁免台账结构不符 schema_version 1：{path}', file=sys.stderr)
+        raise SystemExit(2)
+    table: dict[tuple[str, int, str], dict] = {}
+    for it in data['items']:
+        try:
+            key = (str(it['file']), int(it['svg_index']), str(it['rule_id']))
+        except (KeyError, TypeError, ValueError):
+            print(f'豁免条目缺字段/类型错误：{it!r}', file=sys.stderr)
+            raise SystemExit(2)
+        if it['rule_id'] not in RULES:
+            print(f'豁免条目 rule_id 未登记：{it["rule_id"]}', file=sys.stderr)
+            raise SystemExit(2)
+        table[key] = it
+    return table
+
+
+def apply_exemptions(files: list, table: dict[tuple[str, int, str], dict]) -> set[tuple[str, int, str]]:
+    """把命中的豁免项从各文件 findings 中移除，返回实际命中的键集合。"""
+    used: set[tuple[str, int, str]] = set()
+    for fs in files:
+        for r in fs.results:
+            kept = []
+            for f in r.findings:
+                k = (f.file, f.svg_index, f.rule_id)
+                if k in table:
+                    used.add(k)
+                else:
+                    kept.append(f)
+            r.findings = kept
+        kept_side = []
+        for f in fs.sidecar_findings:
+            k = (f.file, f.svg_index, f.rule_id)
+            if k in table:
+                used.add(k)
+            else:
+                kept_side.append(f)
+        fs.sidecar_findings = kept_side
+    return used
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog='scan_consistency.py',
@@ -728,6 +782,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument('--arrow-gap', type=float, default=8.0, help='箭头悬空判定阈值 px（默认 8，style-guide §5.5.3）')
     parser.add_argument('--fail-on', choices=('none', 'hard', 'any'), default='none',
                         help='按 findings 置非零退出码：none=总为0（只报告），hard=存在 hard，any=存在任意')
+    parser.add_argument('--exemptions', help='逐项豁免台账 JSON 路径（schema_version 1；命中项不计 findings，未命中条目报警防台账漂移）')
     args = parser.parse_args(argv)
 
     if not args.book_root:
@@ -738,9 +793,17 @@ def main(argv: list[str] | None = None) -> int:
         print(f'书仓根目录不存在：{book_root}', file=sys.stderr)
         return 2
 
+    exemption_table: dict[tuple[str, int, str], dict] = {}
+    if args.exemptions:
+        exemption_table = load_exemptions(Path(args.exemptions).expanduser())
+
     md_files = discover_canonical(book_root)
     id_registry: dict[str, str] = {}
     files = [scan_file(p, book_root, args.padding, args.arrow_gap, id_registry) for p in md_files]
+
+    used_keys: set[tuple[str, int, str]] = set()
+    if exemption_table:
+        used_keys = apply_exemptions(files, exemption_table)
 
     all_findings: list[Finding] = []
     for fs in files:
@@ -758,6 +821,17 @@ def main(argv: list[str] | None = None) -> int:
         for rid in sorted(by_rule, key=lambda r: (-by_rule[r], r)):
             name, sev, _ = RULES[rid]
             print(f'  {rid}({sev}) {name}: {by_rule[rid]}')
+
+    if exemption_table:
+        unused = set(exemption_table) - used_keys
+        print(f'豁免台账：命中 {len(used_keys)}/{len(exemption_table)} 项'
+              f'（已裁决历史项,不计 findings;裁决日分布见台账）')
+        if unused:
+            print(f'⚠️ 未命中豁免条目 {len(unused)} 项（对应 finding 已消失或图已改,台账漂移,应清理）：',
+                  file=sys.stderr)
+            for k in sorted(unused):
+                it = exemption_table[k]
+                print(f'  - {k[2]} {k[0]} svg#{k[1]}（{it.get("adjudicated", "?")} 裁决）', file=sys.stderr)
 
     if args.report:
         report_path = Path(args.report)

--- a/skills/svg-book-illustrator/scripts/tests/test_scan_consistency.py
+++ b/skills/svg-book-illustrator/scripts/tests/test_scan_consistency.py
@@ -171,3 +171,63 @@ class ScanFileSidecarTest(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class ExemptionLedgerTest(unittest.TestCase):
+    """--exemptions 逐项豁免台账（v1.9.1）：命中不计 findings，未命中报警，坏台账 fail-closed。"""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.ms = self.root / 'manuscript'
+        self.ms.mkdir()
+        self.md = self.ms / 'ch99-测试图.md'
+        # sidecar 不一致场景：canonical 无尾换行、sidecar 有 → SIDECAR-01
+        self.md.write_text(COMPLIANT_SVG + '\n\n**图 99-1：测试图**\n', encoding='utf-8')
+        self.sidecar_dir = self.ms / 'ch99-测试图_images'
+        self.sidecar_dir.mkdir()
+        (self.sidecar_dir / 'ch99-测试图-svg-0.svg').write_text(
+            COMPLIANT_SVG.replace('识别场景', '已被改动'), encoding='utf-8')
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _ledger(self, root: Path, items: list) -> Path:
+        import json
+        p = root / 'exemptions.json'
+        p.write_text(json.dumps({'schema_version': 1, 'items': items}, ensure_ascii=False), encoding='utf-8')
+        return p
+
+    def test_exempted_finding_removed_and_used_key_reported(self) -> None:
+        from scan_consistency import apply_exemptions, load_exemptions
+        ledger = self._ledger(self.root, [
+            {'file': 'manuscript/ch99-测试图.md', 'svg_index': 0, 'rule_id': 'SIDECAR-01',
+             'reason': '作者裁决接受(2026-08-29)', 'adjudicated': '2026-08-29'}])
+        table = load_exemptions(ledger)
+        self.assertEqual(len(table), 1)
+        fs = [scan_file(self.md, self.root, padding=40, arrow_gap=8, id_registry={})]
+        self.assertEqual([f.rule_id for f in fs[0].sidecar_findings], ['SIDECAR-01'])
+        used = apply_exemptions(fs, table)
+        self.assertEqual(used, {('manuscript/ch99-测试图.md', 0, 'SIDECAR-01')})
+        self.assertEqual(fs[0].sidecar_findings, [])
+
+    def test_non_matching_entry_keeps_finding_and_marks_unused(self) -> None:
+        from scan_consistency import apply_exemptions, load_exemptions
+        ledger = self._ledger(self.root, [
+            {'file': 'manuscript/ch99-测试图.md', 'svg_index': 3, 'rule_id': 'SIDECAR-01'}])
+        table = load_exemptions(ledger)
+        fs = [scan_file(self.md, self.root, padding=40, arrow_gap=8, id_registry={})]
+        used = apply_exemptions(fs, table)
+        self.assertEqual(used, set())                     # 未命中 → 台账漂移信号
+        self.assertEqual([f.rule_id for f in fs[0].sidecar_findings], ['SIDECAR-01'])
+
+    def test_bad_schema_or_unknown_rule_fail_closed(self) -> None:
+        from scan_consistency import load_exemptions
+        bad = self.root / 'bad.json'
+        bad.write_text('{"schema_version": 2, "items": []}', encoding='utf-8')
+        with self.assertRaises(SystemExit):
+            load_exemptions(bad)
+        unknown = self._ledger(self.root, [
+            {'file': 'x.md', 'svg_index': 0, 'rule_id': 'NOPE-99'}])
+        with self.assertRaises(SystemExit):
+            load_exemptions(unknown)


### PR DESCRIPTION
## 摘要
- `scan_consistency.py --exemptions <台账.json>`(schema_version 1):逐项豁免已裁决历史 findings——键=(file, svg_index, rule_id),命中不计 findings/退出码/报告,汇总单列「命中 N/M」
- **防漂移**:未命中条目 stderr 报警(finding 已消失时台账应清理);**fail-closed**:坏 JSON/缺字段/未知 rule_id exit 2
- **整规则豁免被有意排除**:新图违规永远照报——豁免只覆盖作者已裁决的历史项
- 背景:书仓作者 2026-08-29 对 W1 两组(SYNTAX-05×58/PADDING-01×85)裁决「接受登记」,本能力是其机械化载体

## 测试计划
- [x] 单测 +3(命中移除/未命中保留+used 空/坏 schema 与未知 rule fail-closed),套件 13/13
- [x] 全书端到端(PM 实跑):348 findings → **205(hard 149→91)**,台账命中 143/143,无漂移报警
- [x] `--help` 自检含新参数

## Agent 归属
PM 主会话实现(书仓 W1 裁决落地);git author PB2;关联书仓 T263 W1/track-6