### PR TITLE
feat(multi-agent-orchestration): add PR-first closeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 | 日期       | 类型   | Skill                                                                 | 版本    | 更新要点                                                                                                                                                                                                                                       |
 | :--------- | :----- | :-------------------------------------------------------------------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 2026-09-03 | 更新   | [multi-agent-orchestration](skills/multi-agent-orchestration/)         | v2.14.1 | **Orca 分支错配前置失败关闭**：worktree 建立后立即核对实际 branch 与 HEAD，同名分支被 Orca 改成 `-2` 后缀时在 terminal、Task 和 worker-start 之前退出，避免留下已注入任务的 partial dispatch；同时增加 reviewer 证据预算与正反 E2E 回归。 |
+| 2026-09-04 | 更新   | [multi-agent-orchestration](skills/multi-agent-orchestration/)         | v2.15.0 | **PR-first 唯一审计与事务式本地集成**：create 前机械区分 exact/suspected/unrelated PR，唯一 worker 自建 PR 可接管；本地候选以三方 patch 保留 fresh main 并从隔离 clone 安全推送，保护/漂移/授权未知时停在非成功 `VALIDATE_ONLY`。 |
 | 2026-08-30 | 更新   | [elements-complaint-generator](skills/elements-complaint-generator/)   | v0.15.0 | **最终版式门禁与失败安全**：新增独立 DOCX/PDF 检查器，统一表格居中、固定列宽、跨页行和连续页码，保留横竖版边界；候选件经 LibreOffice 真实渲染通过后才发布。113 棵模板静态门禁与 21 类文书真实 PDF 抽样通过，68 棵主文书逐树长文本压力矩阵继续列为 P0。 |
 | 2026-08-30 | 更新   | [video-screenshot](skills/video-screenshot/)                           | v0.8.2 | **事务性输出与失败安全**：参数和视频先预检，新结果在同级 staging 完整生成后才替换旧结果；新增所有权标记、旧版报告兼容校验、符号链接/未知文件/下游产物保护，以及损坏视频和提交回滚真实 CLI 回归 |
 | 2026-08-30 | 更新   | [legal-industry-report](skills/legal-industry-report/)               | v1.1.0 | **法律专业正式行业报告（月度/季度）**：增加 `legal-` 领域前缀，统一法律研报产品命名；继续面向公开展示与广泛分发，保留行业全景、规则包、证据账本和机构出版物式 PDF。 |
@@ -645,7 +645,7 @@
 <td>工具·Agent协作</td>
 <td style="word-break:break-word">Orca-first 多 Agent 本地编排，支持 Wave receipt、worktree/terminal UI、Run/Task/Dispatch、worker transcript、严格 lifecycle 结算、五后端总控、Harness 层级门禁、Wave Autopilot live-session 快路径与 L2 跨会话持久 controller core</td>
 <td style="text-align:center">MIT</td>
-<td style="text-align:center">v2.14.1</td>
+<td style="text-align:center">v2.15.0</td>
 <td style="text-align:center"><a href="https://github.com/cat-xierluo/legal-skills/releases/download/v2026.08.06/multi-agent-orchestration-1.20.5.zip">下载 v1.20.5</a></td>
 <td></td>
 </tr>

--- a/skills/multi-agent-orchestration/CHANGELOG.md
+++ b/skills/multi-agent-orchestration/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [2.15.0] - 2026-09-04
+
+### 新增
+
+- **PR 唯一性审计 `pr-audit.v1`**：新增 `scripts/pr-audit.py` 与 `pm-orchestrate.sh pr-audit`。按 canonical repo/Git common dir、base/head ref 与 OID、head repository、真实 diff 指纹相等以及独立 `Task:`/`Agent:` trailer，把 open PR 分为 exact、suspected、unrelated；同 head 错 SHA、元数据相同但 diff 不同、同内容异分支、fork、事实未知和候选截断均失败关闭，stdout 保持单 JSON。
+- **PR-first 三态收口**：`pm-closeout.sh` 新增 `local-after-pr`（默认）、`remote-pr`、`validate-only`，以及两阶段显式授权：第一阶段绑定 repo/PR/head/SHA/operation，main mutation 前第二阶段再绑定最终 base/candidate/tree。只读预审发生在任何 push/create 之前，唯一 worker 自建 PR 可直接接管，zero 才允许授权式 push/create；调用方 body 中保留 `Task:`/`Agent:` trailer 会在 mutation 前被拒。
+
+### 修复
+
+- **本地 main 事务边界**：候选改为在 fresh main 隔离 clone 中对冻结 worker patch 做三方应用，不再整文件覆盖 main；从隔离 main 候选 safe-push，远端确认后才快进真实 clean main。scope 冲突、safe-push 失败、错误/dirty/进行中 Git 操作的 main worktree 均保持 main 不变。
+- **保护规则与漂移失败关闭**：改读 GitHub branch metadata 的类型化 `.protected` 布尔值，同时覆盖 classic branch protection 与 rulesets；只有明确 `false` 才允许本地 main push，并在最终 push 前再次确认，403/404/畸形/中途翻转都降为非成功 `VALIDATE_ONLY`。最终 main push/GitHub merge 前重跑唯一 PR 审计并复核 base/head/diff/checks/review；远端 mutation 前另拒绝原生 merge queue（留给 Task-070），合并用 `--match-head-commit`，成功还需验证三字段、merge commit 已进入 main、第一父提交等于已审 base 且 tree 等于候选 tree。
+- **分布式 commit point 状态**：普通失败（exit 2–8）保持 main 零 mutation；create/merge/push/close 调用开始后若服务端可能已提交但回执、tree 或本地同步不确定，统一 exit 9 输出 `OUTCOME_UNKNOWN`、`REVIEW_REQUIRED` 或 `LOCAL_PENDING`，保留精确 PR/commit 供恢复，禁止把部分成功伪报成普通失败或盲重试。
+
+### 技术优化
+
+- `test-pr-audit.sh` 新增 18 项分类、GHE/凭证脱敏、diff mismatch、101 条截断和稳定错误合同测试；`test-pm-closeout.sh` 扩至 118 项，覆盖原 36 项及 validate-only 零写入、自建 PR 接管、create/same-content race、同文件三方合并/冲突、classic/ruleset/merge-queue 保护分流、保护中途翻转、base TOCTOU、candidate-bound 重授权、post-commit outcome-unknown/local-pending、Git/PR diff 凭证脱敏、scope/pathspec、safe-push 失败、错误 main worktree、可靠 Git operation marker（active rebase 目录拒绝、stale `REBASE_HEAD` 忽略）与最终 PR 集合漂移。
+
+### 待办事项
+
+- 真实 GitHub 非保护仓的 `PR → 隔离 main push → 本地 main 快进 → PR close`，以及保护仓的 `PR → 本地候选 → GitHub merge` 尚未在本次本地环境执行，标记 `NOT_VERIFIED`；确定性 fake-gh/throwaway Git 证据不得替代真实外部验收。
+
 ## [2.14.2] - 2026-09-03
 
 ### 修复（pm-monitor tmux 判活三态，Task-113）

--- a/skills/multi-agent-orchestration/SKILL.md
+++ b/skills/multi-agent-orchestration/SKILL.md
@@ -3,7 +3,7 @@ name: multi-agent-orchestration
 description: 本技能应在用户要求并行推进多个任务、开启多个 worker/agent、使用 Orca Run/Task/Dispatch 或 tmux 独立 session、让 PM 通过 UI/会话转录实时巡检并统一调度 Claude Code、Codex、CodeBuddy、QoderWork 等 CLI，或要求防止 PM 直接实现逃逸时使用；用户授权 Wave Autopilot 后，PM 按项目任务源固定策略自动链式推进波次（组波/派单/验收/合并/泊车）。触发词包括“并行推进”“开多个 worker”“Orca 编排”“supervised worker”“PM 总控”“独立 session”“多 agent 并行”“分派任务”“自动推进”“Wave Autopilot”“自动组波/自动推进波次”。不要用于单个短任务、纯任务状态同步，或 Git 分支/提交/PR/merge 规则。
 license: MIT
 metadata:
-  version: "2.14.2"
+  version: "2.15.0"
   homepage: https://github.com/cat-xierluo/legal-skills
   author: 杨卫薪律师（微信ywxlaw）
 ---
@@ -379,7 +379,7 @@ PM 必须：
 2. 运行与产物类型匹配的验证；GUI/Web/桌面行为要启动真实入口做代表性交互。
 3. 核对 allowed files、敏感文件、安装授权、Git identity、commit 和 PR 范围。
 4. supervised worker 先 reuse/release/retain，再 ack；不得因为只读检查“看起来完成”而跳过 settlement。worker 仍存活且漏发 `worker_done` 时先结构化提醒；确认已死才走 `settle`。terminal-managed/tmux 按用户意图保留或关闭。
-5. 用户或项目已授权 Git 外部写入时，默认按 **PR 先行** 收口：先 safe-push 并创建或接管唯一匹配的 PR，冻结其 base/head/diff/checks 作为审阅边界；PM 验收后再在最新 main 上建立本地集成候选并复跑门禁。Monorepo 不得直接 `git merge` feature 分支，按 `git-workflow` 使用目录级或 squash 集成；main 有保护规则时，本地候选只用于验收，最终仍由 GitHub PR merge。该顺序不自动授予 push/merge/close 权限；Task-097 完成前，现有 `pm-closeout.sh` 仍会在 create 后直接 GitHub merge，选择本地集成时不得调用该一体化路径。详细分流见 `references/14-pm-orchestrate.md` §4。
+5. 用户或项目已授权 Git 外部写入时，默认按 **PR 先行** 收口：先用 `pm-orchestrate.sh pr-audit` 或 `pm-closeout.sh` 只读预审 open PR；唯一 exact（含真实 diff 指纹相等）才接管，任何 suspected/多候选都失败关闭，零候选才在绑定 repo/head/SHA/operation 的显式授权回执通过后 safe-push 并创建。冻结 PR 的 base/head/diff/checks/review 后，从最新 main 构造三方 patch 候选并复跑门禁；main mutation 还需第二阶段回执绑定最终 base/candidate/tree，随后再次核对唯一 PR 集合与整份冻结快照。`local-after-pr` 仅在 GitHub branch metadata 明确 `protected=false` 时从隔离 main 候选 safe-push，并在 push 前再次确认仍为 false，远端确认后才快进本地 clean main；`remote-pr` 先确认无原生 merge queue，再使用 `--match-head-commit` 交给 GitHub 合并，并核对 merge parent/tree 与已验证候选一致；queue 消费留给 Task-070。`validate-only` 不 push、不 create、不 merge。Monorepo 不得直接 `git merge` feature 分支，两种写入模式都必须声明 `--integration-path`。main commit point 前的普通失败必须零 main mutation；commit point 后的回执丢失或结果漂移必须输出 exit 9 的 `OUTCOME_UNKNOWN/REVIEW_REQUIRED/LOCAL_PENDING`，先查远端再恢复，禁止盲重试。详细参数、授权回执和状态语义见 `references/14-pm-orchestrate.md` §4。
 6. 合并 worker 分支后必须 diff 校验共享文档真值：worker 违规写入 `docs/TASKS.md`
    等共享文档的改动会随合并带回，`git diff <base>...HEAD -- docs/TASKS.md`（及
    CHANGELOG/DECISIONS）逐处核对；发现 worker 版本覆盖 PM 真值时以 main 版本
@@ -483,7 +483,7 @@ session id（authority receipt 每会话唯一，fail-closed），切 provider �
 | `bash` 4+ | macOS: `brew install bash`；Linux: 包管理器安装 |
 | `git` | macOS: `xcode-select --install` 或 `brew install git` |
 | `jq` | macOS: `brew install jq`；Linux: `sudo apt-get install jq` |
-| `gh` | 仅 `pm-closeout.sh` 的 PR 创建/合并需要；macOS: `brew install gh`；Linux: 按 GitHub CLI 官方包安装 |
+| `gh` | `pr-audit` 的只读 PR 事实与 `pm-closeout.sh` 的授权式 PR 创建/合并需要；macOS: `brew install gh`；Linux: 按 GitHub CLI 官方包安装 |
 | `tmux` | 仅 tmux 路径需要；macOS: `brew install tmux` |
 | `python3` | 安装门禁和 scope guard 需要 |
 
@@ -527,6 +527,7 @@ Hard Fail：
 12. 非平凡实现波未过 `review-acceptance-gate.py` 就接受交付/合并；或 PM 实现/深度审查例外缺枚举 `reason_code`、非空 `reason` 或 `authorized_by`，或把 `ordinary_delivery: false` 的收口计为常规交付。
 13. 验收失败未过 `acceptance-recovery.py` 分类就泊车（internal_recoverable 修复预算未耗尽即 park），或在 runtime/heartbeat/文档之外另写「gate failure => park」分类分支。
 14. reviewer dispatch 未按 `--role reviewer` 纪律约束写范围：无 `--review-repair-grant` 授权却写自身 Session Context 之外，或写任何 `config/*.local.yaml`；或 docs-only acceptance repair 未过 `acceptance-repair-gate.py` preflight/postflight（缺字段、head 漂移、范围外/非文档修改、未解决 blocker、重复修复、owner 串行冲突任一即拒绝）。
+15. PR 收口在 create/push/merge 前未通过唯一性审计，第一阶段授权未绑定 canonical repo、PR、head branch、冻结 SHA 与 operation，第二阶段 main mutation 授权未再绑定最终 base/candidate/tree，或 mutation 前未重验 PR 集合、base/head/diff/checks/review；commit point 前的不确定性必须停在非成功 `VALIDATE_ONLY`，commit point 后的不确定性必须输出 exit 9 的可恢复状态并禁止盲重试。
 
 修改本 Skill 后至少运行：
 
@@ -557,6 +558,7 @@ bash scripts/test-orca-wave-lifecycle.sh
 bash scripts/test-settle-liveness.sh
 bash scripts/test-settle-command.sh
 bash scripts/test-recover-unconfigured.sh
+bash scripts/test-pr-audit.sh
 bash scripts/test-pm-closeout.sh
 python3 scripts/test-autopilot-controller.py
 python3 scripts/test-autopilot-facts.py

--- a/skills/multi-agent-orchestration/references/14-pm-orchestrate.md
+++ b/skills/multi-agent-orchestration/references/14-pm-orchestrate.md
@@ -1,6 +1,6 @@
 # PM 统一控制入口
 
-> `scripts/pm-orchestrate.sh`；本页适配 `multi-agent-orchestration` v2.10.1。
+> `scripts/pm-orchestrate.sh`；本页适配 `multi-agent-orchestration` v2.15.0。
 
 ## 目录
 
@@ -101,35 +101,71 @@ worker 分支提交
 
 ### 4.1 先查已有 PR，避免双开
 
-worker 可能已经自行 push/开 PR。PM 在 `gh pr create` 前先按精确 head 分支列出 open PR，并核对 `baseRefName`、`headRefName`、`headRefOid`、任务范围和 Agent 归属：
+worker 可能已经自行 push/开 PR。先运行只读审计：
 
 ```bash
-gh pr list --state open --head "$BRANCH" \
-  --json number,url,baseRefName,headRefName,headRefOid,title
+bash scripts/pm-orchestrate.sh pr-audit \
+  --worktree "$WT" --base-ref main --head-ref "$BRANCH" --head-sha "$HEAD_SHA" \
+  --task-id Task-097 --agent-id agent-name
 ```
 
-- 恰有一个 PR 且 head SHA 等于本轮冻结的 worker tip：接管该 PR 做验收，不再创建。
-- 没有匹配 PR：完成 safe-push 后创建一个显式 `--head "$BRANCH"` 的 PR。
-- 多个候选、同分支但 SHA 不同、或不同分支出现疑似同内容 PR：失败关闭，逐个比较 diff 后由 PM 选择；不得猜测、不得再开一个 PR。
+- stdout 只有一个 `pr-audit.v1` JSON；stderr 只写摘要 receipt，机器消费者不得混读。
+- `exact` 同时要求 canonical repo/Git common dir、base ref/OID、head owner/ref/OID、真实 diff 指纹相等以及独立 `Task:`/`Agent:` trailer 一致；恰好一个 exact 且零 suspected 才返回 `adopt`。
+- 同 head 错 SHA、同内容异分支、fork/cross-repository、归属不完整、diff/候选事实未知或 101 条候选截断都归 `suspected/ambiguous`，禁止 push/create。
+- `create` 只表示当前只读证据允许进入授权门禁；不是 push 或创建权限。
 - 接管 worker 自建 PR 不降低门禁：仍检查完整 diff、identity、checks、review、敏感文件和声明范围。
 
-Task-097 将把上述检查机械化为 `pr-audit` 与 `pm-closeout` 的 create 前门禁；完成前按本节手工执行，不能声称已有自动去重。
+### 4.2 授权回执与 `pm-closeout`
 
-> **当前脚本能力告警**：`pm-closeout.sh` 目前是一体化的 `safe-push → gh pr create → gh pr merge`，没有“创建 PR 后暂停并转本地集成”的开关。选择 `LOCAL_INTEGRATE` 时不得运行这条旧的一体化路径；先按本节手工分段，等 Task-097 为脚本补齐显式三态后再恢复自动收口。
+所有 mutation 授权只接受本次 CLI 的显式参数，不从可继承环境变量取得。push/create 的第一阶段回执必须与脚本打印的 expected 字符串逐字一致：
 
-### 4.2 本地集成的三种结果
+```text
+operation=<branch-push|pr-create|main-push|remote-merge|pr-close>;
+repo=<HOST/OWNER/REPO>;pr=<PR号或none>;head=<branch>;sha=<40-hex>
+```
+
+实际值为单行、无换行；上方仅为字段说明。典型调用：
+
+```bash
+bash scripts/pm-closeout.sh \
+  --worktree "$WT" --main-worktree "$MAIN_WT" \
+  --mode local-after-pr --main-protection auto \
+  --task-id Task-097 --agent-id agent-name \
+  --integration-path skills/multi-agent-orchestration \
+  --title "feat(multi-agent-orchestration): ..." \
+  --safe-push-script /absolute/path/to/git-workflow/scripts/safe-push.sh \
+  --verify-cmd bash --verify-arg scripts/test-pm-closeout.sh \
+  --authorize-main-push 'operation=main-push;repo=github.com/OWNER/REPO;pr=123;head=feat/x;sha=<40-hex>' \
+  --authorize-main-candidate 'operation=main-push-candidate;repo=github.com/OWNER/REPO;pr=123;head=feat/x;sha=<40-hex>;base=<40-hex>;candidate=<40-hex>;tree=<40-hex>'
+```
+
+若预审为 zero，还需在任何写入前同时提供绑定相同 repo/head/SHA 的 `--authorize-branch-push` 与 `--authorize-pr-create`；worker 已自建 exact PR 时两者都不需要。`--authorize-pr-close` 独立可选：省略时本地集成完成后保留 PR open；提供但不匹配时在 main push 前失败。
+
+候选完成后还有第二阶段 mutation challenge，绑定最终 `base/candidate/tree`；调用方必须把完整 expected 值原样传回 `--authorize-main-candidate` 或 `--authorize-remote-candidate`。main 前移会改变 challenge，旧回执不可复用：首次调用可以停在 exit 8 的 `VALIDATE_ONLY`，审阅 challenge 后再用同一参数重跑。粗粒度 `main-push/remote-merge` 回执与候选回执缺一不可。
+
+调用方 `body-file` 不得自带 `Task:`/`Agent:` trailer；脚本在任何 push/create 前拒绝，由唯一写入点追加，避免重复或冲突归属导致“PR 已创建但无法接管”。
+
+`--main-protection auto` 读取 GitHub branch metadata 的类型化 `.protected` 布尔值；该字段同时覆盖 classic branch protection 与 rulesets。只有明确 `false` 才认定 unprotected；403/404、缺字段、畸形响应或未知状态都降为非成功 `VALIDATE_ONLY`。本地 main push 前再次读取该字段，候选验证期间从 false 变为 true/unknown 时不沿用旧结论。`--main-protection protected` 只允许显式选择更保守的远端路径，不提供 `unprotected` 绕过开关。
+
+### 4.3 三种收口结果
 
 | 结果 | 适用条件 | 行为 |
 |---|---|---|
-| `LOCAL_INTEGRATE` | 用户/项目允许 PM 更新 main，main 无保护阻断，存在干净且身份唯一的 main worktree | 从最新 `origin/main` 建本地候选，导入冻结的 PR head，复跑门禁，生成带 `(#PR)` 的本地集成提交，再按 `git-workflow` 安全推送 main |
-| `REMOTE_PR_MERGE` | main 有 branch protection、required review/checks，或项目明确以 GitHub 为合并权威 | 本地候选只做验证；确认 PR head 未漂移后用 GitHub squash/merge，并复核 `state/mergedAt/mergeCommit` |
-| `VALIDATE_ONLY` | main worktree dirty/身份不明、PR 不唯一、checks/review 未决、授权不足或范围不清 | 只报告证据与阻塞，不修改 main、不关闭 PR |
+| `LOCAL_AFTER_PR` | branch metadata 正向证明 main unprotected，存在唯一 clean/idle main worktree，且两阶段 main-push 授权均匹配 | 在隔离 main clone 对冻结 worker patch 做三方应用并验证；从隔离 clone safe-push，远端确认后才 `--ff-only` 同步真实 main；提交主题带 `(#PR)` |
+| `REMOTE_PR` | main 有 classic protection/ruleset，或项目明确以 GitHub 为合并权威 | 同样先建本地候选并验证；mutation 前重审唯一 PR 集合与冻结快照，确认无原生 merge queue 后用 `--match-head-commit` 合并，并复核 `state/mergedAt/mergeCommit`、merge 第一父提交等于已审 base、merge tree 等于候选 tree，且 merge commit 已进入 main |
+| `VALIDATE_ONLY` | 用户显式只读，或 main/PR/checks/review/授权/范围/保护状态任一不明 | 显式请求时退出 0；由写入模式自动降级时退出 8，不 push、不 create、不 merge、不 close |
 
-本地集成必须基于再次 fetch 后的最新 `origin/main`，并绑定已经审阅的精确 PR head SHA；任一 SHA、diff 或 checks 在验证期间变化，都回到 PR 审计，不沿用旧结论。
+两种写入模式都必须至少提供一个仓库相对的 `--integration-path`；拒绝绝对路径、`..`、symlink 逃逸与 pathspec magic。候选从冻结 `WORKER_BASE..WORKER_TIP` 生成限定范围的 binary/full-index patch，在 fresh main 上 `--3way --index` 应用；同文件非重叠修改可保留，语义冲突则停在零 main mutation。
 
-Monorepo 禁止直接 `git merge <feature>`。只导入任务声明范围：单 Skill 优先按目录级 checkout；仓库已明确允许 squash 时，仍须先确认 PR 已基于最新 main、diff 仅含声明目录且无意外删除。具体命令、身份门禁和提交格式以 `git-workflow` 为准。
+候选验证后、任何 main push/GitHub merge 前都重新 fetch main、重跑 `pr-audit` 并核对同一 PR 的 base/head/diff/checks/review；任何漂移回到审计，不沿用旧结论。Monorepo 禁止直接 `git merge <feature>`；最终本地同步只允许将已经远端确认的隔离 main 候选 `--ff-only` 到同一 Git common dir 的唯一 clean main worktree。
 
-### 4.3 远端结果与清理
+Task-097 不消费 GitHub 原生 merge queue：远端 mutation 前必须读到类型化 rules 数组且确认没有 `merge_queue`；发现 queue 或 API 状态未知都停在 exit 8 的 `VALIDATE_ONLY`，不得让 `gh pr merge` 留下稍后异步修改 main 的排队项。队列消费和延迟复核属于 Task-070。
+
+普通失败（exit 2–8）都发生在 main commit point 前，因此必须保持 main 未修改。分布式写入存在不可消除的“服务端已提交、客户端回执丢失”窗口；写入调用开始后若无法确认，不得伪称零 mutation，也不得误报成功，而以 exit 9 输出可恢复状态：`PR_CREATE_OUTCOME_UNKNOWN`、`PR_CREATED_REVIEW_REQUIRED`、`REMOTE_MERGE_OUTCOME_UNKNOWN`、`REMOTE_MERGED_REVIEW_REQUIRED`、`MAIN_PUSH_OUTCOME_UNKNOWN`、`REMOTE_MAIN_APPLIED_LOCAL_PENDING` 或 `LOCAL_AFTER_PR_CLOSE_OUTCOME_UNKNOWN`。看到这些状态必须先读取远端真实 PR/main 再决定恢复动作，禁止盲重试 mutation。
+
+`gh pr create` 本身也是分布式 commit point，GitHub 不提供本流程可用的幂等键，另一个 creator 可能在最终审计与 create 之间同时提交。因此本脚本能机械保证的是“commit point 前零 create、单次调用至多一次 create、结果不明时不重试”，不能承诺仓库最终全局零重复 open PR。post-create 重审发现多个候选时保留新建 PR 回执并进入 `PR_CREATED_REVIEW_REQUIRED`；不得在没有独立 close 授权时用自动关闭补偿掩盖竞态。
+
+### 4.4 远端结果与清理
 
 - 本地集成提交成功推入 main 后，原 PR 若未被 GitHub 自动标为 merged，使用包含 main commit SHA 的说明关闭；不得把 `CLOSED` 伪报成 GitHub `MERGED`。
 - GitHub 合并路径以 `state == MERGED`、非空 `mergedAt` 和 `mergeCommit.oid` 为成功证据。

--- a/skills/multi-agent-orchestration/scripts/pm-closeout.sh
+++ b/skills/multi-agent-orchestration/scripts/pm-closeout.sh
@@ -1,17 +1,45 @@
 #!/bin/bash
-# pm-closeout.sh — PM 收口管道：sync-merge→解冲突(安全模式)→门禁→safe-push→PR create/merge(编号机械提取)→验证→清分支
-# 用法: pm-closeout.sh --worktree <path> --title <t> --safe-push-script <path>
-#       --verify-cmd <executable> [--verify-arg <arg> ...] [--body-file <f>] [--keep-branch]
-# 铁律: PR 编号只从 gh pr create 的返回 URL 提取；分支删除只在 state==MERGED 之后。
+# pm-closeout.sh — PR-first PM closeout with exact PR adoption and explicit results.
 set -euo pipefail
 SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SP="${PM_CLOSEOUT_SAFE_PUSH:-}"
 GIT_NAME="${EXPECTED_GIT_NAME:-}"; GIT_EMAIL="${EXPECTED_GIT_EMAIL:-}"
-WT=""; TITLE=""; BODY_FILE=""; VERIFY_BIN=""; KEEP_BRANCH=0; TMP_BODY=""
-WORKER_BASE=""; WORKER_TIP=""; START_MAIN=""; STABLE_MAIN=""; SYNC_STABLE=0
-VERIFY_ARGS=()
+WT=""; MAIN_WT=""; TITLE=""; BODY_FILE=""; VERIFY_BIN=""; KEEP_BRANCH=0; TMP_BODY=""
+WORKER_BASE=""; WORKER_TIP=""; START_MAIN=""; STABLE_MAIN=""
+MODE="${PM_CLOSEOUT_MODE:-local-after-pr}"; MAIN_PROTECTION="${PM_CLOSEOUT_MAIN_PROTECTION:-auto}"
+TASK_ID="${PM_CLOSEOUT_TASK_ID:-}"; AGENT_ID="${PM_CLOSEOUT_AGENT_ID:-}"
+AUTH_BRANCH_PUSH=""; AUTH_PR_CREATE=""; AUTH_MAIN_PUSH=""; AUTH_REMOTE_MERGE=""; AUTH_PR_CLOSE=""
+AUTH_MAIN_CANDIDATE=""; AUTH_REMOTE_CANDIDATE=""
+CANDIDATE_WT=""; CANDIDATE_PARENT=""; CANDIDATE_PATCH=""
+VERIFY_ARGS=(); INTEGRATION_PATHS=()
+
+redact_stream() {
+  python3 -c '
+import re,sys
+value=sys.stdin.read()
+value=re.sub(r"(?i)([a-z][a-z0-9+.-]*://)[^/@\s]+@", r"\1***@", value)
+value=re.sub(r"(?i)([?&](?:access_token|token|password|secret)=)[^&\s]+", r"\1***", value)
+value=re.sub(r"(?i)\b[^\s/@:]+:[^\s@]+@([^\s/:]+)", r"***@\1", value)
+sys.stdout.write(value.strip())'
+}
+
+run_redacted() {
+  local operation=$1 err rc detail
+  shift
+  err=$(mktemp "${TMPDIR:-/tmp}/pm-closeout-error.XXXXXX")
+  if "$@" 2>"$err"; then rc=0; else rc=$?; fi
+  if [ "$rc" -ne 0 ]; then
+    detail=$(redact_stream < "$err")
+    echo "PM_CLOSEOUT_COMMAND_FAILED: operation=$operation exit=$rc detail=${detail:-none}" >&2
+  fi
+  rm -f -- "$err"
+  return "$rc"
+}
 
 cleanup_temp() {
+  if [ -n "$CANDIDATE_PARENT" ] && [ -d "$CANDIDATE_PARENT" ]; then
+    rm -rf -- "$CANDIDATE_PARENT"
+  fi
   if [ -n "$TMP_BODY" ] && [ -f "$TMP_BODY" ]; then
     rm -f -- "$TMP_BODY"
   fi
@@ -20,6 +48,7 @@ trap cleanup_temp EXIT
 
 while [ $# -gt 0 ]; do case $1 in
   --worktree) WT="$2"; shift 2 ;;
+  --main-worktree) MAIN_WT="$2"; shift 2 ;;
   --title) TITLE="$2"; shift 2 ;;
   --body-file) BODY_FILE="$2"; shift 2 ;;
   --safe-push-script) SP="$2"; shift 2 ;;
@@ -27,14 +56,34 @@ while [ $# -gt 0 ]; do case $1 in
   --verify-arg) VERIFY_ARGS+=("$2"); shift 2 ;;
   --verify) echo "PM_CLOSEOUT_USAGE: --verify 字符串已停用；改用 --verify-cmd + --verify-arg，禁止 shell 字符串执行" >&2; exit 64 ;;
   --keep-branch) KEEP_BRANCH=1; shift ;;
+  --mode) MODE="$2"; shift 2 ;;
+  --main-protection) MAIN_PROTECTION="$2"; shift 2 ;;
+  --task-id) TASK_ID="$2"; shift 2 ;;
+  --agent-id) AGENT_ID="$2"; shift 2 ;;
+  --integration-path) INTEGRATION_PATHS+=("$2"); shift 2 ;;
+  --authorize-branch-push) AUTH_BRANCH_PUSH="$2"; shift 2 ;;
+  --authorize-pr-create) AUTH_PR_CREATE="$2"; shift 2 ;;
+  --authorize-main-push) AUTH_MAIN_PUSH="$2"; shift 2 ;;
+  --authorize-remote-merge) AUTH_REMOTE_MERGE="$2"; shift 2 ;;
+  --authorize-main-candidate) AUTH_MAIN_CANDIDATE="$2"; shift 2 ;;
+  --authorize-remote-candidate) AUTH_REMOTE_CANDIDATE="$2"; shift 2 ;;
+  --authorize-pr-close) AUTH_PR_CLOSE="$2"; shift 2 ;;
   *) echo "PM_CLOSEOUT_USAGE: 未知参数 $1" >&2; exit 64 ;;
 esac; done
 [ -n "$WT" ] && [ -n "$TITLE" ] || { echo "PM_CLOSEOUT_USAGE: 需要 --worktree 与 --title" >&2; exit 64; }
-[ -n "$SP" ] && [ -f "$SP" ] && [ ! -L "$SP" ] || {
-  echo "PM_CLOSEOUT_NO_SAFE_PUSH: 需要 --safe-push-script 指向已审查的 git-workflow safe-push.sh（或设置 PM_CLOSEOUT_SAFE_PUSH）" >&2
-  exit 7
+[ -n "$TASK_ID" ] && [ -n "$AGENT_ID" ] || { echo "PM_CLOSEOUT_USAGE: 需要 --task-id 与 --agent-id 绑定 PR 归属" >&2; exit 64; }
+case "$MODE" in local-after-pr|remote-pr|validate-only) ;; *) echo "PM_CLOSEOUT_USAGE: 非法 --mode $MODE" >&2; exit 64 ;; esac
+case "$MAIN_PROTECTION" in auto|protected) ;; *) echo "PM_CLOSEOUT_USAGE: --main-protection 仅接受 auto|protected；unprotected 必须由 GitHub branch metadata 正向证明" >&2; exit 64 ;; esac
+[ "$MODE" = "validate-only" ] || [ "${#INTEGRATION_PATHS[@]}" -gt 0 ] || {
+  echo "PM_CLOSEOUT_USAGE: local-after-pr/remote-pr 至少需要一个 --integration-path" >&2; exit 64
 }
-SP="$(cd "$(dirname "$SP")" && pwd -P)/$(basename "$SP")"
+if [ "$MODE" != "validate-only" ]; then
+  [ -n "$SP" ] && [ -f "$SP" ] && [ ! -L "$SP" ] || {
+    echo "PM_CLOSEOUT_NO_SAFE_PUSH: 需要 --safe-push-script 指向已审查的 git-workflow safe-push.sh（或设置 PM_CLOSEOUT_SAFE_PUSH）" >&2
+    exit 7
+  }
+  SP="$(cd "$(dirname "$SP")" && pwd -P)/$(basename "$SP")"
+fi
 [ -n "$VERIFY_BIN" ] || {
   echo "PM_CLOSEOUT_VERIFY_REQUIRED: 需要 --verify-cmd；多步门禁请封装为仓库内可执行脚本" >&2
   exit 64
@@ -48,147 +97,611 @@ done
 cd "$WT"
 BR=$(git branch --show-current)
 [ -n "$BR" ] || { echo "PM_CLOSEOUT_DETACHED_HEAD: 必须在具名分支收口" >&2; exit 2; }
-[ -n "$GIT_NAME" ] || GIT_NAME=$(git config user.name || true)
-[ -n "$GIT_EMAIL" ] || GIT_EMAIL=$(git config user.email || true)
-[ -n "$GIT_NAME" ] && [ -n "$GIT_EMAIL" ] || {
-  echo "PM_CLOSEOUT_GIT_IDENTITY_REQUIRED: 设置仓库 git user.name/user.email 或 EXPECTED_GIT_NAME/EXPECTED_GIT_EMAIL" >&2
-  exit 7
-}
+if [ "$MODE" != "validate-only" ]; then
+  [ -n "$GIT_NAME" ] || GIT_NAME=$(git config user.name || true)
+  [ -n "$GIT_EMAIL" ] || GIT_EMAIL=$(git config user.email || true)
+  [ -n "$GIT_NAME" ] && [ -n "$GIT_EMAIL" ] || {
+    echo "PM_CLOSEOUT_GIT_IDENTITY_REQUIRED: 设置仓库 git user.name/user.email 或 EXPECTED_GIT_NAME/EXPECTED_GIT_EMAIL" >&2
+    exit 7
+  }
+fi
 echo "PM_CLOSEOUT_BRANCH: $BR"
 
 # 1) 未提交改动检查(fail-closed)
 if [ -n "$(git status --porcelain)" ]; then echo "PM_CLOSEOUT_DIRTY: 工作树有未提交改动,先处理" >&2; exit 2; fi
 
-# 2) 冻结 worker 贡献范围；每次 main 前移后都重新合并并重跑门禁。
-git fetch origin --quiet
+# 2) 冻结 worker 贡献范围。PR 先行，禁止在 worker 分支 merge main。
+run_redacted git-fetch-worker git fetch origin --quiet || exit $?
 WORKER_TIP=$(git rev-parse --verify 'HEAD^{commit}')
 START_MAIN=$(git rev-parse --verify 'origin/main^{commit}')
 WORKER_BASE=$(git merge-base "$WORKER_TIP" "$START_MAIN")
-[ -n "$WORKER_BASE" ] && git merge-base --is-ancestor "$WORKER_BASE" "$WORKER_TIP" || {
+if [ -z "$WORKER_BASE" ] || ! git merge-base --is-ancestor "$WORKER_BASE" "$WORKER_TIP"; then
   echo "PM_CLOSEOUT_WORKER_RANGE_INVALID: base=$WORKER_BASE tip=$WORKER_TIP main=$START_MAIN" >&2
   exit 3
-}
+fi
 echo "PM_CLOSEOUT_WORKER_RANGE: base=$WORKER_BASE tip=$WORKER_TIP start_main=$START_MAIN"
 
-resolve_conflicts() {
-  local message=$1
-  local main_commit=$2
-  python3 "$SKILL_DIR/scripts/pm-closeout-resolve.py" \
-    --worker-base "$WORKER_BASE" --worker-tip "$WORKER_TIP" \
-    --main-commit "$main_commit"
-  git commit -m "$message" --quiet
+# 路径声明使用仓库相对路径，拒绝 absolute/../ 和现有 symlink 组件逃逸。
+validate_integration_path() {
+  python3 - "$1" "$2" <<'PY'
+import os, pathlib, sys
+root=os.path.realpath(sys.argv[1]); value=sys.argv[2]
+parts=pathlib.PurePosixPath(value).parts
+if not value or value.startswith(':') or os.path.isabs(value) or any(p in ('', '.', '..') for p in parts): raise SystemExit(2)
+candidate=os.path.abspath(os.path.join(root, *parts))
+if os.path.commonpath([root, candidate]) != root: raise SystemExit(2)
+probe=root
+for part in parts:
+    probe=os.path.join(probe, part)
+    if os.path.lexists(probe) and os.path.islink(probe): raise SystemExit(3)
+print('/'.join(parts))
+PY
+}
+for i in "${!INTEGRATION_PATHS[@]}"; do
+  normalized=$(validate_integration_path "$WT" "${INTEGRATION_PATHS[$i]}") || {
+    echo "PM_CLOSEOUT_INTEGRATION_PATH_INVALID: ${INTEGRATION_PATHS[$i]}" >&2; exit 2
+  }
+  INTEGRATION_PATHS[i]="$normalized"
+done
+if [ "${#INTEGRATION_PATHS[@]}" -gt 0 ]; then
+  while IFS= read -r -d '' changed; do
+    in_scope=0
+    for scope in "${INTEGRATION_PATHS[@]}"; do
+      case "$changed" in "$scope"|"$scope"/*) in_scope=1; break ;; esac
+    done
+    [ "$in_scope" -eq 1 ] || { echo "PM_CLOSEOUT_SCOPE_VIOLATION: $changed" >&2; exit 3; }
+  done < <(git diff --name-only --no-renames -z "$WORKER_BASE" "$WORKER_TIP")
+fi
+
+# 3) worker 门禁：数组执行，且不得改变工作树、HEAD 或分支。
+verify_head=$WORKER_TIP; verify_branch=$BR
+echo "PM_CLOSEOUT_VERIFY: worker $VERIFY_BIN (${#VERIFY_ARGS[@]} args)"
+if ! "$VERIFY_BIN" "${VERIFY_ARGS[@]}"; then echo "PM_CLOSEOUT_VERIFY_FAILED" >&2; exit 4; fi
+[ -z "$(git status --porcelain)" ] || { echo "PM_CLOSEOUT_VERIFY_DIRTY" >&2; exit 4; }
+after_verify_head=$(git rev-parse --verify 'HEAD^{commit}')
+after_verify_branch=$(git branch --show-current)
+if [ "$after_verify_head" != "$verify_head" ] || [ "$after_verify_branch" != "$verify_branch" ]; then
+  echo "PM_CLOSEOUT_VERIFY_GIT_STATE_CHANGED: before=$verify_head/$verify_branch after=$after_verify_head/$after_verify_branch" >&2; exit 4
+fi
+
+# 4) mutation 前只读预审：唯一 exact 接管，歧义拒绝，zero 才允许进入 push/create。
+audit_prs() {
+  python3 "$SKILL_DIR/scripts/pr-audit.py" --repo "$WT" --base-ref main \
+    --head-ref "$BR" --head-sha "$WORKER_TIP" --task-id "$TASK_ID" --agent-id "$AGENT_ID"
+}
+AUDIT_JSON=$(audit_prs) || exit $?
+AUDIT_DECISION=$(printf '%s' "$AUDIT_JSON" | jq -er '.decision') || { echo "PM_CLOSEOUT_PR_AUDIT_INVALID" >&2; exit 5; }
+REMOTE=$(printf '%s' "$AUDIT_JSON" | jq -er '.repository.remote') || { echo "PM_CLOSEOUT_REMOTE_IDENTITY_INVALID" >&2; exit 5; }
+echo "PM_CLOSEOUT_PR_AUDIT: decision=$AUDIT_DECISION exact=$(printf '%s' "$AUDIT_JSON" | jq -r '.counts.exact') suspected=$(printf '%s' "$AUDIT_JSON" | jq -r '.counts.suspected') unrelated=$(printf '%s' "$AUDIT_JSON" | jq -r '.counts.unrelated')"
+PR_N=""; PR_URL=""
+
+expected_authority() {
+  local operation=$1 pr_number=${2:-none}
+  printf 'operation=%s;repo=%s;pr=%s;head=%s;sha=%s' "$operation" "$REMOTE" "$pr_number" "$BR" "$WORKER_TIP"
+}
+require_authority() {
+  local actual=$1 operation=$2 pr_number=${3:-none} expected
+  expected=$(expected_authority "$operation" "$pr_number")
+  [ "$actual" = "$expected" ] || {
+    echo "PM_CLOSEOUT_AUTHORIZATION_REQUIRED: operation=$operation expected=$expected" >&2
+    return 1
+  }
+}
+require_candidate_authority() {
+  local actual=$1 operation=$2 expected
+  expected=$(printf 'operation=%s;repo=%s;pr=%s;head=%s;sha=%s;base=%s;candidate=%s;tree=%s' \
+    "$operation" "$REMOTE" "$PR_N" "$BR" "$WORKER_TIP" "$STABLE_MAIN" "$CANDIDATE_SHA" "$CANDIDATE_TREE")
+  [ "$actual" = "$expected" ] || {
+    echo "PM_CLOSEOUT_CANDIDATE_AUTHORIZATION_REQUIRED: operation=$operation expected=$expected" >&2
+    return 1
+  }
+}
+finish_validate_only() {
+  local reason=$1 pr_number=${2:-${PR_N:-none}}
+  echo "PM_CLOSEOUT_RESULT: VALIDATE_ONLY pr=$pr_number head=$WORKER_TIP reason=$reason"
+  [ "$MODE" = "validate-only" ] && exit 0
+  exit 8
 }
 
-# 最多 3 轮：每次合并后都必须重新验证；持续前移则失败关闭。
-for sync_attempt in 1 2 3; do
-  git fetch origin --quiet
-  candidate_main=$(git rev-parse --verify 'origin/main^{commit}')
-  if ! git merge-base --is-ancestor "$START_MAIN" "$candidate_main"; then
-    echo "PM_CLOSEOUT_MAIN_HISTORY_REWRITTEN: start=$START_MAIN current=$candidate_main" >&2
-    exit 3
+if [ "$AUDIT_DECISION" = "adopt" ]; then
+  PR_N=$(printf '%s' "$AUDIT_JSON" | jq -er '.exact[0].number | tostring')
+  PR_URL=$(printf '%s' "$AUDIT_JSON" | jq -er '.exact[0].url')
+  echo "PM_CLOSEOUT_PR_ADOPTED: #$PR_N ($PR_URL)"
+elif [ "$AUDIT_DECISION" = "ambiguous" ]; then
+  echo "PM_CLOSEOUT_PR_AMBIGUOUS: exact/suspected candidates require PM review; no PR created" >&2
+  exit 5
+else
+  if [ "$MODE" = "validate-only" ]; then
+    echo "PM_CLOSEOUT_MODE: requested=validate-only effective=validate-only protection=not-queried reason=no-existing-pr"
+    echo "PM_CLOSEOUT_RESULT: VALIDATE_ONLY pr=none head=$WORKER_TIP reason=no-existing-pr"
+    exit 0
   fi
-  if ! git merge-base --is-ancestor "$candidate_main" HEAD 2>/dev/null; then
-    if ! git merge "$candidate_main" -m "sync-merge origin/main (pm-closeout round $sync_attempt)" 2>/dev/null; then
-      resolve_conflicts "sync-merge origin/main (round $sync_attempt, resolved)" "$candidate_main"
+  require_authority "$AUTH_BRANCH_PUSH" branch-push || exit 8
+  require_authority "$AUTH_PR_CREATE" pr-create || exit 8
+
+  if [ -n "$BODY_FILE" ]; then
+    [ -f "$BODY_FILE" ] && [ ! -L "$BODY_FILE" ] || {
+      echo "PM_CLOSEOUT_BODY_FILE_INVALID: $BODY_FILE" >&2; exit 64
+    }
+    if LC_ALL=C grep -Eqi '^(Task|Agent):[[:space:]]*' "$BODY_FILE"; then
+      echo "PM_CLOSEOUT_BODY_TRAILER_RESERVED: body-file 不得自带 Task:/Agent:，由收口脚本唯一追加" >&2
+      exit 64
     fi
   fi
 
-  # 3) 门禁（必需；参数数组执行，不经 shell/eval）
-  verify_head=$(git rev-parse --verify 'HEAD^{commit}')
-  verify_branch=$(git branch --show-current)
-  echo "PM_CLOSEOUT_VERIFY: round=$sync_attempt $VERIFY_BIN (${#VERIFY_ARGS[@]} args)"
-  if ! "$VERIFY_BIN" "${VERIFY_ARGS[@]}"; then
-    echo "PM_CLOSEOUT_VERIFY_FAILED" >&2
-    exit 4
+  run_redacted safe-push-branch "$SP" --repo . --base origin/main --branch "$BR" \
+    --expected-name "$GIT_NAME" --expected-email "$GIT_EMAIL" >/dev/null || exit $?
+  if [ "$(git rev-parse 'HEAD^{commit}')" != "$WORKER_TIP" ] || \
+     [ "$(git branch --show-current)" != "$BR" ] || [ -n "$(git status --porcelain)" ]; then
+    echo "PM_CLOSEOUT_SAFE_PUSH_GIT_STATE_CHANGED: expected=$WORKER_TIP/$BR" >&2; exit 4
   fi
-  if [ -n "$(git status --porcelain)" ]; then
-    echo "PM_CLOSEOUT_VERIFY_DIRTY: 门禁后工作树不干净" >&2
-    exit 4
+  echo "PM_CLOSEOUT_PUSHED: $BR"
+
+  # Push 与 create 之间也可能有 worker/其他 PM 自建 PR；再次审计后才决定 create。
+  POST_PUSH_AUDIT=$(audit_prs) || exit $?
+  POST_PUSH_DECISION=$(printf '%s' "$POST_PUSH_AUDIT" | jq -er '.decision') || { echo "PM_CLOSEOUT_PR_AUDIT_INVALID" >&2; exit 5; }
+  if [ "$POST_PUSH_DECISION" = "adopt" ]; then
+    PR_N=$(printf '%s' "$POST_PUSH_AUDIT" | jq -er '.exact[0].number | tostring')
+    PR_URL=$(printf '%s' "$POST_PUSH_AUDIT" | jq -er '.exact[0].url')
+    echo "PM_CLOSEOUT_PR_ADOPTED_AFTER_PUSH_RACE: #$PR_N ($PR_URL)"
+  elif [ "$POST_PUSH_DECISION" = "ambiguous" ]; then
+    echo "PM_CLOSEOUT_PR_AMBIGUOUS_AFTER_PUSH: no PR created" >&2
+    exit 5
   fi
-  after_verify_head=$(git rev-parse --verify 'HEAD^{commit}')
-  after_verify_branch=$(git branch --show-current)
-  if [ "$after_verify_head" != "$verify_head" ] || \
-     [ "$after_verify_branch" != "$verify_branch" ] || \
-     [ "$after_verify_branch" != "$BR" ]; then
-    echo "PM_CLOSEOUT_VERIFY_GIT_STATE_CHANGED: before=$verify_head/$verify_branch after=$after_verify_head/$after_verify_branch" >&2
-    exit 4
+
+  if [ -z "$PR_N" ]; then
+    TMP_BODY=$(mktemp "${TMPDIR:-/tmp}/pm-closeout-body.XXXXXX")
+    if [ -n "$BODY_FILE" ]; then
+      command cat -- "$BODY_FILE" > "$TMP_BODY"
+      printf '\n\nTask: %s\nAgent: %s\n' "$TASK_ID" "$AGENT_ID" >> "$TMP_BODY"
+    else
+      printf '%s\n\nTask: %s\nAgent: %s\n\n%s\n' "$TITLE" "$TASK_ID" "$AGENT_ID" \
+        '- 管道自动收口（未提供 body-file）：验证证据见分支提交与门禁日志。' > "$TMP_BODY"
+    fi
+    BODY_FILE="$TMP_BODY"
+  CREATE_ARGS=(--repo "$REMOTE" --base main --head "$BR" --title "$TITLE" --body-file "$BODY_FILE")
+  set +e
+  CREATE_OUT=$(gh pr create "${CREATE_ARGS[@]}" 2>&1)
+  create_rc=$?
+  set -e
+  receipt_pr=""
+  if [ "$create_rc" -eq 0 ]; then
+    PR_URL=$(printf '%s\n' "$CREATE_OUT" | tail -1)
+    PR_N=$(printf '%s\n' "$PR_URL" | sed -nE 's#^.*/pull/([0-9]+).*$#\1#p')
+    receipt_pr=$PR_N
   fi
-  if ! git merge-base --is-ancestor "$candidate_main" HEAD; then
-    echo "PM_CLOSEOUT_VERIFY_BASE_LOST: candidate_main=$candidate_main head=$after_verify_head" >&2
-    exit 4
+  # create 成败都只重审一次。失败可能是并发创建；只有唯一 exact 才接管。
+  set +e
+  POST_CREATE_AUDIT=$(audit_prs)
+  post_create_audit_rc=$?
+  set -e
+  if [ "$post_create_audit_rc" -ne 0 ]; then
+    echo "PM_CLOSEOUT_RESULT: PR_CREATE_OUTCOME_UNKNOWN head=$WORKER_TIP reason=post-create-audit-failed" >&2
+    exit 9
   fi
-  git_dir=$(git rev-parse --git-dir)
-  for operation_marker in MERGE_HEAD CHERRY_PICK_HEAD REBASE_HEAD REVERT_HEAD; do
-    if [ -e "$git_dir/$operation_marker" ]; then
-      echo "PM_CLOSEOUT_VERIFY_OPERATION_IN_PROGRESS: $operation_marker" >&2
-      exit 4
+  POST_CREATE_DECISION=$(printf '%s' "$POST_CREATE_AUDIT" | jq -er '.decision') || {
+    echo "PM_CLOSEOUT_RESULT: PR_CREATE_OUTCOME_UNKNOWN head=$WORKER_TIP reason=post-create-audit-invalid" >&2
+    exit 9
+  }
+  if [ "$POST_CREATE_DECISION" != "adopt" ]; then
+    if [ "$create_rc" -ne 0 ]; then
+      create_detail=$(printf '%s' "$CREATE_OUT" | redact_stream)
+      echo "PM_CLOSEOUT_RESULT: PR_CREATE_OUTCOME_UNKNOWN head=$WORKER_TIP audit=$POST_CREATE_DECISION detail=${create_detail:-none}" >&2
+    else
+      echo "PM_CLOSEOUT_RESULT: PR_CREATED_REVIEW_REQUIRED pr=$PR_N head=$WORKER_TIP audit=$POST_CREATE_DECISION" >&2
+    fi
+    exit 9
+  fi
+  adopted_n=$(printf '%s' "$POST_CREATE_AUDIT" | jq -er '.exact[0].number | tostring')
+  adopted_url=$(printf '%s' "$POST_CREATE_AUDIT" | jq -er '.exact[0].url')
+  if [ "$create_rc" -eq 0 ] && [ -n "$receipt_pr" ] && [ "$adopted_n" != "$receipt_pr" ]; then
+    echo "PM_CLOSEOUT_RESULT: PR_CREATED_REVIEW_REQUIRED pr=$receipt_pr head=$WORKER_TIP audit_pr=$adopted_n reason=receipt-audit-mismatch" >&2
+    exit 9
+  fi
+  PR_N=$adopted_n; PR_URL=$adopted_url
+  if [ "$create_rc" -eq 0 ]; then echo "PM_CLOSEOUT_PR_CREATED: #$PR_N ($PR_URL)"
+  else echo "PM_CLOSEOUT_PR_ADOPTED_AFTER_CREATE_RACE: #$PR_N ($PR_URL)"; fi
+  fi
+fi
+echo "PM_CLOSEOUT_PR: #$PR_N ($PR_URL)"
+
+# 6) 冻结 PR base/head OID、真实 diff、checks/review canonical digest。
+pr_snapshot() {
+  gh pr view "$PR_N" --repo "$REMOTE" \
+    --json number,url,state,baseRefName,baseRefOid,headRefName,headRefOid,statusCheckRollup,reviewDecision,mergeable,mergedAt,mergeCommit
+}
+pr_diff_digest() {
+  local diff_file rc=0
+  diff_file=$(mktemp "${TMPDIR:-/tmp}/pm-closeout-pr-diff.XXXXXX")
+  run_redacted pr-diff gh pr diff "$PR_N" --repo "$REMOTE" > "$diff_file" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    rm -f -- "$diff_file"
+    return "$rc"
+  fi
+  python3 -c 'import hashlib,sys; print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest())' < "$diff_file" || rc=$?
+  rm -f -- "$diff_file"
+  return "$rc"
+}
+canonical_gate_digest() {
+  python3 -c '
+import hashlib,json,sys
+d=json.load(sys.stdin); checks=d.get("statusCheckRollup")
+if not isinstance(checks,list): raise SystemExit(2)
+checks=sorted(checks,key=lambda x:json.dumps(x,sort_keys=True,separators=(",",":")))
+raw=json.dumps({"checks":checks,"reviewDecision":d.get("reviewDecision")},sort_keys=True,separators=(",",":")).encode()
+print(hashlib.sha256(raw).hexdigest())'
+}
+snapshot_ready() {
+  local s=$1
+  printf '%s' "$s" | python3 -c '
+import json,sys
+expected=sys.argv[1]; expected_branch=sys.argv[2]
+try: d=json.load(sys.stdin)
+except Exception: raise SystemExit(2)
+required=("state","baseRefName","baseRefOid","headRefName","headRefOid","statusCheckRollup")
+if any(k not in d for k in required): raise SystemExit(2)
+if d["state"]!="OPEN" or d["baseRefName"]!="main" or d["headRefName"]!=expected_branch or d["headRefOid"]!=expected: raise SystemExit(3)
+if not isinstance(d["baseRefOid"],str) or len(d["baseRefOid"])!=40: raise SystemExit(2)
+if not isinstance(d["statusCheckRollup"],list): raise SystemExit(2)
+good={"SUCCESS","NEUTRAL","SKIPPED"}
+for row in d["statusCheckRollup"]:
+    if not isinstance(row,dict): raise SystemExit(2)
+    status=str(row.get("status") or "").upper()
+    conclusion=str(row.get("conclusion") or row.get("state") or "").upper()
+    if status and status!="COMPLETED": raise SystemExit(1)
+    if conclusion not in good: raise SystemExit(1)
+if str(d.get("reviewDecision") or "") in {"CHANGES_REQUESTED","REVIEW_REQUIRED"}: raise SystemExit(1)
+' "$WORKER_TIP" "$BR"
+}
+
+SNAPSHOT=$(pr_snapshot 2>/dev/null || true)
+if [ -z "$SNAPSHOT" ] || ! snapshot_ready "$SNAPSHOT"; then
+  finish_validate_only pr-snapshot-or-checks-not-ready
+fi
+FROZEN_BASE_OID=$(printf '%s' "$SNAPSHOT" | jq -er '.baseRefOid')
+FROZEN_HEAD_OID=$(printf '%s' "$SNAPSHOT" | jq -er '.headRefOid')
+[ "$FROZEN_BASE_OID" = "$(git rev-parse 'origin/main^{commit}')" ] || {
+  finish_validate_only pr-base-not-fresh
+}
+FROZEN_DIFF=$(pr_diff_digest) || finish_validate_only pr-diff-unavailable
+FROZEN_GATE=$(printf '%s' "$SNAPSHOT" | canonical_gate_digest) || finish_validate_only checks-review-unknown
+echo "PM_CLOSEOUT_REVIEW_FROZEN: pr=$PR_N base=$FROZEN_BASE_OID head=$FROZEN_HEAD_OID diff=$FROZEN_DIFF checks_review=$FROZEN_GATE"
+
+snapshot_still_frozen() {
+  local current diff gate
+  current=$(pr_snapshot 2>/dev/null) || return 1
+  snapshot_ready "$current" || return 1
+  [ "$(printf '%s' "$current" | jq -r '.baseRefOid')" = "$FROZEN_BASE_OID" ] || return 1
+  [ "$(printf '%s' "$current" | jq -r '.headRefOid')" = "$FROZEN_HEAD_OID" ] || return 1
+  diff=$(pr_diff_digest) || return 1
+  gate=$(printf '%s' "$current" | canonical_gate_digest) || return 1
+  [ "$diff" = "$FROZEN_DIFF" ] && [ "$gate" = "$FROZEN_GATE" ]
+}
+audit_still_unique() {
+  local current decision number
+  current=$(audit_prs) || return 1
+  decision=$(printf '%s' "$current" | jq -er '.decision') || return 1
+  [ "$decision" = "adopt" ] || return 1
+  number=$(printf '%s' "$current" | jq -er '.exact[0].number | tostring') || return 1
+  [ "$number" = "$PR_N" ]
+}
+
+# 7) 保护规则与操作授权分流。branch metadata 的 protected 布尔值同时
+# 覆盖 classic branch protection 与 rulesets；未知或畸形结果失败关闭。
+read_protection_state() {
+  local out rc
+  set +e
+  out=$(gh api --hostname "$REMOTE_HOST" "repos/$REMOTE_REPO/branches/main" 2>/dev/null)
+  rc=$?
+  set -e
+  if [ "$rc" -eq 0 ] && printf '%s' "$out" | jq -e '.protected | type == "boolean"' >/dev/null 2>&1; then
+    if [ "$(printf '%s' "$out" | jq -r '.protected')" = "true" ]; then printf 'protected\n'
+    else printf 'unprotected\n'; fi
+  else
+    printf 'unknown\n'
+  fi
+}
+read_merge_queue_state() {
+  local out rc
+  set +e
+  out=$(gh api --hostname "$REMOTE_HOST" "repos/$REMOTE_REPO/rules/branches/main" 2>/dev/null)
+  rc=$?
+  set -e
+  if [ "$rc" -ne 0 ] || ! printf '%s' "$out" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    printf 'unknown\n'
+  elif printf '%s' "$out" | jq -e 'any(.[]; .type == "merge_queue")' >/dev/null 2>&1; then
+    printf 'present\n'
+  else
+    printf 'absent\n'
+  fi
+}
+
+PROTECTION_STATE="$MAIN_PROTECTION"
+REMOTE_HOST=${REMOTE%%/*}
+REMOTE_REPO=${REMOTE#*/}
+if [ "$MAIN_PROTECTION" = "auto" ]; then
+  PROTECTION_STATE=$(read_protection_state)
+fi
+REQUESTED_MODE="$MODE"; EFFECTIVE_MODE="$MODE"; MODE_REASON="requested"
+if [ "$MODE" = "local-after-pr" ] && [ "$PROTECTION_STATE" = "protected" ]; then
+  EFFECTIVE_MODE="remote-pr"; MODE_REASON="protected-main"
+elif [ "$MODE" = "local-after-pr" ] && [ "$PROTECTION_STATE" = "unknown" ]; then
+  EFFECTIVE_MODE="validate-only"; MODE_REASON="main-protection-unknown"
+fi
+if [ "$EFFECTIVE_MODE" = "local-after-pr" ] && ! require_authority "$AUTH_MAIN_PUSH" main-push "$PR_N"; then
+  EFFECTIVE_MODE="validate-only"; MODE_REASON="main-push-authorization-missing-or-mismatched"
+elif [ "$EFFECTIVE_MODE" = "remote-pr" ] && ! require_authority "$AUTH_REMOTE_MERGE" remote-merge "$PR_N"; then
+  EFFECTIVE_MODE="validate-only"; MODE_REASON="remote-merge-authorization-missing-or-mismatched"
+fi
+echo "PM_CLOSEOUT_MODE: requested=$REQUESTED_MODE effective=$EFFECTIVE_MODE protection=$PROTECTION_STATE reason=$MODE_REASON"
+if [ "$EFFECTIVE_MODE" = "validate-only" ]; then
+  echo "PM_CLOSEOUT_RESULT: VALIDATE_ONLY pr=$PR_N head=$WORKER_TIP reason=$MODE_REASON"
+  [ "$REQUESTED_MODE" = "validate-only" ] && exit 0
+  exit 8
+fi
+
+canonical_common_dir() {
+  local repo=$1 raw top
+  raw=$(git -C "$repo" rev-parse --git-common-dir 2>/dev/null) || return 1
+  top=$(git -C "$repo" rev-parse --show-toplevel 2>/dev/null) || return 1
+  case "$raw" in /*) ;; *) raw="$top/$raw" ;; esac
+  (cd "$raw" && pwd -P)
+}
+NEED_MAIN_WT=0
+[ "$EFFECTIVE_MODE" = "local-after-pr" ] && NEED_MAIN_WT=1
+if [ "$NEED_MAIN_WT" -eq 1 ] && [ -z "$MAIN_WT" ]; then
+  main_worktree_count=0
+  while IFS= read -r line; do
+    case "$line" in
+      "worktree "*) candidate_path=${line#worktree } ;;
+      "branch refs/heads/main") MAIN_WT=${candidate_path:-}; main_worktree_count=$((main_worktree_count + 1)) ;;
+    esac
+  done < <(git worktree list --porcelain)
+  if [ "$main_worktree_count" -ne 1 ]; then
+    echo "PM_CLOSEOUT_RESULT: VALIDATE_ONLY pr=$PR_N reason=main-worktree-not-unique"; exit 8
+  fi
+fi
+if [ "$NEED_MAIN_WT" -eq 1 ]; then
+  MAIN_WT=$(cd "$MAIN_WT" 2>/dev/null && pwd -P || true)
+  WORKER_COMMON=$(canonical_common_dir "$WT" || true)
+  MAIN_COMMON=$(canonical_common_dir "$MAIN_WT" || true)
+  WORKER_REMOTE_URL=$(git -C "$WT" remote get-url origin 2>/dev/null || true)
+  MAIN_REMOTE_URL=$(git -C "$MAIN_WT" remote get-url origin 2>/dev/null || true)
+  if [ -z "$MAIN_WT" ] || [ -z "$WORKER_COMMON" ] || [ "$WORKER_COMMON" != "$MAIN_COMMON" ] || [ "$WORKER_REMOTE_URL" != "$MAIN_REMOTE_URL" ]; then
+    echo "PM_CLOSEOUT_RESULT: VALIDATE_ONLY pr=$PR_N reason=main-worktree-wrong-repository"; exit 8
+  fi
+  if [ "$(git -C "$MAIN_WT" branch --show-current 2>/dev/null || true)" != "main" ]; then
+    echo "PM_CLOSEOUT_RESULT: VALIDATE_ONLY pr=$PR_N reason=main-worktree-wrong-branch"; exit 8
+  fi
+  if [ -n "$(git -C "$MAIN_WT" status --porcelain)" ]; then
+    echo "PM_CLOSEOUT_RESULT: VALIDATE_ONLY pr=$PR_N reason=main-worktree-dirty"; exit 8
+  fi
+  main_git_dir=$(git -C "$MAIN_WT" rev-parse --absolute-git-dir 2>/dev/null || true)
+  # REBASE_HEAD may persist after a completed/conflicted rebase; active rebases
+  # are identified by rebase-merge/rebase-apply below.
+  for operation_marker in MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD BISECT_START; do
+    if [ -n "$main_git_dir" ] && [ -e "$main_git_dir/$operation_marker" ]; then
+      echo "PM_CLOSEOUT_RESULT: VALIDATE_ONLY pr=$PR_N reason=main-worktree-operation-in-progress-$operation_marker"; exit 8
     fi
   done
+  for operation_dir in rebase-merge rebase-apply sequencer; do
+    if [ -n "$main_git_dir" ] && [ -e "$main_git_dir/$operation_dir" ]; then
+      echo "PM_CLOSEOUT_RESULT: VALIDATE_ONLY pr=$PR_N reason=main-worktree-operation-in-progress-$operation_dir"; exit 8
+    fi
+  done
+  for scope in "${INTEGRATION_PATHS[@]}"; do
+    validate_integration_path "$MAIN_WT" "$scope" >/dev/null || {
+      echo "PM_CLOSEOUT_RESULT: VALIDATE_ONLY pr=$PR_N reason=integration-path-main-symlink"; exit 8
+    }
+  done
+fi
 
-  git fetch origin --quiet
-  observed_main=$(git rev-parse --verify 'origin/main^{commit}')
-  if ! git merge-base --is-ancestor "$START_MAIN" "$observed_main"; then
-    echo "PM_CLOSEOUT_MAIN_HISTORY_REWRITTEN: start=$START_MAIN current=$observed_main" >&2
-    exit 3
+reset_candidate() {
+  if [ -n "$CANDIDATE_PARENT" ] && [ -d "$CANDIDATE_PARENT" ]; then
+    rm -rf -- "$CANDIDATE_PARENT"
   fi
-  if [ "$observed_main" = "$candidate_main" ]; then
-    STABLE_MAIN="$candidate_main"
-    SYNC_STABLE=1
-    break
-  fi
-  echo "PM_CLOSEOUT_MAIN_ADVANCED: round=$sync_attempt before=$candidate_main after=$observed_main"
-done
-[ "$SYNC_STABLE" -eq 1 ] || {
-  echo "PM_CLOSEOUT_MAIN_MOVED_TOO_MANY_TIMES: max_rounds=3" >&2
-  exit 3
+  CANDIDATE_WT=""; CANDIDATE_PARENT=""; CANDIDATE_PATCH=""
 }
-echo "PM_CLOSEOUT_MAIN_STABLE: $STABLE_MAIN"
 
-# 4) safe-push
-"$SP" --repo . --base origin/main --branch "$BR" --expected-name "$GIT_NAME" --expected-email "$GIT_EMAIL" >/dev/null
-echo "PM_CLOSEOUT_PUSHED: $BR"
-
-# 5) PR create → 从 URL 机械提取编号
-if [ -z "$BODY_FILE" ]; then
-  TMP_BODY=$(mktemp "${TMPDIR:-/tmp}/pm-closeout-body.XXXXXX")
-  printf '%s
-
-%s
-' "$TITLE" "- 管道自动收口（未提供 body-file）：验证证据见分支提交与门禁日志。" > "$TMP_BODY"
-  BODY_FILE="$TMP_BODY"
-fi
-CREATE_ARGS=(--base main --head "$BR" --title "$TITLE" --body-file "$BODY_FILE")
-if ! CREATE_OUT=$(gh pr create "${CREATE_ARGS[@]}" 2>&1); then
-  echo "PM_CLOSEOUT_PR_CREATE_FAILED: $CREATE_OUT" >&2
-  exit 5
-fi
-URL=$(printf '%s\n' "$CREATE_OUT" | tail -1)
-PR_N=$(printf '%s\n' "$URL" | sed -nE 's#^.*/pull/([0-9]+).*$#\1#p')
-[ -n "$PR_N" ] || { echo "PM_CLOSEOUT_PR_CREATE_INVALID_RECEIPT: $CREATE_OUT" >&2; exit 5; }
-echo "PM_CLOSEOUT_PR: #$PR_N ($URL)"
-
-# 6) merge(用提取的编号) + 状态验证
-if ! MERGE_OUT=$(gh pr merge "$PR_N" --squash --subject "$TITLE (#$PR_N)" 2>&1); then
-  echo "PM_CLOSEOUT_MERGE_FAILED: #$PR_N $MERGE_OUT" >&2
-  exit 6
-fi
-if ! STATE_OUT=$(gh pr view "$PR_N" --json state 2>&1); then
-  echo "PM_CLOSEOUT_MERGE_STATE_READ_FAILED: #$PR_N $STATE_OUT" >&2
-  exit 6
-fi
-if ! STATE=$(printf '%s\n' "$STATE_OUT" | jq -er '.state | select(type == "string")'); then
-  echo "PM_CLOSEOUT_MERGE_STATE_INVALID: #$PR_N $STATE_OUT" >&2
-  exit 6
-fi
-[ "$STATE" = "MERGED" ] || { echo "PM_CLOSEOUT_MERGE_UNCONFIRMED: #$PR_N state=$STATE" >&2; exit 6; }
-echo "PM_CLOSEOUT_MERGED: #$PR_N"
-
-# 7) 分支清理(仅在 MERGED 确认后)
-if [ "$KEEP_BRANCH" -eq 0 ]; then
-  if git push origin --delete "$BR" --quiet 2>/dev/null; then
-    echo "PM_CLOSEOUT_BRANCH_DELETED: $BR"
-  else
-    echo "PM_CLOSEOUT_BRANCH_DELETE_WARNING: PR 已合并，但远端分支删除失败，请人工复核 $BR" >&2
+# 8) 从 fresh origin/main 建隔离 main clone；三方应用冻结 patch，冲突即失败关闭。
+WORKER_REMOTE_URL=$(git remote get-url origin)
+CANDIDATE_STABLE=0
+for candidate_round in 1 2 3; do
+  run_redacted git-fetch-candidate-base git fetch origin --quiet || exit $?
+  candidate_main=$(git rev-parse --verify 'origin/main^{commit}')
+  CANDIDATE_PARENT=$(mktemp -d "${TMPDIR:-/tmp}/pm-closeout-candidate.XXXXXX")
+  CANDIDATE_WT="$CANDIDATE_PARENT/repository"
+  CANDIDATE_PATCH="$CANDIDATE_PARENT/worker.patch"
+  run_redacted git-clone-candidate git clone --quiet --no-checkout "$WT" "$CANDIDATE_WT" || exit $?
+  git -C "$CANDIDATE_WT" remote set-url origin "$WORKER_REMOTE_URL"
+  run_redacted git-fetch-candidate git -C "$CANDIDATE_WT" fetch --quiet origin \
+    'main:refs/remotes/origin/main' || exit $?
+  git -C "$CANDIDATE_WT" checkout -q -B main "$candidate_main"
+  git --literal-pathspecs diff --binary --full-index --no-renames \
+    --output="$CANDIDATE_PATCH" "$WORKER_BASE" "$WORKER_TIP" -- "${INTEGRATION_PATHS[@]}"
+  if ! git -C "$CANDIDATE_WT" apply --3way --index "$CANDIDATE_PATCH"; then
+    finish_validate_only integration-conflict
   fi
+  if git -C "$CANDIDATE_WT" diff --cached --quiet; then
+    finish_validate_only empty-integration-candidate
+  fi
+  CANDIDATE_DATE=$(git show -s --format=%aI "$WORKER_TIP")
+  GIT_AUTHOR_DATE="$CANDIDATE_DATE" GIT_COMMITTER_DATE="$CANDIDATE_DATE" \
+    git -C "$CANDIDATE_WT" -c user.name="$GIT_NAME" -c user.email="$GIT_EMAIL" \
+      -c user.useConfigOnly=true -c commit.gpgSign=false -c commit.cleanup=verbatim \
+      -c core.hooksPath=/dev/null \
+      commit -q -m "$TITLE (#$PR_N)"
+  CANDIDATE_SHA=$(git -C "$CANDIDATE_WT" rev-parse 'HEAD^{commit}')
+  CANDIDATE_TREE=$(git -C "$CANDIDATE_WT" rev-parse 'HEAD^{tree}')
+  [ "$(git -C "$CANDIDATE_WT" rev-parse 'HEAD^1')" = "$candidate_main" ] || {
+    echo "PM_CLOSEOUT_CANDIDATE_PARENT_MISMATCH" >&2; exit 4
+  }
+  echo "PM_CLOSEOUT_VERIFY: candidate round=$candidate_round $VERIFY_BIN (${#VERIFY_ARGS[@]} args)"
+  if ! (cd "$CANDIDATE_WT" && "$VERIFY_BIN" "${VERIFY_ARGS[@]}"); then echo "PM_CLOSEOUT_VERIFY_FAILED: candidate" >&2; exit 4; fi
+  [ -z "$(git -C "$CANDIDATE_WT" status --porcelain)" ] && [ "$(git -C "$CANDIDATE_WT" rev-parse HEAD)" = "$CANDIDATE_SHA" ] || {
+    echo "PM_CLOSEOUT_VERIFY_GIT_STATE_CHANGED: candidate" >&2; exit 4
+  }
+  run_redacted git-fetch-after-candidate git fetch origin --quiet || exit $?
+  observed_main=$(git rev-parse --verify 'origin/main^{commit}')
+  if [ "$observed_main" != "$candidate_main" ]; then
+    echo "PM_CLOSEOUT_MAIN_ADVANCED: round=$candidate_round before=$candidate_main after=$observed_main"
+    reset_candidate
+    # main movement changes the PR base and often its diff.  Re-read all review
+    # facts before rebuilding; unknown/pending facts stop rather than inherit.
+    REFRESHED=$(pr_snapshot 2>/dev/null || true)
+    if [ -z "$REFRESHED" ] || ! snapshot_ready "$REFRESHED"; then
+      finish_validate_only main-moved-pr-revalidation-not-ready
+    fi
+    FROZEN_BASE_OID=$(printf '%s' "$REFRESHED" | jq -er '.baseRefOid')
+    FROZEN_HEAD_OID=$(printf '%s' "$REFRESHED" | jq -er '.headRefOid')
+    [ "$FROZEN_BASE_OID" = "$observed_main" ] || {
+      finish_validate_only main-moved-pr-base-not-fresh
+    }
+    FROZEN_DIFF=$(pr_diff_digest) || finish_validate_only main-moved-pr-diff-unavailable
+    FROZEN_GATE=$(printf '%s' "$REFRESHED" | canonical_gate_digest) || {
+      finish_validate_only main-moved-checks-review-unknown
+    }
+    echo "PM_CLOSEOUT_REVIEW_REFROZEN: pr=$PR_N base=$FROZEN_BASE_OID head=$FROZEN_HEAD_OID diff=$FROZEN_DIFF checks_review=$FROZEN_GATE"
+    continue
+  fi
+  if ! snapshot_still_frozen; then echo "PM_CLOSEOUT_REVIEW_DRIFT: head/base/diff/checks changed" >&2; exit 5; fi
+  STABLE_MAIN=$candidate_main; CANDIDATE_STABLE=1; break
+done
+[ "$CANDIDATE_STABLE" -eq 1 ] || { echo "PM_CLOSEOUT_MAIN_MOVED_TOO_MANY_TIMES: max_rounds=3" >&2; exit 3; }
+echo "PM_CLOSEOUT_CANDIDATE_VERIFIED: pr=$PR_N base=$STABLE_MAIN commit=$CANDIDATE_SHA"
+
+# 外部 mutation 使用第二阶段授权，绑定最终验证过的 base、candidate commit 与 tree。
+# main 前移后旧回执必然失效，调用方必须基于新 challenge 明确重授权。
+if [ "$EFFECTIVE_MODE" = "remote-pr" ]; then
+  require_candidate_authority "$AUTH_REMOTE_CANDIDATE" remote-merge-candidate || \
+    finish_validate_only remote-candidate-authorization-missing-or-mismatched
+else
+  require_candidate_authority "$AUTH_MAIN_CANDIDATE" main-push-candidate || \
+    finish_validate_only main-candidate-authorization-missing-or-mismatched
 fi
-echo "PM_CLOSEOUT_OK: pr=$PR_N branch=$BR"
+
+# 9a) protected/remote authority: final unique+snapshot gate, head-locked GitHub merge, three-field confirmation.
+if [ "$EFFECTIVE_MODE" = "remote-pr" ]; then
+  run_redacted git-fetch-before-remote-merge git fetch origin --quiet || exit $?
+  [ "$(git rev-parse 'origin/main^{commit}')" = "$STABLE_MAIN" ] || finish_validate_only origin-main-drift-before-remote-merge
+  audit_still_unique || { echo "PM_CLOSEOUT_PR_SET_DRIFT: before remote merge" >&2; exit 5; }
+  snapshot_still_frozen || { echo "PM_CLOSEOUT_REVIEW_DRIFT: before remote merge" >&2; exit 5; }
+  MERGE_QUEUE_STATE=$(read_merge_queue_state)
+  [ "$MERGE_QUEUE_STATE" = "absent" ] || {
+    finish_validate_only "merge-queue-$MERGE_QUEUE_STATE-task-070-required"
+  }
+  set +e
+  MERGE_OUT=$(gh pr merge "$PR_N" --repo "$REMOTE" --squash \
+    --match-head-commit "$FROZEN_HEAD_OID" --subject "$TITLE (#$PR_N)" 2>&1)
+  merge_rc=$?
+  STATE_OUT=$(gh pr view "$PR_N" --repo "$REMOTE" --json state,mergedAt,mergeCommit 2>&1)
+  state_rc=$?
+  set -e
+  if [ "$state_rc" -ne 0 ] || ! printf '%s' "$STATE_OUT" | jq -e \
+    '.state=="MERGED" and (.mergedAt|type=="string" and length>0) and (.mergeCommit.oid|type=="string" and test("^[0-9a-fA-F]{40}$"))' \
+    >/dev/null 2>&1; then
+    # merge 是远端 commit point；命令/回执失败后不能声称 main 未变。
+    echo "PM_CLOSEOUT_RESULT: REMOTE_MERGE_OUTCOME_UNKNOWN pr=$PR_N head=$WORKER_TIP merge_exit=$merge_rc state_exit=$state_rc" >&2
+    exit 9
+  fi
+  MERGE_SHA=$(printf '%s' "$STATE_OUT" | jq -r '.mergeCommit.oid')
+  run_redacted git-fetch-after-remote-merge git fetch origin --quiet || {
+    echo "PM_CLOSEOUT_RESULT: REMOTE_MERGE_OUTCOME_UNKNOWN pr=$PR_N merge_commit=$MERGE_SHA reason=fetch-failed" >&2
+    exit 9
+  }
+  git merge-base --is-ancestor "$MERGE_SHA" 'origin/main^{commit}' || {
+    echo "PM_CLOSEOUT_RESULT: REMOTE_MERGED_REVIEW_REQUIRED pr=$PR_N merge_commit=$MERGE_SHA reason=commit-not-on-main" >&2
+    exit 9
+  }
+  MERGE_PARENT=$(git rev-parse "$MERGE_SHA^1" 2>/dev/null || true)
+  MERGE_TREE=$(git rev-parse "$MERGE_SHA^{tree}" 2>/dev/null || true)
+  if [ "$MERGE_PARENT" != "$STABLE_MAIN" ] || [ "$MERGE_TREE" != "$CANDIDATE_TREE" ]; then
+    echo "PM_CLOSEOUT_RESULT: REMOTE_MERGED_REVIEW_REQUIRED pr=$PR_N merge_commit=$MERGE_SHA expected_base=$STABLE_MAIN actual_base=${MERGE_PARENT:-unknown} expected_tree=$CANDIDATE_TREE actual_tree=${MERGE_TREE:-unknown}" >&2
+    exit 9
+  fi
+  echo "PM_CLOSEOUT_MERGED: #$PR_N commit=$MERGE_SHA"
+  [ "$KEEP_BRANCH" -eq 1 ] || echo "PM_CLOSEOUT_BRANCH_RETAINED: automatic cleanup belongs to Task-103; no raw delete push"
+  echo "PM_CLOSEOUT_RESULT: REMOTE_PR pr=$PR_N head=$WORKER_TIP merge_commit=$MERGE_SHA"; exit 0
+fi
+
+# 9b) unprotected local authority: push the verified isolated main candidate first;
+# only after remote confirmation fast-forward the user's clean main worktree.
+[ -z "$(git -C "$MAIN_WT" status --porcelain)" ] || finish_validate_only main-worktree-became-dirty
+[ "$(git -C "$MAIN_WT" branch --show-current)" = "main" ] || finish_validate_only main-worktree-branch-drift
+[ "$(git -C "$MAIN_WT" rev-parse HEAD)" = "$STABLE_MAIN" ] || finish_validate_only main-worktree-head-drift
+run_redacted git-fetch-before-local-push git fetch origin --quiet || exit $?
+[ "$(git rev-parse 'origin/main^{commit}')" = "$STABLE_MAIN" ] || finish_validate_only origin-main-drift-before-local-push
+audit_still_unique || { echo "PM_CLOSEOUT_PR_SET_DRIFT: before local main push" >&2; exit 5; }
+snapshot_still_frozen || { echo "PM_CLOSEOUT_REVIEW_DRIFT: before local main push" >&2; exit 5; }
+FINAL_PROTECTION_STATE=$(read_protection_state)
+[ "$FINAL_PROTECTION_STATE" = "unprotected" ] || {
+  finish_validate_only "main-protection-drift-$FINAL_PROTECTION_STATE"
+}
+if [ -n "$AUTH_PR_CLOSE" ]; then require_authority "$AUTH_PR_CLOSE" pr-close "$PR_N" || exit 64; fi
+set +e
+run_redacted safe-push-main "$SP" --repo "$CANDIDATE_WT" --base origin/main --branch main \
+  --expected-name "$GIT_NAME" --expected-email "$GIT_EMAIL" >/dev/null
+safe_push_rc=$?
+set -e
+LOCAL_SHA=$CANDIDATE_SHA
+run_redacted git-fetch-after-local-push git fetch origin --quiet || {
+  echo "PM_CLOSEOUT_RESULT: MAIN_PUSH_OUTCOME_UNKNOWN candidate=$LOCAL_SHA reason=fetch-failed" >&2
+  exit 9
+}
+REMOTE_MAIN=$(git rev-parse 'origin/main^{commit}')
+if [ "$safe_push_rc" -ne 0 ] && [ "$REMOTE_MAIN" != "$LOCAL_SHA" ]; then
+  if [ "$REMOTE_MAIN" = "$STABLE_MAIN" ]; then exit "$safe_push_rc"; fi
+  echo "PM_CLOSEOUT_RESULT: MAIN_PUSH_OUTCOME_UNKNOWN candidate=$LOCAL_SHA remote=$REMOTE_MAIN" >&2
+  exit 9
+fi
+[ "$REMOTE_MAIN" = "$LOCAL_SHA" ] || {
+  echo "PM_CLOSEOUT_RESULT: MAIN_PUSH_OUTCOME_UNKNOWN candidate=$LOCAL_SHA remote=$REMOTE_MAIN" >&2; exit 9
+}
+[ "$(git -C "$CANDIDATE_WT" rev-parse 'HEAD^{tree}')" = "$CANDIDATE_TREE" ] || {
+  echo "PM_CLOSEOUT_RESULT: REMOTE_MAIN_APPLIED_REVIEW_REQUIRED main_commit=$LOCAL_SHA reason=candidate-tree-drift" >&2
+  exit 9
+}
+
+# Remote delivery is complete. Synchronize local main only if its exact preconditions still hold.
+if [ -n "$(git -C "$MAIN_WT" status --porcelain)" ] || \
+   [ "$(git -C "$MAIN_WT" branch --show-current)" != "main" ] || \
+   [ "$(git -C "$MAIN_WT" rev-parse HEAD)" != "$STABLE_MAIN" ]; then
+  echo "PM_CLOSEOUT_RESULT: REMOTE_MAIN_APPLIED_LOCAL_PENDING remote_main=$LOCAL_SHA reason=main-worktree-drift-after-push" >&2
+  exit 9
+fi
+run_redacted git-fetch-main-worktree git -C "$MAIN_WT" fetch origin main --quiet || {
+  echo "PM_CLOSEOUT_RESULT: REMOTE_MAIN_APPLIED_LOCAL_PENDING remote_main=$LOCAL_SHA reason=local-fetch-failed" >&2
+  exit 9
+}
+git -C "$MAIN_WT" merge --ff-only "$LOCAL_SHA" >/dev/null || {
+  echo "PM_CLOSEOUT_RESULT: REMOTE_MAIN_APPLIED_LOCAL_PENDING remote_main=$LOCAL_SHA reason=fast-forward-failed" >&2; exit 9
+}
+[ "$(git -C "$MAIN_WT" rev-parse HEAD)" = "$LOCAL_SHA" ] && \
+[ "$(git -C "$MAIN_WT" rev-parse 'HEAD^{tree}')" = "$CANDIDATE_TREE" ] && \
+[ -z "$(git -C "$MAIN_WT" status --porcelain)" ] || {
+  echo "PM_CLOSEOUT_RESULT: REMOTE_MAIN_APPLIED_LOCAL_PENDING remote_main=$LOCAL_SHA reason=tree-or-status-mismatch" >&2; exit 9
+}
+echo "PM_CLOSEOUT_LOCAL_INTEGRATED: pr=$PR_N commit=$LOCAL_SHA"
+if [ -n "$AUTH_PR_CLOSE" ]; then
+  CLOSE_READY=$(gh pr view "$PR_N" --repo "$REMOTE" --json state,headRefOid 2>/dev/null || true)
+  if [ "$(printf '%s' "$CLOSE_READY" | jq -r '.state // empty' 2>/dev/null)" != "OPEN" ] || \
+     [ "$(printf '%s' "$CLOSE_READY" | jq -r '.headRefOid // empty' 2>/dev/null)" != "$FROZEN_HEAD_OID" ]; then
+    echo "PM_CLOSEOUT_PR_LEFT_OPEN: #$PR_N reason=head-or-state-drift-after-main-push"
+    echo "PM_CLOSEOUT_RESULT: LOCAL_AFTER_PR pr=$PR_N head=$WORKER_TIP main_commit=$LOCAL_SHA"
+    exit 0
+  fi
+  set +e
+  gh pr close "$PR_N" --repo "$REMOTE" --comment "Integrated locally as $LOCAL_SHA" >/dev/null 2>&1
+  close_rc=$?
+  CLOSED=$(gh pr view "$PR_N" --repo "$REMOTE" --json state 2>&1)
+  close_state_rc=$?
+  set -e
+  if [ "$close_state_rc" -ne 0 ] || [ "$(printf '%s' "$CLOSED" | jq -r '.state // empty' 2>/dev/null)" != "CLOSED" ]; then
+    echo "PM_CLOSEOUT_RESULT: LOCAL_AFTER_PR_CLOSE_OUTCOME_UNKNOWN pr=$PR_N main_commit=$LOCAL_SHA close_exit=$close_rc state_exit=$close_state_rc" >&2
+    exit 9
+  fi
+  echo "PM_CLOSEOUT_PR_CLOSED: #$PR_N integrated_commit=$LOCAL_SHA"
+else
+  echo "PM_CLOSEOUT_PR_LEFT_OPEN: #$PR_N reason=close-authorization-missing"
+fi
+echo "PM_CLOSEOUT_RESULT: LOCAL_AFTER_PR pr=$PR_N head=$WORKER_TIP main_commit=$LOCAL_SHA"

--- a/skills/multi-agent-orchestration/scripts/pm-orchestrate.sh
+++ b/skills/multi-agent-orchestration/scripts/pm-orchestrate.sh
@@ -13,10 +13,12 @@ usage() {
   cat >&2 <<'USAGE'
 Usage:
   pm-orchestrate.sh run-create --objective TEXT
+  pm-orchestrate.sh pr-audit --worktree PATH --base-ref main --head-ref BRANCH --head-sha SHA [--task-id ID] [--agent-id ID]
   pm-orchestrate.sh <command> --worktree PATH --session NAME [options]
 
 Commands:
   run-create  Create and bind one Orca Run for a Wave
+  pr-audit    Read-only classification of open PRs for one frozen worker head
   send        Send guidance: Dispatch inbox for supervised, terminal input otherwise
   read|peek   Read exact worker transcript/terminal output; peek uses 15 rows
   show        Show supervised Dispatch state
@@ -67,6 +69,11 @@ Common:
   --resume-text TEXT With `reauthorize`: short continuation note sent to the new terminal
                      after worker-start re-injection (e.g. progress preserved, continue from X)
   --task-id ID       With `reauthorize`: task override when METADATA lacks task_id
+                     With `pr-audit`: optional task ownership marker
+  --agent-id ID      With `pr-audit`: optional Agent ownership marker
+  --base-ref NAME    With `pr-audit`: expected PR base (default: main)
+  --head-ref NAME    With `pr-audit`: exact worker head branch
+  --head-sha SHA     With `pr-audit`: frozen full worker commit id
 
 Supervised wait prints the complete Delivery JSON and never auto-acks it. Process every
 message and decide release/reuse/retain before running `ack`.
@@ -93,6 +100,11 @@ DESTROY=0
 ALLOW_CMDS=()
 REAUTH_RESUME_TEXT=""
 REAUTH_TASK_ID=""
+PR_BASE_REF="main"
+PR_HEAD_REF=""
+PR_HEAD_SHA=""
+PR_TASK_ID=""
+PR_AGENT_ID=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -111,14 +123,18 @@ while [[ $# -gt 0 ]]; do
     --force) FORCE=1; shift ;;
     --allow-cmd) ALLOW_CMDS+=("$2"); shift 2 ;;
     --resume-text) REAUTH_RESUME_TEXT="$2"; shift 2 ;;
-    --task-id) REAUTH_TASK_ID="$2"; shift 2 ;;
+    --task-id) REAUTH_TASK_ID="$2"; PR_TASK_ID="$2"; shift 2 ;;
+    --agent-id) PR_AGENT_ID="$2"; shift 2 ;;
+    --base-ref) PR_BASE_REF="$2"; shift 2 ;;
+    --head-ref) PR_HEAD_REF="$2"; shift 2 ;;
+    --head-sha) PR_HEAD_SHA="$2"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "ERROR: unknown argument: $1" >&2; usage; exit 64 ;;
   esac
 done
 
 case "$COMMAND" in
-  run-create|send|read|peek|show|wait|ack|reply|release|retain|settle|reauthorize|quota-park) ;;
+  run-create|pr-audit|send|read|peek|show|wait|ack|reply|release|retain|settle|reauthorize|quota-park) ;;
   *) echo "ERROR: unknown command: $COMMAND" >&2; usage; exit 64 ;;
 esac
 command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required" >&2; exit 64; }
@@ -131,6 +147,29 @@ if [ "$COMMAND" = "run-create" ]; then
 fi
 
 [ -n "$WORKTREE" ] || { echo "ERROR: --worktree is required" >&2; exit 64; }
+[ "$COMMAND" != "pr-audit" ] || {
+  [ -n "$PR_HEAD_REF" ] && [ -n "$PR_HEAD_SHA" ] || {
+    echo "ERROR: pr-audit requires --head-ref and --head-sha" >&2
+    exit 64
+  }
+  audit_args=(
+    --repo "$WORKTREE" --base-ref "$PR_BASE_REF"
+    --head-ref "$PR_HEAD_REF" --head-sha "$PR_HEAD_SHA"
+  )
+  [ -z "$PR_TASK_ID" ] || audit_args+=(--task-id "$PR_TASK_ID")
+  [ -z "$PR_AGENT_ID" ] || audit_args+=(--agent-id "$PR_AGENT_ID")
+  audit_json=$(python3 "$SCRIPT_DIR/pr-audit.py" "${audit_args[@]}") || exit $?
+  audit_decision=$(printf '%s' "$audit_json" | jq -er '.decision') || {
+    echo "ERROR: pr-audit helper returned invalid JSON" >&2
+    exit 2
+  }
+  audit_exact=$(printf '%s' "$audit_json" | jq -er '.counts.exact')
+  audit_suspected=$(printf '%s' "$audit_json" | jq -er '.counts.suspected')
+  audit_unrelated=$(printf '%s' "$audit_json" | jq -er '.counts.unrelated')
+  echo "PM_ORCHESTRATE_PR_AUDIT: decision=$audit_decision exact=$audit_exact suspected=$audit_suspected unrelated=$audit_unrelated" >&2
+  printf '%s\n' "$audit_json"
+  exit 0
+}
 [ -n "$SESSION" ] || { echo "ERROR: --session is required" >&2; exit 64; }
 [[ "$LINES" =~ ^[0-9]+$ ]] || { echo "ERROR: --lines must be an integer" >&2; exit 64; }
 [[ "$WAIT_TIMEOUT" =~ ^[0-9]+$ ]] || { echo "ERROR: --timeout must be an integer" >&2; exit 64; }

--- a/skills/multi-agent-orchestration/scripts/pr-audit.py
+++ b/skills/multi-agent-orchestration/scripts/pr-audit.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Classify open pull requests against one frozen worker contribution.
+
+The helper is deliberately read-only.  It binds the audit to a local Git common
+directory and one origin remote, then asks ``gh`` for open PR metadata.  Its
+single JSON document is intended to be consumed by pm-closeout.sh.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from urllib.parse import urlsplit
+from typing import Any
+
+
+SCHEMA = "pr-audit.v1"
+HEX40 = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+class AuditError(RuntimeError):
+    pass
+
+
+def redact_sensitive(text: str) -> str:
+    """Redact URL userinfo/query credentials before anything reaches stderr."""
+    value = re.sub(
+        r"(?i)([a-z][a-z0-9+.-]*://)[^/@\s]+@",
+        r"\1***@",
+        text,
+    )
+    value = re.sub(
+        r"(?i)([?&](?:access_token|token|password|secret)=)[^&\s]+",
+        r"\1***",
+        value,
+    )
+    value = re.sub(r"(?i)\b[^\s/@:]+:[^\s@]+@([^\s/:]+)", r"***@\1", value)
+    return value
+
+
+def run(argv: list[str], *, cwd: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    label = " ".join(argv[:3])
+    try:
+        proc = subprocess.run(argv, cwd=cwd, text=True, capture_output=True, shell=False)
+    except FileNotFoundError as exc:
+        raise AuditError(f"dependency_missing command={argv[0]}") from exc
+    except OSError as exc:
+        raise AuditError(f"command_start_failed command={label} error={redact_sensitive(str(exc))}") from exc
+    if check and proc.returncode != 0:
+        detail = redact_sensitive((proc.stderr or proc.stdout).strip())
+        raise AuditError(f"command_failed command={label} exit={proc.returncode} detail={detail or 'none'}")
+    return proc
+
+
+def git(repo: str, *args: str) -> str:
+    return run(["git", *args], cwd=repo).stdout.strip()
+
+
+def canonical_remote(url: str) -> str:
+    """Return credential-free HOST/OWNER/REPO for gh --repo."""
+    value = url.strip().rstrip("/")
+    host = ""
+    path = ""
+    if re.match(r"^[^/@:]+@[^/:]+:.+$", value):
+        authority, path = value.split(":", 1)
+        host = authority.split("@", 1)[1]
+    elif "://" in value:
+        parsed = urlsplit(value)
+        host = parsed.hostname or ""
+        path = parsed.path.lstrip("/")
+    else:
+        # Deterministic throwaway/local remotes are supported without exposing
+        # their filesystem path in JSON or gh argv.
+        leaf = os.path.basename(value)
+        if leaf.endswith(".git"):
+            leaf = leaf[:-4]
+        if not leaf:
+            raise AuditError("origin remote identity is empty")
+        return f"local/repository/{leaf}"
+    if path.endswith(".git"):
+        path = path[:-4]
+    path = path.strip("/")
+    if not host or len(path.split("/")) < 2:
+        raise AuditError("origin must identify a credential-free GitHub/GHE host and owner/repo")
+    return f"{host}/{path}"
+
+
+def fingerprint(raw: str) -> str:
+    # Normalize only Git's transport/object-id decoration.  Content lines,
+    # including trailing spaces, are preserved byte-for-byte.
+    kept: list[str] = []
+    for line in raw.splitlines(keepends=True):
+        kept.append(re.sub(r"^index [0-9a-f]+\.\.[0-9a-f]+", "index <oids>", line))
+    return hashlib.sha256("".join(kept).encode("utf-8")).hexdigest()
+
+
+def ownership_evidence(row: dict[str, Any], task_id: str, agent_id: str) -> dict[str, Any]:
+    body = row.get("body") if isinstance(row.get("body"), str) else ""
+
+    def trailers(label: str) -> list[str]:
+        return [value.strip() for value in re.findall(rf"(?mi)^{label}:[ \t]*(.+?)[ \t]*$", body)]
+
+    task_trailers = trailers("Task")
+    agent_trailers = trailers("Agent")
+    task_match = not task_id or task_trailers == [task_id]
+    agent_match = not agent_id or agent_trailers == [agent_id]
+    return {
+        "task_id": task_id,
+        "agent_id": agent_id,
+        "task_trailers": task_trailers,
+        "agent_trailers": agent_trailers,
+        "task_match": task_match,
+        "agent_match": agent_match,
+        "match": task_match and agent_match,
+    }
+
+
+def row_receipt(
+    row: dict[str, Any],
+    *,
+    classification: str,
+    reasons: list[str],
+    ownership: dict[str, Any],
+    diff_fp: str | None,
+) -> dict[str, Any]:
+    checks = row.get("statusCheckRollup")
+    if isinstance(checks, list):
+        checks = sorted(checks, key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":")))
+    raw_head_owner = row.get("headRepositoryOwner")
+    if isinstance(raw_head_owner, dict):
+        head_owner = raw_head_owner.get("login") or raw_head_owner.get("name")
+    else:
+        head_owner = raw_head_owner
+    return {
+        "number": row.get("number"),
+        "url": row.get("url"),
+        "title": row.get("title"),
+        "base_ref": row.get("baseRefName"),
+        "base_sha": row.get("baseRefOid"),
+        "head_ref": row.get("headRefName"),
+        "head_sha": row.get("headRefOid"),
+        "head_repository_owner": head_owner,
+        "is_cross_repository": row.get("isCrossRepository"),
+        "classification": classification,
+        "reasons": reasons,
+        "ownership": ownership,
+        "diff_fingerprint": diff_fp,
+        "checks_review_fingerprint": hashlib.sha256(
+            json.dumps(
+                {
+                    "reviewDecision": row.get("reviewDecision"),
+                    "statusCheckRollup": checks,
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest(),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--base-ref", default="main")
+    parser.add_argument("--head-ref", required=True)
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--task-id", default="")
+    parser.add_argument("--agent-id", default="")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if not HEX40.fullmatch(args.head_sha):
+        raise AuditError("--head-sha must be a full 40-hex commit id")
+
+    repo = os.path.realpath(args.repo)
+    top = os.path.realpath(git(repo, "rev-parse", "--show-toplevel"))
+    common_raw = git(repo, "rev-parse", "--git-common-dir")
+    common = os.path.realpath(common_raw if os.path.isabs(common_raw) else os.path.join(top, common_raw))
+    resolved_head = git(repo, "rev-parse", "--verify", f"{args.head_sha}^{{commit}}")
+    if resolved_head.lower() != args.head_sha.lower():
+        raise AuditError("--head-sha does not resolve to the frozen commit")
+    current_head = git(repo, "rev-parse", "--verify", "HEAD^{commit}")
+    if current_head != resolved_head:
+        raise AuditError(f"frozen head is not the worktree HEAD: expected={resolved_head} actual={current_head}")
+    current_branch = git(repo, "branch", "--show-current")
+    if current_branch != args.head_ref:
+        raise AuditError(f"head ref is not the worktree branch: expected={args.head_ref} actual={current_branch}")
+
+    run(["git", "fetch", "origin", "--quiet"], cwd=repo)
+    base_tip = git(repo, "rev-parse", "--verify", f"origin/{args.base_ref}^{{commit}}")
+    base_commit = git(repo, "merge-base", resolved_head, base_tip)
+    local_diff = run(
+        ["git", "diff", "--binary", "--full-index", "--no-ext-diff", base_commit, resolved_head],
+        cwd=repo,
+    ).stdout
+    expected_fp = fingerprint(local_diff)
+    remote_url = git(repo, "remote", "get-url", "origin")
+    remote = canonical_remote(remote_url)
+    if not remote:
+        raise AuditError("origin remote identity is empty")
+
+    fields = "number,url,baseRefName,baseRefOid,headRefName,headRefOid,headRepositoryOwner,isCrossRepository,title,body,reviewDecision,statusCheckRollup"
+    listed = run(
+        ["gh", "pr", "list", "--repo", remote, "--state", "open", "--limit", "101", "--json", fields],
+        cwd=repo,
+    )
+    try:
+        rows = json.loads(listed.stdout)
+    except json.JSONDecodeError as exc:
+        raise AuditError(f"gh pr list returned invalid JSON: {exc}") from exc
+    if not isinstance(rows, list) or any(not isinstance(row, dict) for row in rows):
+        raise AuditError("gh pr list must return a JSON array of objects")
+
+    truncated = len(rows) >= 101
+    expected_owner = remote.split("/")[-2]
+    buckets: dict[str, list[dict[str, Any]]] = {"exact": [], "suspected": [], "unrelated": []}
+    for row in rows:
+        base_match = row.get("baseRefName") == args.base_ref
+        base_sha_match = str(row.get("baseRefOid") or "").lower() == base_tip.lower()
+        head_match = row.get("headRefName") == args.head_ref
+        sha_match = str(row.get("headRefOid") or "").lower() == resolved_head.lower()
+        raw_head_owner = row.get("headRepositoryOwner")
+        if isinstance(raw_head_owner, dict):
+            head_owner = raw_head_owner.get("login") or raw_head_owner.get("name")
+        else:
+            head_owner = raw_head_owner
+        repository_match = head_owner == expected_owner and row.get("isCrossRepository") is False
+        owner = ownership_evidence(row, args.task_id, args.agent_id)
+        pr_fp: str | None = None
+        same_content = False
+        diff_unknown = False
+        if base_match or head_match:
+            number = row.get("number")
+            if isinstance(number, int) or (isinstance(number, str) and number.isdigit()):
+                diff_proc = run(
+                    ["gh", "pr", "diff", str(number), "--repo", remote],
+                    cwd=repo,
+                    check=False,
+                )
+                if diff_proc.returncode == 0:
+                    pr_fp = fingerprint(diff_proc.stdout)
+                    same_content = pr_fp == expected_fp
+                else:
+                    diff_unknown = True
+
+        reasons: list[str] = []
+        if base_match and base_sha_match and head_match and sha_match and repository_match and owner["match"] and same_content and not diff_unknown:
+            classification = "exact"
+            reasons.append("base_ref_oid_head_ref_oid_repository_task_agent_match")
+        elif head_match or (base_match and same_content) or diff_unknown or owner["task_match"] and owner["agent_match"] and (args.task_id or args.agent_id):
+            classification = "suspected"
+            if base_match and head_match and not sha_match:
+                reasons.append("same_head_different_sha")
+            if base_match and same_content and not head_match:
+                reasons.append("same_content_different_head")
+            if diff_unknown:
+                reasons.append("diff_unknown")
+            if head_match and not base_match:
+                reasons.append("same_head_different_base")
+            if base_match and not base_sha_match:
+                reasons.append("same_base_ref_different_base_sha")
+            if base_match and head_match and sha_match and pr_fp is not None and not same_content:
+                reasons.append("pr_diff_mismatch")
+            if base_match and head_match and sha_match and not owner["match"]:
+                reasons.append("ownership_mismatch")
+            if base_match and head_match and sha_match and not repository_match:
+                reasons.append("head_repository_mismatch_or_cross_repository")
+            if owner["match"] and (args.task_id or args.agent_id):
+                reasons.append("ownership_related")
+            if not reasons:
+                reasons.append("related_but_not_exact")
+        else:
+            classification = "unrelated"
+            reasons.append("no_exact_or_suspected_relation")
+        buckets[classification].append(
+            row_receipt(
+                row,
+                classification=classification,
+                reasons=reasons,
+                ownership=owner,
+                diff_fp=pr_fp,
+            )
+        )
+
+    exact_count = len(buckets["exact"])
+    suspected_count = len(buckets["suspected"])
+    if truncated:
+        decision = "ambiguous"
+    elif exact_count == 1 and suspected_count == 0:
+        decision = "adopt"
+    elif exact_count == 0 and suspected_count == 0:
+        decision = "create"
+    else:
+        decision = "ambiguous"
+
+    result = {
+        "schema_version": SCHEMA,
+        "repository": {"top": top, "common_dir": common, "remote": remote},
+        "expected": {
+            "base_ref": args.base_ref,
+            "base_tip": base_tip,
+            "base_commit": base_commit,
+            "head_ref": args.head_ref,
+            "head_sha": resolved_head,
+            "task_id": args.task_id,
+            "agent_id": args.agent_id,
+            "head_repository_owner": expected_owner,
+            "is_cross_repository": False,
+            "diff_fingerprint": expected_fp,
+        },
+        "counts": {name: len(values) for name, values in buckets.items()},
+        "candidate_set_truncated": truncated,
+        "decision": decision,
+        **buckets,
+    }
+    json.dump(result, sys.stdout, ensure_ascii=False, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except AuditError as exc:
+        print(f"PR_AUDIT_ERROR: {redact_sensitive(str(exc))}", file=sys.stderr)
+        raise SystemExit(2)
+    except Exception as exc:  # Defensive CLI boundary: never leak traceback/credentials.
+        print(f"PR_AUDIT_ERROR: unexpected_error detail={redact_sensitive(str(exc))}", file=sys.stderr)
+        raise SystemExit(2)

--- a/skills/multi-agent-orchestration/scripts/test-pm-closeout.sh
+++ b/skills/multi-agent-orchestration/scripts/test-pm-closeout.sh
@@ -47,6 +47,18 @@ cat > "$SAFE_PUSH" <<'SH'
 set -euo pipefail
 printf '%q ' "$@" >> "${PM_TEST_SAFE_LOG:?}"
 printf '\n' >> "$PM_TEST_SAFE_LOG"
+[ "${PM_TEST_SAFE_LEAK:-0}" -eq 0 ] || { echo 'fatal: https://user:LEAK-ME@example.invalid/repository.git failed' >&2; exit 72; }
+[ "${PM_TEST_SAFE_FAIL:-0}" -eq 0 ] || exit 71
+if [ "${PM_TEST_SAFE_DO_PUSH:-0}" -eq 1 ]; then
+  repo=.; branch=
+  while [ $# -gt 0 ]; do
+    case "$1" in --repo) repo=$2; shift 2 ;; --branch) branch=$2; shift 2 ;; *) shift ;; esac
+  done
+  git -C "$repo" push -q origin "$branch"
+  if [ -n "${PM_TEST_DIRTY_MAIN_AFTER_PUSH:-}" ]; then
+    printf 'post-push drift\n' > "$PM_TEST_DIRTY_MAIN_AFTER_PUSH/post-push-drift.txt"
+  fi
+fi
 SH
 chmod +x "$SAFE_PUSH"
 
@@ -63,6 +75,12 @@ printf '%s\n' "$#:$*" >> "${PM_TEST_VERIFY_LOG:?}"
     advance_round=$(wc -l < "$PM_TEST_VERIFY_LOG" | tr -d ' ')
     advance_path="main-advanced-$advance_round.txt"
     advance_now=1
+  elif [ -n "${PM_TEST_VERIFY_ADVANCE_AT_CALL:-}" ]; then
+    advance_round=$(wc -l < "$PM_TEST_VERIFY_LOG" | tr -d ' ')
+    if [ "$advance_round" = "$PM_TEST_VERIFY_ADVANCE_AT_CALL" ]; then
+      advance_path="main-advanced-at-$advance_round.txt"
+      advance_now=1
+    fi
   else
     [ -n "${PM_TEST_ADVANCE_MARKER:-}" ]
     [ -e "$PM_TEST_ADVANCE_MARKER" ] || advance_now=1
@@ -89,19 +107,105 @@ set -euo pipefail
 printf '%q ' "$@" >> "${PM_TEST_GH_LOG:?}"
 printf '\n' >> "$PM_TEST_GH_LOG"
 case "$1 $2" in
+  "pr list")
+    if [ "${PM_TEST_GH_MODE:-ok}" = "post-create-audit-fail" ] && grep -qF 'pr create' "$PM_TEST_GH_LOG"; then
+      echo 'post-create list unavailable' >&2
+      exit 45
+    fi
+    if [ "${PM_TEST_GH_MODE:-ok}" = "existing" ] || [ "${PM_TEST_GH_MODE:-ok}" = "diff-leak" ] || [ "${PM_TEST_GH_MODE:-ok}" = "check-drift" ] || \
+       [ "${PM_TEST_GH_MODE:-ok}" = "duplicate-final" ] || [ "${PM_TEST_GH_MODE:-ok}" = "base-race" ] || \
+       [ "${PM_TEST_GH_MODE:-ok}" = "view-fail-after-merge" ] || [ "${PM_TEST_GH_MODE:-ok}" = "close-view-fail" ] || \
+       { [ "${PM_TEST_GH_MODE:-ok}" != "create-fail" ] && grep -qF 'pr create' "$PM_TEST_GH_LOG"; }; then
+      head_oid=$(git rev-parse HEAD)
+      base_oid=$(git rev-parse origin/main)
+      row=$(printf '{"number":123,"url":"https://example.invalid/repo/pull/123","baseRefName":"main","baseRefOid":"%s","headRefName":"%s","headRefOid":"%s","headRepositoryOwner":{"login":"repository"},"isCrossRepository":false,"title":"Task-097 by agent-test","body":"Task: Task-097\\nAgent: agent-test","reviewDecision":"APPROVED","statusCheckRollup":[]}' "$base_oid" "$(git branch --show-current)" "$head_oid")
+      if { [ "${PM_TEST_GH_MODE:-ok}" = "duplicate-final" ] && [ "$(grep -cF 'pr list' "$PM_TEST_GH_LOG")" -ge 2 ]; } || \
+         { [ "${PM_TEST_GH_MODE:-ok}" = "create-suspected" ] && grep -qF 'pr create' "$PM_TEST_GH_LOG"; }; then
+        row2=${row/\"number\":123/\"number\":124}; row2=${row2/pull\/123/pull\/124}
+        row2=${row2/\"headRefName\":\"$(git branch --show-current)\"/\"headRefName\":\"feat\/same-content-race\"}
+        printf '[%s,%s]\n' "$row" "$row2"
+      else
+        printf '[%s]\n' "$row"
+      fi
+    else
+      echo '[]'
+    fi
+    ;;
+  "pr diff")
+    if [ "${PM_TEST_GH_MODE:-ok}" = "diff-leak" ] && \
+       [ "$(grep -cF 'pr diff' "$PM_TEST_GH_LOG")" -ge 2 ]; then
+      echo 'fatal: https://user:PR-DIFF-LEAK@example.invalid/repository.git?access_token=DIFF-TOKEN failed' >&2
+      exit 46
+    fi
+    base=$(git merge-base HEAD origin/main)
+    git diff "$base" HEAD
+    ;;
   "pr create")
     [ "${PM_TEST_GH_MODE:-ok}" != "create-fail" ] || { echo "create failed" >&2; exit 41; }
+    [ "${PM_TEST_GH_MODE:-ok}" != "race" ] || { echo "a pull request already exists" >&2; exit 41; }
     echo "https://example.invalid/repo/pull/123"
     ;;
   "pr merge")
     [ "${PM_TEST_GH_MODE:-ok}" != "merge-fail" ] || { echo "merge failed" >&2; exit 42; }
+    if [ "${PM_TEST_GH_MODE:-ok}" != "view-fail" ] && [ "${PM_TEST_GH_MODE:-ok}" != "view-invalid" ]; then
+      main_oid=$(git rev-parse origin/main)
+      head_oid=$(git rev-parse HEAD)
+      if [ "${PM_TEST_GH_MODE:-ok}" = "base-race" ]; then
+        advance_oid=$(printf 'main advanced after final review\n' | git commit-tree "$(git rev-parse "$main_oid^{tree}")" -p "$main_oid")
+        git push -q origin "$advance_oid:refs/heads/main"
+        main_oid=$advance_oid
+      fi
+      tree_oid=$(git merge-tree --write-tree "$main_oid" "$head_oid")
+      merge_oid=$(printf 'fake squash merge\n' | git commit-tree "$tree_oid" -p "$main_oid")
+      git push -q origin "$merge_oid:refs/heads/main"
+      printf '%s\n' "$merge_oid" > "${PM_TEST_MERGE_SHA_FILE:?}"
+    fi
     ;;
   "pr view")
-    [ "${PM_TEST_GH_MODE:-ok}" != "view-fail" ] || { echo "view failed" >&2; exit 43; }
-    if [ "${PM_TEST_GH_MODE:-ok}" = "view-invalid" ]; then
-      echo '{"state":null}'
+    if grep -qF 'pr close' "$PM_TEST_GH_LOG"; then
+      [ "${PM_TEST_GH_MODE:-ok}" != "close-view-fail" ] || { echo "close state unavailable" >&2; exit 43; }
+      echo '{"state":"CLOSED"}'
+    elif grep -qF 'pr merge' "$PM_TEST_GH_LOG"; then
+      [ "${PM_TEST_GH_MODE:-ok}" != "view-fail" ] && [ "${PM_TEST_GH_MODE:-ok}" != "view-fail-after-merge" ] || { echo "view failed" >&2; exit 43; }
+      if [ "${PM_TEST_GH_MODE:-ok}" = "view-invalid" ]; then
+        echo '{"state":"MERGED","mergedAt":null,"mergeCommit":null}'
+      else
+        merge_oid=$(cat "${PM_TEST_MERGE_SHA_FILE:?}")
+        printf '{"state":"MERGED","mergedAt":"2026-09-04T00:00:00Z","mergeCommit":{"oid":"%s"}}\n' "$merge_oid"
+      fi
     else
-      echo '{"state":"MERGED"}'
+      head_oid=$(git rev-parse HEAD)
+      base_oid=$(git rev-parse origin/main)
+      checks='[]'
+      if [ "${PM_TEST_GH_MODE:-ok}" = "check-drift" ] && [ "$(grep -cF 'pr view' "$PM_TEST_GH_LOG")" -ge 2 ]; then
+        checks='[{"name":"ci","status":"COMPLETED","conclusion":"NEUTRAL"}]'
+      fi
+      printf '{"number":123,"url":"https://example.invalid/repo/pull/123","state":"OPEN","baseRefName":"main","baseRefOid":"%s","headRefName":"%s","headRefOid":"%s","statusCheckRollup":%s,"reviewDecision":"APPROVED","mergeable":"MERGEABLE","mergedAt":null,"mergeCommit":null}\n' "$base_oid" "$(git branch --show-current)" "$head_oid" "$checks"
+    fi
+    ;;
+  "pr close") ;;
+  "api --hostname")
+    if [[ "${4:-}" == */rules/branches/main ]]; then
+      case "${PM_TEST_PROTECTION_MODE:-unprotected}" in
+        merge-queue) echo '[{"type":"merge_queue"}]' ;;
+        rules-404) echo 'HTTP 404' >&2; exit 1 ;;
+        *) echo '[]' ;;
+      esac
+    else
+      case "${PM_TEST_PROTECTION_MODE:-unprotected}" in
+        unprotected|flip-protection)
+          if [ "${PM_TEST_PROTECTION_MODE:-}" = "flip-protection" ] && \
+             [ "$(grep -cF '/branches/main' "$PM_TEST_GH_LOG")" -ge 2 ]; then
+            echo '{"protected":true}'
+          else
+            echo '{"protected":false}'
+          fi
+          ;;
+        protected|classic-protected|merge-queue) echo '{"protected":true}' ;;
+        404) echo 'HTTP 404' >&2; exit 1 ;;
+        malformed) echo '{}' ;;
+        *) exit 1 ;;
+      esac
     fi
     ;;
   *) echo "unexpected gh call: $*" >&2; exit 44 ;;
@@ -113,14 +217,58 @@ export PATH="$BIN:$PATH"
 export PM_TEST_SAFE_LOG="$TMP_ROOT/safe.log"
 export PM_TEST_VERIFY_LOG="$TMP_ROOT/verify.log"
 export PM_TEST_GH_LOG="$TMP_ROOT/gh.log"
+export PM_TEST_MERGE_SHA_FILE="$TMP_ROOT/merge-sha"
+export PM_CLOSEOUT_MODE=remote-pr
+export PM_CLOSEOUT_TASK_ID=Task-097
+export PM_CLOSEOUT_AGENT_ID=agent-test
 : > "$PM_TEST_SAFE_LOG"
 : > "$PM_TEST_VERIFY_LOG"
 : > "$PM_TEST_GH_LOG"
 
+authority_for() {
+  local repo=$1 operation=$2 pr_number=${3:-none} remote_url leaf remote_id branch sha
+  remote_url=$(git -C "$repo" remote get-url origin)
+  leaf=${remote_url##*/}; leaf=${leaf%.git}
+  remote_id="local/repository/$leaf"
+  branch=$(git -C "$repo" branch --show-current)
+  sha=$(git -C "$repo" rev-parse HEAD)
+  printf 'operation=%s;repo=%s;pr=%s;head=%s;sha=%s' "$operation" "$remote_id" "$pr_number" "$branch" "$sha"
+}
+
+candidate_authority_for() {
+  local repo=$1 operation=$2 pr_number=$3 title=$4 remote_url leaf remote_id branch sha base tree candidate date
+  remote_url=$(git -C "$repo" remote get-url origin)
+  leaf=${remote_url##*/}; leaf=${leaf%.git}
+  remote_id="local/repository/$leaf"
+  branch=$(git -C "$repo" branch --show-current)
+  sha=$(git -C "$repo" rev-parse HEAD)
+  base=$(git -C "$repo" rev-parse origin/main)
+  tree=$(git -C "$repo" merge-tree --write-tree "$base" "$sha")
+  date=$(git -C "$repo" show -s --format=%aI "$sha")
+  candidate=$(GIT_AUTHOR_DATE="$date" GIT_COMMITTER_DATE="$date" \
+    git -C "$repo" -c user.name="$(git -C "$repo" config user.name)" \
+      -c user.email="$(git -C "$repo" config user.email)" \
+      commit-tree "$tree" -p "$base" -m "$title (#$pr_number)")
+  printf 'operation=%s;repo=%s;pr=%s;head=%s;sha=%s;base=%s;candidate=%s;tree=%s' \
+    "$operation" "$remote_id" "$pr_number" "$branch" "$sha" "$base" "$candidate" "$tree"
+}
+
+INITIAL_ARGS=(
+  --integration-path change.txt
+  --authorize-branch-push "$(authority_for "$WT" branch-push)"
+  --authorize-pr-create "$(authority_for "$WT" pr-create)"
+  --authorize-remote-merge "$(authority_for "$WT" remote-merge 123)"
+  --authorize-remote-candidate "$(candidate_authority_for "$WT" remote-merge-candidate 123 test)"
+  --authorize-main-push "$(authority_for "$WT" main-push 123)"
+  --authorize-main-candidate "$(candidate_authority_for "$WT" main-push-candidate 123 test)"
+  --authorize-pr-close "$(authority_for "$WT" pr-close 123)"
+)
+INITIAL_MAIN_SHA=$(git -C "$WT" rev-parse origin/main)
+
 echo "Case 1: legacy shell-string verification is rejected before execution"
 set +e
 bash "$CLOSEOUT" --worktree "$WT" --title test --safe-push-script "$SAFE_PUSH" \
-  --verify 'touch should-not-run' > "$TMP_ROOT/legacy.out" 2>&1
+  "${INITIAL_ARGS[@]}" --verify 'touch should-not-run' > "$TMP_ROOT/legacy.out" 2>&1
 legacy_rc=$?
 set -e
 assert_eq "$legacy_rc" "64" "legacy --verify is fail-closed"
@@ -129,7 +277,7 @@ assert_eq "$legacy_rc" "64" "legacy --verify is fail-closed"
 echo "Case 2: verification command is mandatory"
 set +e
 bash "$CLOSEOUT" --worktree "$WT" --title test --safe-push-script "$SAFE_PUSH" \
-  > "$TMP_ROOT/no-verify.out" 2>&1
+  "${INITIAL_ARGS[@]}" > "$TMP_ROOT/no-verify.out" 2>&1
 no_verify_rc=$?
 set -e
 assert_eq "$no_verify_rc" "64" "missing verification blocks closeout"
@@ -140,10 +288,10 @@ echo "Case 3: argv verification preserves spaces and gh create errors stay visib
 set +e
 PM_TEST_GH_MODE=create-fail bash "$CLOSEOUT" --worktree "$WT" --title test \
   --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --verify-arg 'arg with spaces' \
-  --keep-branch > "$TMP_ROOT/create-fail.out" 2>&1
+  "${INITIAL_ARGS[@]}" --keep-branch > "$TMP_ROOT/create-fail.out" 2>&1
 create_rc=$?
 set -e
-assert_eq "$create_rc" "5" "gh pr create failure blocks merge"
+assert_eq "$create_rc" "9" "gh pr create failure becomes an explicit outcome-unknown state"
 grep -qF '1:arg with spaces' "$PM_TEST_VERIFY_LOG" && ok "verification runs as an argv array" || bad "verification argv changed"
 grep -qF 'create failed' "$TMP_ROOT/create-fail.out" && ok "gh create error is preserved" || bad "gh create error was swallowed"
 if grep -qF 'pr merge' "$PM_TEST_GH_LOG"; then bad "merge ran after create failure"; else ok "merge does not run after create failure"; fi
@@ -154,23 +302,25 @@ for mode in view-fail view-invalid; do
   set +e
   PM_TEST_GH_MODE="$mode" bash "$CLOSEOUT" --worktree "$WT" --title test \
     --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
-    > "$TMP_ROOT/$mode.out" 2>&1
+    "${INITIAL_ARGS[@]}" > "$TMP_ROOT/$mode.out" 2>&1
   rc=$?
   set -e
-  assert_eq "$rc" "6" "$mode blocks completion"
+  assert_eq "$rc" "9" "$mode blocks success with outcome unknown"
 done
 
 echo "Case 5: happy path uses one body-file argument and confirms MERGED"
 : > "$PM_TEST_GH_LOG"
 PM_TEST_GH_MODE=ok bash "$CLOSEOUT" --worktree "$WT" --title test \
   --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
-  > "$TMP_ROOT/happy.out" 2>&1
-grep -qF 'PM_CLOSEOUT_OK: pr=123 branch=feat/closeout-test' "$TMP_ROOT/happy.out" \
+  "${INITIAL_ARGS[@]}" > "$TMP_ROOT/happy.out" 2>&1
+grep -qF 'PM_CLOSEOUT_RESULT: REMOTE_PR pr=123' "$TMP_ROOT/happy.out" \
   && ok "happy path returns a mechanically extracted PR receipt" \
   || bad "happy path receipt missing"
 create_line=$(grep -F 'pr create' "$PM_TEST_GH_LOG" | tail -1)
 body_count=$(printf '%s\n' "$create_line" | grep -o -- '--body-file' | wc -l | tr -d ' ')
 assert_eq "$body_count" "1" "PR create receives exactly one body-file"
+git --git-dir="$REMOTE" update-ref refs/heads/main "$INITIAL_MAIN_SHA"
+git -C "$WT" fetch -q origin main
 
 echo "Case 6: resolver stages only declared document conflicts and ignores literal markers elsewhere"
 DOC_REPO="$TMP_ROOT/doc-conflict"
@@ -336,6 +486,12 @@ rm -f "$ADV_WT/Makefile.bak"
 git -C "$ADV_WT" commit -qam 'worker variable block'
 printf '\n.PHONY: lint\nlint:\n\t@echo worker-lint\n' >> "$ADV_WT/Makefile"
 git -C "$ADV_WT" commit -qam 'worker target block'
+ADV_ARGS=(
+  --integration-path Makefile
+  --authorize-branch-push "$(authority_for "$ADV_WT" branch-push)"
+  --authorize-pr-create "$(authority_for "$ADV_WT" pr-create)"
+  --authorize-remote-merge "$(authority_for "$ADV_WT" remote-merge 123)"
+)
 : > "$PM_TEST_VERIFY_LOG"
 : > "$PM_TEST_SAFE_LOG"
 : > "$PM_TEST_GH_LOG"
@@ -345,26 +501,43 @@ PM_TEST_ADVANCE_REPO="$ADV_SEED" \
 PM_TEST_ADVANCE_MARKER="$TMP_ROOT/advance.marker" \
 PM_TEST_GH_MODE=ok bash "$CLOSEOUT" --worktree "$ADV_WT" --title test \
   --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
-  > "$TMP_ROOT/advance.out" 2>&1
+  "${ADV_ARGS[@]}" > "$TMP_ROOT/advance.out" 2>&1
 advance_rc=$?
 set -e
-if [ "$advance_rc" -ne 0 ]; then
+assert_eq "$advance_rc" "8" "main movement invalidates the pre-candidate authorization"
+ADV_CANDIDATE_AUTH=$(sed -n 's/^PM_CLOSEOUT_CANDIDATE_AUTHORIZATION_REQUIRED: operation=remote-merge-candidate expected=//p' "$TMP_ROOT/advance.out" | tail -1)
+[ -n "$ADV_CANDIDATE_AUTH" ] && ok "main-advance emits a candidate-bound authorization challenge" || bad "candidate challenge missing"
+set +e
+PM_TEST_GH_MODE=ok bash "$CLOSEOUT" --worktree "$ADV_WT" --title test \
+  --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  "${ADV_ARGS[@]}" --authorize-remote-candidate "$ADV_CANDIDATE_AUTH" \
+  > "$TMP_ROOT/advance-retry.out" 2>&1
+advance_retry_rc=$?
+set -e
+if [ "$advance_retry_rc" -ne 0 ]; then
+  sed -n '1,160p' "$TMP_ROOT/advance-retry.out" >&2
+fi
+assert_eq "$advance_retry_rc" "0" "candidate-bound reauthorization completes main-advance closeout"
+if [ "$advance_rc" -ne 8 ]; then
   sed -n '1,160p' "$TMP_ROOT/advance.out" >&2
 fi
-assert_eq "$advance_rc" "0" "main-advance closeout completes"
 verify_rounds=$(wc -l < "$PM_TEST_VERIFY_LOG" | tr -d ' ')
-assert_eq "$verify_rounds" "2" "main movement forces verification to run again"
-grep -qF 'PM_CLOSEOUT_MAIN_ADVANCED: round=1' "$TMP_ROOT/advance.out" \
-  && ok "pre-push refresh observes the moving main" \
-  || bad "main-advance receipt missing"
+assert_eq "$verify_rounds" "4" "main movement plus reauthorization reruns worker and candidate verification"
+grep -qF 'PM_CLOSEOUT_CANDIDATE_VERIFIED: pr=123' "$TMP_ROOT/advance.out" \
+  && ok "PR-first candidate verification emits a stable receipt" \
+  || bad "candidate verification receipt missing"
 grep -qF 'MODE ?= worker' "$ADV_WT/Makefile" \
   && grep -qF 'worker-lint' "$ADV_WT/Makefile" \
-  && grep -qF 'main advanced' "$ADV_WT/main-advanced.txt" \
-  && ok "second sync preserves worker content and the newly advanced main" \
-  || bad "main refresh lost worker or main content"
-git -C "$ADV_WT" merge-base --is-ancestor origin/main HEAD \
-  && ok "stable origin/main is an ancestor before safe-push" \
-  || bad "closeout pushed from a stale main baseline"
+  && git -C "$ADV_WT" show origin/main:main-advanced.txt | grep -qF 'main advanced' \
+  && [ ! -e "$ADV_WT/main-advanced.txt" ] \
+  && ok "PR-first keeps worker head immutable while candidate consumes fresh main" \
+  || bad "worker head or refreshed main evidence changed unexpectedly"
+[ "$(git -C "$ADV_WT" branch --show-current)" = 'feat/advance-main' ] \
+  && ok "candidate verification never checks out or mutates main in the worker tree" \
+  || bad "worker branch changed during candidate verification"
+ADV_MAIN_AFTER_VERIFY=$(git -C "$ADV_WT" rev-parse 'origin/main^1')
+git --git-dir="$ADV_REMOTE" update-ref refs/heads/main "$ADV_MAIN_AFTER_VERIFY"
+git -C "$ADV_WT" fetch -q origin main
 
 echo "Case 10: continuously moving main exhausts the bounded loop before push or PR"
 : > "$PM_TEST_VERIFY_LOG"
@@ -376,18 +549,20 @@ PM_TEST_VERIFY_ADVANCE_ALWAYS=1 \
 PM_TEST_ADVANCE_REPO="$ADV_SEED" \
 PM_TEST_GH_MODE=ok bash "$CLOSEOUT" --worktree "$ADV_WT" --title test \
   --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
-  > "$TMP_ROOT/advance-always.out" 2>&1
+  "${ADV_ARGS[@]}" > "$TMP_ROOT/advance-always.out" 2>&1
 advance_always_rc=$?
 set -e
 assert_eq "$advance_always_rc" "3" "continuous main movement fails closed"
 advance_always_rounds=$(wc -l < "$PM_TEST_VERIFY_LOG" | tr -d ' ')
-assert_eq "$advance_always_rounds" "3" "moving-main loop is bounded to three verification rounds"
+assert_eq "$advance_always_rounds" "4" "one worker verify plus three candidate rounds bounds moving-main verification"
 grep -qF 'PM_CLOSEOUT_MAIN_MOVED_TOO_MANY_TIMES' "$TMP_ROOT/advance-always.out" \
   && ok "bounded-loop exhaustion has an explicit receipt" \
   || bad "bounded-loop exhaustion receipt missing"
-[ ! -s "$PM_TEST_SAFE_LOG" ] && [ ! -s "$PM_TEST_GH_LOG" ] \
-  && ok "safe-push and PR mutations never run after loop exhaustion" \
-  || bad "external mutation ran after moving-main exhaustion"
+if grep -qF 'pr merge' "$PM_TEST_GH_LOG"; then
+  bad "merge ran after moving-main exhaustion"
+else
+  ok "moving-main exhaustion performs no merge or main integration mutation"
+fi
 
 echo "Case 11: a clean verify-side commit is detected as a forbidden Git state mutation"
 : > "$PM_TEST_SAFE_LOG"
@@ -395,7 +570,7 @@ echo "Case 11: a clean verify-side commit is detected as a forbidden Git state m
 set +e
 PM_TEST_VERIFY_COMMIT=1 PM_TEST_GH_MODE=ok bash "$CLOSEOUT" \
   --worktree "$WT" --title test --safe-push-script "$SAFE_PUSH" \
-  --verify-cmd "$VERIFY" --keep-branch \
+  --verify-cmd "$VERIFY" "${INITIAL_ARGS[@]}" --keep-branch \
   > "$TMP_ROOT/verify-commit.out" 2>&1
 verify_commit_rc=$?
 set -e
@@ -406,6 +581,576 @@ grep -qF 'PM_CLOSEOUT_VERIFY_GIT_STATE_CHANGED' "$TMP_ROOT/verify-commit.out" \
 [ ! -s "$PM_TEST_SAFE_LOG" ] && [ ! -s "$PM_TEST_GH_LOG" ] \
   && ok "no push or PR mutation follows a verify-side commit" \
   || bad "external mutation ran after verify changed HEAD"
+
+echo "Case 12: create race re-audits and adopts the unique worker PR without a second create"
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=race PM_CLOSEOUT_MODE=remote-pr bash "$CLOSEOUT" \
+  --worktree "$WT" --title test --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" \
+  --integration-path change.txt \
+  --authorize-branch-push "$(authority_for "$WT" branch-push)" \
+  --authorize-pr-create "$(authority_for "$WT" pr-create)" \
+  --keep-branch > "$TMP_ROOT/race.out" 2>&1
+race_rc=$?
+set -e
+assert_eq "$race_rc" "8" "concurrent create adopts uniquely then stops without merge authority"
+grep -qF 'PM_CLOSEOUT_PR_ADOPTED_AFTER_CREATE_RACE: #123' "$TMP_ROOT/race.out" \
+  && ok "create race adopts the unique exact PR" || bad "create-race adoption receipt missing"
+assert_eq "$(grep -cF 'pr create' "$PM_TEST_GH_LOG")" "1" "create race performs exactly one create attempt"
+if grep -qF 'pr merge' "$PM_TEST_GH_LOG"; then bad "race path merged unexpectedly"; else ok "race path creates no duplicate or merge"; fi
+
+echo "Case 13: dirty main worktree degrades locally with zero main mutation"
+MAIN_WT="$TMP_ROOT/main-worktree"
+git -C "$WT" branch -f main origin/main
+git -C "$WT" worktree add -q "$MAIN_WT" main
+main_before=$(git -C "$MAIN_WT" rev-parse HEAD)
+printf 'dirty\n' > "$MAIN_WT/uncommitted.txt"
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=existing PM_CLOSEOUT_MODE=local-after-pr bash "$CLOSEOUT" \
+  --worktree "$WT" --main-worktree "$MAIN_WT" --integration-path change.txt \
+  --authorize-main-push "$(authority_for "$WT" main-push 123)" \
+  --title test --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/dirty-main.out" 2>&1
+dirty_main_rc=$?
+set -e
+assert_eq "$dirty_main_rc" "8" "dirty main is a non-success validate-only downgrade"
+grep -qF 'reason=main-worktree-dirty' "$TMP_ROOT/dirty-main.out" \
+  && ok "dirty main yields validate-only" || bad "dirty-main reason missing"
+assert_eq "$(git -C "$MAIN_WT" rev-parse HEAD)" "$main_before" "dirty main HEAD is not mutated"
+if grep -qF 'pr merge' "$PM_TEST_GH_LOG"; then bad "dirty main triggered merge"; else ok "dirty main performs no merge"; fi
+rm -f "$MAIN_WT/uncommitted.txt"
+
+echo "Case 14: checks drift after candidate verification leaves main unchanged"
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=check-drift PM_CLOSEOUT_MODE=local-after-pr bash "$CLOSEOUT" \
+  --worktree "$WT" --main-worktree "$MAIN_WT" --integration-path change.txt \
+  --authorize-main-push "$(authority_for "$WT" main-push 123)" \
+  --title test --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/check-drift.out" 2>&1
+drift_rc=$?
+set -e
+assert_eq "$drift_rc" "5" "checks drift fails closed"
+grep -qF 'PM_CLOSEOUT_REVIEW_DRIFT' "$TMP_ROOT/check-drift.out" \
+  && ok "checks drift emits re-review receipt" || bad "checks drift receipt missing"
+assert_eq "$(git -C "$MAIN_WT" rev-parse HEAD)" "$main_before" "checks drift performs zero main mutation"
+
+echo "Case 15: local-after-pr commits (#PR), safe-pushes main and closes only with authority"
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+PM_TEST_GH_MODE=existing PM_TEST_SAFE_DO_PUSH=1 PM_CLOSEOUT_MODE=local-after-pr bash "$CLOSEOUT" \
+  --worktree "$WT" --main-worktree "$MAIN_WT" --integration-path change.txt \
+  --authorize-main-push "$(authority_for "$WT" main-push 123)" \
+  --authorize-main-candidate "$(candidate_authority_for "$WT" main-push-candidate 123 'local integration')" \
+  --authorize-pr-close "$(authority_for "$WT" pr-close 123)" \
+  --title 'local integration' --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/local-success.out" 2>&1
+grep -qF 'PM_CLOSEOUT_RESULT: LOCAL_AFTER_PR pr=123' "$TMP_ROOT/local-success.out" \
+  && ok "local-after-pr reaches the explicit result" || bad "local result missing"
+grep -qF '(#123)' < <(git -C "$MAIN_WT" log -1 --pretty=%s) \
+  && ok "local integration subject is bound to PR number" || bad "local subject lacks PR number"
+assert_eq "$(git -C "$MAIN_WT" rev-parse HEAD)" "$(git -C "$MAIN_WT" rev-parse origin/main)" "local main push is confirmed"
+grep -qF 'pr close' "$PM_TEST_GH_LOG" && ok "authorized local integration closes with commit receipt" || bad "authorized close missing"
+
+echo "Case 16: main movement during candidate causes PR refreeze and candidate re-verification"
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=existing PM_CLOSEOUT_MODE=remote-pr \
+  PM_TEST_VERIFY_ADVANCE_MAIN=1 PM_TEST_VERIFY_ADVANCE_AT_CALL=2 \
+  PM_TEST_ADVANCE_REPO="$ADV_SEED" PM_TEST_ADVANCE_MARKER="$TMP_ROOT/unused-at-call.marker" \
+  bash "$CLOSEOUT" --worktree "$ADV_WT" --title test --safe-push-script "$SAFE_PUSH" \
+  --verify-cmd "$VERIFY" "${ADV_ARGS[@]}" --keep-branch > "$TMP_ROOT/main-refreeze.out" 2>&1
+refreeze_rc=$?
+set -e
+assert_eq "$refreeze_rc" "8" "candidate-time main movement requires a new candidate-bound authorization"
+REFREEZE_AUTH=$(sed -n 's/^PM_CLOSEOUT_CANDIDATE_AUTHORIZATION_REQUIRED: operation=remote-merge-candidate expected=//p' "$TMP_ROOT/main-refreeze.out" | tail -1)
+[ -n "$REFREEZE_AUTH" ] && ok "refrozen candidate emits a new authorization challenge" || bad "refrozen challenge missing"
+set +e
+PM_TEST_GH_MODE=existing PM_CLOSEOUT_MODE=remote-pr bash "$CLOSEOUT" \
+  --worktree "$ADV_WT" --title test --safe-push-script "$SAFE_PUSH" \
+  --verify-cmd "$VERIFY" "${ADV_ARGS[@]}" --authorize-remote-candidate "$REFREEZE_AUTH" \
+  --keep-branch > "$TMP_ROOT/main-refreeze-retry.out" 2>&1
+refreeze_retry_rc=$?
+set -e
+assert_eq "$refreeze_retry_rc" "0" "refrozen candidate succeeds after exact reauthorization"
+grep -qF 'PM_CLOSEOUT_REVIEW_REFROZEN:' "$TMP_ROOT/main-refreeze.out" \
+  && ok "main movement refreezes base/diff/checks facts" || bad "PR refreeze receipt missing"
+assert_eq "$(wc -l < "$PM_TEST_VERIFY_LOG" | tr -d ' ')" "5" "refreeze plus authorized retry reverify every candidate"
+
+make_same_file_fixture() {
+  local name=$1 main_mode=$2
+  FX_REMOTE="$TMP_ROOT/$name-remote.git"
+  FX_REPO="$TMP_ROOT/$name-worker"
+  FX_MAIN="$TMP_ROOT/$name-main"
+  git init -q --bare "$FX_REMOTE"
+  git init -q "$FX_REPO"
+  git -C "$FX_REPO" config user.name "Closeout Test"
+  git -C "$FX_REPO" config user.email "closeout@example.invalid"
+  printf 'worker=base\nstable=keep\nmain=base\n' > "$FX_REPO/shared.txt"
+  git -C "$FX_REPO" add shared.txt
+  git -C "$FX_REPO" commit -qm base
+  git -C "$FX_REPO" branch -M main
+  git -C "$FX_REPO" remote add origin "$FX_REMOTE"
+  git -C "$FX_REPO" push -qu origin main
+  git --git-dir="$FX_REMOTE" symbolic-ref HEAD refs/heads/main
+  git -C "$FX_REPO" checkout -qb "feat/$name"
+  sed -i.bak 's/worker=base/worker=feature/' "$FX_REPO/shared.txt"; rm -f "$FX_REPO/shared.txt.bak"
+  git -C "$FX_REPO" commit -qam worker
+  git -C "$FX_REPO" worktree add -q "$FX_MAIN" main
+  if [ "$main_mode" = conflict ]; then
+    sed -i.bak 's/worker=base/worker=main/' "$FX_MAIN/shared.txt"
+  else
+    sed -i.bak 's/main=base/main=fresh/' "$FX_MAIN/shared.txt"
+  fi
+  rm -f "$FX_MAIN/shared.txt.bak"
+  git -C "$FX_MAIN" commit -qam 'main advances same file'
+  git -C "$FX_MAIN" push -q origin main
+  git -C "$FX_REPO" fetch -q origin main
+}
+
+echo "Case 17: validate-only with zero PR performs no push or create"
+make_same_file_fixture validate-zero preserve
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+PM_TEST_GH_MODE=no-pr PM_CLOSEOUT_MODE=validate-only bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --title test --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/validate-zero.out" 2>&1
+grep -qF 'VALIDATE_ONLY pr=none' "$TMP_ROOT/validate-zero.out" \
+  && ok "zero-PR validate-only emits an explicit result" || bad "validate-only zero result missing"
+[ ! -s "$PM_TEST_SAFE_LOG" ] && ! grep -qF 'pr create' "$PM_TEST_GH_LOG" \
+  && ok "validate-only performs zero external mutation" || bad "validate-only mutated remote state"
+
+echo "Case 18: a worker-created exact PR is adopted before any branch push"
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+PM_TEST_GH_MODE=existing PM_CLOSEOUT_MODE=validate-only bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --title test --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/adopt-no-push.out" 2>&1
+grep -qF 'PM_CLOSEOUT_PR_ADOPTED: #123' "$TMP_ROOT/adopt-no-push.out" \
+  && ok "worker-created PR is adopted" || bad "worker PR adoption missing"
+[ ! -s "$PM_TEST_SAFE_LOG" ] && ! grep -qF 'pr create' "$PM_TEST_GH_LOG" \
+  && ok "adoption performs zero branch push and zero create" || bad "adoption mutated branch or PR set"
+
+echo "Case 19: three-way candidate preserves a fresh main edit in the same file"
+PRESERVE_MAIN_BEFORE=$(git -C "$FX_MAIN" rev-parse HEAD)
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=existing PM_TEST_SAFE_DO_PUSH=1 PM_CLOSEOUT_MODE=local-after-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --main-worktree "$FX_MAIN" --integration-path shared.txt \
+  --authorize-main-push "$(authority_for "$FX_REPO" main-push 123)" \
+  --authorize-main-candidate "$(candidate_authority_for "$FX_REPO" main-push-candidate 123 preserve)" \
+  --title preserve --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/preserve.out" 2>&1
+preserve_rc=$?
+set -e
+assert_eq "$preserve_rc" "0" "non-overlapping same-file edits integrate"
+grep -q '^worker=feature$' "$FX_MAIN/shared.txt" && grep -q '^main=fresh$' "$FX_MAIN/shared.txt" \
+  && ok "three-way patch preserves worker and fresh-main content" || bad "same-file integration lost content"
+[ "$(git -C "$FX_MAIN" rev-parse HEAD)" = "$(git -C "$FX_MAIN" rev-parse origin/main)" ] \
+  && [ "$(git -C "$FX_MAIN" rev-parse HEAD)" != "$PRESERVE_MAIN_BEFORE" ] \
+  && ok "verified candidate is pushed then fast-forwarded locally" || bad "local/remote main did not converge"
+
+echo "Case 20: same-line conflict fails before remote or local main mutation"
+make_same_file_fixture conflict conflict
+CONFLICT_MAIN_BEFORE=$(git -C "$FX_MAIN" rev-parse HEAD)
+CONFLICT_REMOTE_BEFORE=$(git -C "$FX_REPO" rev-parse origin/main)
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=existing PM_CLOSEOUT_MODE=local-after-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --main-worktree "$FX_MAIN" --integration-path shared.txt \
+  --authorize-main-push "$(authority_for "$FX_REPO" main-push 123)" \
+  --title conflict --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/conflict.out" 2>&1
+conflict_rc=$?
+set -e
+assert_eq "$conflict_rc" "8" "same-line conflict becomes non-success validate-only"
+assert_eq "$(git -C "$FX_MAIN" rev-parse HEAD)" "$CONFLICT_MAIN_BEFORE" "conflict leaves local main unchanged"
+git -C "$FX_REPO" fetch -q origin main
+assert_eq "$(git -C "$FX_REPO" rev-parse origin/main)" "$CONFLICT_REMOTE_BEFORE" "conflict leaves remote main unchanged"
+
+echo "Case 21: unknown protection cannot be overridden into a local push"
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=existing PM_TEST_PROTECTION_MODE=404 PM_CLOSEOUT_MODE=local-after-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --main-worktree "$FX_MAIN" --integration-path shared.txt \
+  --authorize-main-push "$(authority_for "$FX_REPO" main-push 123)" \
+  --title protection --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/protection-unknown.out" 2>&1
+protection_unknown_rc=$?
+set -e
+assert_eq "$protection_unknown_rc" "8" "404 protection evidence degrades to non-success validate-only"
+if grep -qF 'branch main' "$PM_TEST_SAFE_LOG" || grep -qF 'pr merge' "$PM_TEST_GH_LOG"; then
+  bad "unknown protection triggered a main mutation"
+else
+  ok "unknown protection performs zero main push/merge"
+fi
+
+echo "Case 22: safe-push failure leaves the real main worktree unchanged"
+make_same_file_fixture push-fail preserve
+PUSH_FAIL_MAIN_BEFORE=$(git -C "$FX_MAIN" rev-parse HEAD)
+PUSH_FAIL_REMOTE_BEFORE=$(git -C "$FX_REPO" rev-parse origin/main)
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=existing PM_TEST_SAFE_FAIL=1 PM_CLOSEOUT_MODE=local-after-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --main-worktree "$FX_MAIN" --integration-path shared.txt \
+  --authorize-main-push "$(authority_for "$FX_REPO" main-push 123)" \
+  --authorize-main-candidate "$(candidate_authority_for "$FX_REPO" main-push-candidate 123 push-fail)" \
+  --title push-fail --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/push-fail.out" 2>&1
+push_fail_rc=$?
+set -e
+assert_eq "$push_fail_rc" "71" "safe-push error propagates"
+assert_eq "$(git -C "$FX_MAIN" rev-parse HEAD)" "$PUSH_FAIL_MAIN_BEFORE" "safe-push failure leaves local main unchanged"
+git -C "$FX_REPO" fetch -q origin main
+assert_eq "$(git -C "$FX_REPO" rev-parse origin/main)" "$PUSH_FAIL_REMOTE_BEFORE" "safe-push failure leaves remote main unchanged"
+
+echo "Case 23: final duplicate PR set blocks merge after candidate verification"
+make_same_file_fixture duplicate-final preserve
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=duplicate-final PM_CLOSEOUT_MODE=remote-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --integration-path shared.txt \
+  --authorize-remote-merge "$(authority_for "$FX_REPO" remote-merge 123)" \
+  --authorize-remote-candidate "$(candidate_authority_for "$FX_REPO" remote-merge-candidate 123 duplicate)" \
+  --title duplicate --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/duplicate-final.out" 2>&1
+duplicate_final_rc=$?
+set -e
+assert_eq "$duplicate_final_rc" "5" "final duplicate set fails closed"
+if grep -qF 'pr merge' "$PM_TEST_GH_LOG"; then bad "merge ran after final PR-set drift"; else ok "PR-set drift performs zero merge"; fi
+
+echo "Case 24: remote merge requires an explicit integration scope"
+set +e
+PM_TEST_GH_MODE=existing PM_CLOSEOUT_MODE=remote-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --authorize-remote-merge "$(authority_for "$FX_REPO" remote-merge 123)" \
+  --title scope --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/remote-no-scope.out" 2>&1
+remote_no_scope_rc=$?
+set -e
+assert_eq "$remote_no_scope_rc" "64" "remote-pr refuses an undeclared whole-PR scope"
+
+echo "Case 25: scope violations and pathspec magic fail before mutation"
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=existing PM_CLOSEOUT_MODE=remote-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --integration-path unrelated.txt \
+  --authorize-remote-merge "$(authority_for "$FX_REPO" remote-merge 123)" \
+  --title scope --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/scope-violation.out" 2>&1
+scope_violation_rc=$?
+PM_TEST_GH_MODE=existing PM_CLOSEOUT_MODE=remote-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --integration-path ':(glob)**' \
+  --authorize-remote-merge "$(authority_for "$FX_REPO" remote-merge 123)" \
+  --title scope --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/pathspec-magic.out" 2>&1
+pathspec_magic_rc=$?
+set -e
+assert_eq "$scope_violation_rc" "3" "out-of-scope worker paths are rejected"
+assert_eq "$pathspec_magic_rc" "2" "pathspec magic is rejected"
+[ ! -s "$PM_TEST_SAFE_LOG" ] && ! grep -qF 'pr merge' "$PM_TEST_GH_LOG" \
+  && ok "scope failures perform zero push/merge" || bad "scope failure mutated remote state"
+
+echo "Case 26: positive protection evidence routes local preference to remote merge"
+make_same_file_fixture protected-route preserve
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+PM_TEST_GH_MODE=existing PM_TEST_PROTECTION_MODE=protected PM_CLOSEOUT_MODE=local-after-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --integration-path shared.txt \
+  --authorize-remote-merge "$(authority_for "$FX_REPO" remote-merge 123)" \
+  --authorize-remote-candidate "$(candidate_authority_for "$FX_REPO" remote-merge-candidate 123 protected)" \
+  --title protected --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/protected-route.out" 2>&1
+grep -qF 'effective=remote-pr protection=protected reason=protected-main' "$TMP_ROOT/protected-route.out" \
+  && grep -qF 'PM_CLOSEOUT_RESULT: REMOTE_PR' "$TMP_ROOT/protected-route.out" \
+  && ok "protected main uses the GitHub merge path" || bad "protected main routing failed"
+
+echo "Case 27: a main worktree from another Git common dir is rejected"
+make_same_file_fixture wrong-main-a preserve
+WRONG_WORKER=$FX_REPO; WRONG_MAIN_EXPECTED=$FX_MAIN
+make_same_file_fixture wrong-main-b preserve
+OTHER_MAIN=$FX_MAIN
+WRONG_MAIN_BEFORE=$(git -C "$WRONG_MAIN_EXPECTED" rev-parse HEAD)
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=existing PM_CLOSEOUT_MODE=local-after-pr bash "$CLOSEOUT" \
+  --worktree "$WRONG_WORKER" --main-worktree "$OTHER_MAIN" --integration-path shared.txt \
+  --authorize-main-push "$(authority_for "$WRONG_WORKER" main-push 123)" \
+  --title wrong-main --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/wrong-main.out" 2>&1
+wrong_main_rc=$?
+set -e
+assert_eq "$wrong_main_rc" "8" "wrong-repository main becomes non-success validate-only"
+assert_eq "$(git -C "$WRONG_MAIN_EXPECTED" rev-parse HEAD)" "$WRONG_MAIN_BEFORE" "wrong-main rejection leaves intended main unchanged"
+
+echo "Case 28: a clean main with an in-progress Git operation is rejected"
+WRONG_MAIN_GIT_DIR=$(git -C "$WRONG_MAIN_EXPECTED" rev-parse --absolute-git-dir)
+printf '%s\n' "$WRONG_MAIN_BEFORE" > "$WRONG_MAIN_GIT_DIR/MERGE_HEAD"
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=existing PM_CLOSEOUT_MODE=local-after-pr bash "$CLOSEOUT" \
+  --worktree "$WRONG_WORKER" --main-worktree "$WRONG_MAIN_EXPECTED" --integration-path shared.txt \
+  --authorize-main-push "$(authority_for "$WRONG_WORKER" main-push 123)" \
+  --title operation --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/main-operation.out" 2>&1
+main_operation_rc=$?
+set -e
+rm -f "$WRONG_MAIN_GIT_DIR/MERGE_HEAD"
+assert_eq "$main_operation_rc" "8" "clean main with MERGE_HEAD is rejected"
+assert_eq "$(git -C "$WRONG_MAIN_EXPECTED" rev-parse HEAD)" "$WRONG_MAIN_BEFORE" "operation-in-progress rejection leaves main unchanged"
+
+echo "Case 29: branch protected metadata covers classic protection and routes remotely"
+make_same_file_fixture classic-protection preserve
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+PM_TEST_GH_MODE=existing PM_TEST_PROTECTION_MODE=classic-protected PM_CLOSEOUT_MODE=local-after-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --integration-path shared.txt \
+  --authorize-remote-merge "$(authority_for "$FX_REPO" remote-merge 123)" \
+  --authorize-remote-candidate "$(candidate_authority_for "$FX_REPO" remote-merge-candidate 123 classic)" \
+  --title classic --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/classic-protection.out" 2>&1
+grep -qF 'effective=remote-pr protection=protected' "$TMP_ROOT/classic-protection.out" \
+  && grep -qF 'repos/repository/classic-protection-remote/branches/main' "$PM_TEST_GH_LOG" \
+  && ok "classic/ruleset protection uses typed branch metadata" \
+  || bad "classic protection was not routed remotely"
+
+echo "Case 30: a base race after final review cannot be reported as a verified remote merge"
+make_same_file_fixture base-race preserve
+BASE_RACE_BEFORE=$(git -C "$FX_REPO" rev-parse origin/main)
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=base-race PM_CLOSEOUT_MODE=remote-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --integration-path shared.txt \
+  --authorize-remote-merge "$(authority_for "$FX_REPO" remote-merge 123)" \
+  --authorize-remote-candidate "$(candidate_authority_for "$FX_REPO" remote-merge-candidate 123 base-race)" \
+  --title base-race --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/base-race.out" 2>&1
+base_race_rc=$?
+set -e
+assert_eq "$base_race_rc" "9" "base race becomes merged-review-required, never REMOTE_PR success"
+grep -qF 'REMOTE_MERGED_REVIEW_REQUIRED' "$TMP_ROOT/base-race.out" \
+  && ok "base race reports the expected and actual merge parent/tree" \
+  || bad "base race recovery receipt missing"
+git -C "$FX_REPO" fetch -q origin main
+[ "$(git -C "$FX_REPO" rev-parse origin/main)" != "$BASE_RACE_BEFORE" ] \
+  && ok "post-commit uncertainty is explicitly distinguished from a zero-mutation failure" \
+  || bad "base-race fixture did not mutate remote main"
+
+echo "Case 31: a lost merge receipt after remote commit is outcome-unknown"
+make_same_file_fixture merge-receipt-loss preserve
+RECEIPT_MAIN_BEFORE=$(git -C "$FX_REPO" rev-parse origin/main)
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=view-fail-after-merge PM_CLOSEOUT_MODE=remote-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --integration-path shared.txt \
+  --authorize-remote-merge "$(authority_for "$FX_REPO" remote-merge 123)" \
+  --authorize-remote-candidate "$(candidate_authority_for "$FX_REPO" remote-merge-candidate 123 receipt-loss)" \
+  --title receipt-loss --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/merge-receipt-loss.out" 2>&1
+receipt_loss_rc=$?
+set -e
+assert_eq "$receipt_loss_rc" "9" "lost post-merge receipt is not misclassified as an ordinary failure"
+grep -qF 'REMOTE_MERGE_OUTCOME_UNKNOWN' "$TMP_ROOT/merge-receipt-loss.out" \
+  && ok "lost merge receipt emits a reconciliation state" || bad "outcome-unknown receipt missing"
+git -C "$FX_REPO" fetch -q origin main
+[ "$(git -C "$FX_REPO" rev-parse origin/main)" != "$RECEIPT_MAIN_BEFORE" ] \
+  && ok "receipt-loss fixture proves main may already be changed" || bad "receipt-loss fixture did not mutate main"
+
+echo "Case 32: remote main success followed by local drift becomes LOCAL_PENDING"
+make_same_file_fixture local-pending preserve
+LOCAL_PENDING_BEFORE=$(git -C "$FX_MAIN" rev-parse HEAD)
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=existing PM_TEST_SAFE_DO_PUSH=1 PM_TEST_DIRTY_MAIN_AFTER_PUSH="$FX_MAIN" \
+  PM_CLOSEOUT_MODE=local-after-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --main-worktree "$FX_MAIN" --integration-path shared.txt \
+  --authorize-main-push "$(authority_for "$FX_REPO" main-push 123)" \
+  --authorize-main-candidate "$(candidate_authority_for "$FX_REPO" main-push-candidate 123 local-pending)" \
+  --title local-pending --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/local-pending.out" 2>&1
+local_pending_rc=$?
+set -e
+assert_eq "$local_pending_rc" "9" "post-push local drift becomes a recoverable local-pending state"
+grep -qF 'REMOTE_MAIN_APPLIED_LOCAL_PENDING' "$TMP_ROOT/local-pending.out" \
+  && ok "local pending receipt names the confirmed remote commit" || bad "local pending receipt missing"
+assert_eq "$(git -C "$FX_MAIN" rev-parse HEAD)" "$LOCAL_PENDING_BEFORE" "local pending does not rewrite the drifted main worktree"
+rm -f "$FX_MAIN/post-push-drift.txt"
+
+echo "Case 33: caller-supplied ownership trailers are rejected before push/create"
+make_same_file_fixture body-trailer preserve
+BODY_WITH_TRAILER="$TMP_ROOT/body-with-trailer.md"
+printf 'Summary\n\ntask: Task-097\nagent: agent-test\n' > "$BODY_WITH_TRAILER"
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=ok PM_CLOSEOUT_MODE=remote-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --integration-path shared.txt --body-file "$BODY_WITH_TRAILER" \
+  --authorize-branch-push "$(authority_for "$FX_REPO" branch-push)" \
+  --authorize-pr-create "$(authority_for "$FX_REPO" pr-create)" \
+  --title body --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/body-trailer.out" 2>&1
+body_trailer_rc=$?
+set -e
+assert_eq "$body_trailer_rc" "64" "reserved Task/Agent trailers fail pre-mutation"
+[ ! -s "$PM_TEST_SAFE_LOG" ] && ! grep -qF 'pr create' "$PM_TEST_GH_LOG" \
+  && ok "invalid body performs zero push/create" || bad "invalid body caused a mutation"
+
+echo "Case 34: post-create same-content race is a named created-review state"
+make_same_file_fixture create-suspected preserve
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=create-suspected PM_CLOSEOUT_MODE=remote-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --integration-path shared.txt \
+  --authorize-branch-push "$(authority_for "$FX_REPO" branch-push)" \
+  --authorize-pr-create "$(authority_for "$FX_REPO" pr-create)" \
+  --title create-race --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/create-suspected.out" 2>&1
+create_suspected_rc=$?
+set -e
+assert_eq "$create_suspected_rc" "9" "post-create suspected PR is not collapsed into ordinary failure"
+grep -qF 'PR_CREATED_REVIEW_REQUIRED pr=123' "$TMP_ROOT/create-suspected.out" \
+  && ok "created PR receipt is preserved for manual reconciliation" || bad "created-review receipt missing"
+assert_eq "$(grep -cF 'pr create' "$PM_TEST_GH_LOG")" "1" "race path creates at most one PR in this invocation"
+
+echo "Case 35: clean worktree with rebase directory is rejected"
+make_same_file_fixture rebase-marker preserve
+REBASE_GIT_DIR=$(git -C "$FX_MAIN" rev-parse --absolute-git-dir)
+mkdir -p "$REBASE_GIT_DIR/rebase-merge"
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=existing PM_CLOSEOUT_MODE=local-after-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --main-worktree "$FX_MAIN" --integration-path shared.txt \
+  --authorize-main-push "$(authority_for "$FX_REPO" main-push 123)" \
+  --title rebase-marker --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/rebase-marker.out" 2>&1
+rebase_marker_rc=$?
+set -e
+rmdir "$REBASE_GIT_DIR/rebase-merge"
+assert_eq "$rebase_marker_rc" "8" "clean main with rebase-merge state is rejected"
+
+echo "Case 36: closeout Git errors redact credentials"
+make_same_file_fixture fetch-redaction preserve
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=ok PM_TEST_SAFE_LEAK=1 PM_CLOSEOUT_MODE=remote-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --integration-path shared.txt \
+  --authorize-branch-push "$(authority_for "$FX_REPO" branch-push)" \
+  --authorize-pr-create "$(authority_for "$FX_REPO" pr-create)" \
+  --title redact --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/fetch-redaction.out" 2>&1
+fetch_redaction_rc=$?
+set -e
+[ "$fetch_redaction_rc" -ne 0 ] && ok "safe-push failure is surfaced" || bad "redaction fixture unexpectedly succeeded"
+! grep -qF 'LEAK-ME' "$TMP_ROOT/fetch-redaction.out" && grep -qF '***@example.invalid' "$TMP_ROOT/fetch-redaction.out" \
+  && ok "closeout redacts remote credentials from Git stderr" || bad "credential redaction failed"
+
+make_same_file_fixture pr-diff-redaction preserve
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=diff-leak PM_CLOSEOUT_MODE=remote-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --integration-path shared.txt \
+  --authorize-remote-merge "$(authority_for "$FX_REPO" remote-merge 123)" \
+  --title redact-diff --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/pr-diff-redaction.out" 2>&1
+pr_diff_redaction_rc=$?
+set -e
+[ "$pr_diff_redaction_rc" -ne 0 ] && ok "PR diff failure is surfaced" || bad "PR diff redaction fixture unexpectedly succeeded"
+! grep -qE 'PR-DIFF-LEAK|DIFF-TOKEN' "$TMP_ROOT/pr-diff-redaction.out" && grep -qF '***@example.invalid' "$TMP_ROOT/pr-diff-redaction.out" \
+  && ok "closeout redacts credentials from PR diff stderr" || bad "PR diff credential redaction failed"
+
+echo "Case 37: lost PR-close receipt preserves delivered main as an outcome-unknown state"
+make_same_file_fixture close-receipt-loss preserve
+CLOSE_MAIN_BEFORE=$(git -C "$FX_MAIN" rev-parse HEAD)
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=close-view-fail PM_TEST_SAFE_DO_PUSH=1 PM_CLOSEOUT_MODE=local-after-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --main-worktree "$FX_MAIN" --integration-path shared.txt \
+  --authorize-main-push "$(authority_for "$FX_REPO" main-push 123)" \
+  --authorize-main-candidate "$(candidate_authority_for "$FX_REPO" main-push-candidate 123 close-receipt)" \
+  --authorize-pr-close "$(authority_for "$FX_REPO" pr-close 123)" \
+  --title close-receipt --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/close-receipt-loss.out" 2>&1
+close_receipt_rc=$?
+set -e
+assert_eq "$close_receipt_rc" "9" "lost close receipt is not reported as a zero-mutation failure"
+grep -qF 'LOCAL_AFTER_PR_CLOSE_OUTCOME_UNKNOWN' "$TMP_ROOT/close-receipt-loss.out" \
+  && ok "close outcome-unknown receipt retains PR and main identities" || bad "close outcome receipt missing"
+[ "$(git -C "$FX_MAIN" rev-parse HEAD)" != "$CLOSE_MAIN_BEFORE" ] \
+  && [ "$(git -C "$FX_MAIN" rev-parse HEAD)" = "$(git -C "$FX_MAIN" rev-parse origin/main)" ] \
+  && ok "close receipt loss keeps the confirmed local/remote main delivery" \
+  || bad "main delivery was not preserved before close receipt loss"
+
+echo "Case 38: post-create audit failure preserves an outcome-unknown receipt"
+make_same_file_fixture post-create-audit preserve
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=post-create-audit-fail PM_CLOSEOUT_MODE=remote-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --integration-path shared.txt \
+  --authorize-branch-push "$(authority_for "$FX_REPO" branch-push)" \
+  --authorize-pr-create "$(authority_for "$FX_REPO" pr-create)" \
+  --title post-create-audit --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/post-create-audit.out" 2>&1
+post_create_audit_rc=$?
+set -e
+assert_eq "$post_create_audit_rc" "9" "post-create audit failure is outcome-unknown, not zero-mutation failure"
+grep -qF 'PR_CREATE_OUTCOME_UNKNOWN' "$TMP_ROOT/post-create-audit.out" \
+  && ok "post-create audit failure retains a reconciliation state" || bad "post-create audit state missing"
+assert_eq "$(grep -cF 'pr create' "$PM_TEST_GH_LOG")" "1" "post-create audit failure never retries create"
+
+echo "Case 39: native merge queue is left to Task-070"
+make_same_file_fixture merge-queue preserve
+MERGE_QUEUE_MAIN_BEFORE=$(git -C "$FX_REPO" rev-parse origin/main)
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=existing PM_TEST_PROTECTION_MODE=merge-queue PM_CLOSEOUT_MODE=local-after-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --integration-path shared.txt \
+  --authorize-main-push "$(authority_for "$FX_REPO" main-push 123)" \
+  --authorize-remote-merge "$(authority_for "$FX_REPO" remote-merge 123)" \
+  --authorize-remote-candidate "$(candidate_authority_for "$FX_REPO" remote-merge-candidate 123 queue)" \
+  --title queue --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/merge-queue.out" 2>&1
+merge_queue_rc=$?
+set -e
+assert_eq "$merge_queue_rc" "8" "merge queue rule degrades to validate-only"
+grep -qF 'merge-queue-present-task-070-required' "$TMP_ROOT/merge-queue.out" \
+  && ! grep -qF 'pr merge' "$PM_TEST_GH_LOG" \
+  && ok "Task-097 never enqueues an asynchronous merge" || bad "merge queue boundary failed"
+git -C "$FX_REPO" fetch -q origin main
+assert_eq "$(git -C "$FX_REPO" rev-parse origin/main)" "$MERGE_QUEUE_MAIN_BEFORE" "merge queue path leaves main unchanged"
+
+echo "Case 40: protection is rechecked immediately before local main push"
+make_same_file_fixture protection-flip preserve
+PROTECTION_FLIP_MAIN_BEFORE=$(git -C "$FX_REPO" rev-parse origin/main)
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=existing PM_TEST_PROTECTION_MODE=flip-protection PM_CLOSEOUT_MODE=local-after-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --main-worktree "$FX_MAIN" --integration-path shared.txt \
+  --authorize-main-push "$(authority_for "$FX_REPO" main-push 123)" \
+  --authorize-main-candidate "$(candidate_authority_for "$FX_REPO" main-push-candidate 123 protection-flip)" \
+  --title protection-flip --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/protection-flip.out" 2>&1
+protection_flip_rc=$?
+set -e
+assert_eq "$protection_flip_rc" "8" "protection flip blocks local push after candidate verification"
+grep -qF 'reason=main-protection-drift-protected' "$TMP_ROOT/protection-flip.out" \
+  && [ ! -s "$PM_TEST_SAFE_LOG" ] \
+  && ok "final protection gate performs zero main push" || bad "final protection recheck failed"
+git -C "$FX_REPO" fetch -q origin main
+assert_eq "$(git -C "$FX_REPO" rev-parse origin/main)" "$PROTECTION_FLIP_MAIN_BEFORE" "protection flip leaves remote main unchanged"
+
+echo "Case 41: stale REBASE_HEAD alone is not an active rebase"
+make_same_file_fixture stale-rebase-head preserve
+STALE_REBASE_GIT_DIR=$(git -C "$FX_MAIN" rev-parse --absolute-git-dir)
+git -C "$FX_REPO" rev-parse HEAD > "$STALE_REBASE_GIT_DIR/REBASE_HEAD"
+: > "$PM_TEST_SAFE_LOG"; : > "$PM_TEST_GH_LOG"; : > "$PM_TEST_VERIFY_LOG"
+set +e
+PM_TEST_GH_MODE=existing PM_CLOSEOUT_MODE=local-after-pr bash "$CLOSEOUT" \
+  --worktree "$FX_REPO" --main-worktree "$FX_MAIN" --integration-path shared.txt \
+  --authorize-main-push "$(authority_for "$FX_REPO" main-push 123)" \
+  --title stale-rebase-head --safe-push-script "$SAFE_PUSH" --verify-cmd "$VERIFY" --keep-branch \
+  > "$TMP_ROOT/stale-rebase-head.out" 2>&1
+stale_rebase_head_rc=$?
+set -e
+rm -f "$STALE_REBASE_GIT_DIR/REBASE_HEAD"
+assert_eq "$stale_rebase_head_rc" "8" "stale REBASE_HEAD reaches the later candidate authorization gate"
+grep -qF 'PM_CLOSEOUT_CANDIDATE_VERIFIED:' "$TMP_ROOT/stale-rebase-head.out" && \
+  ! grep -qF 'main-worktree-operation-in-progress-REBASE_HEAD' "$TMP_ROOT/stale-rebase-head.out" \
+  && ok "stale REBASE_HEAD is ignored while active rebase directories remain guarded" \
+  || bad "stale REBASE_HEAD was mistaken for an active rebase"
 
 printf 'pm-closeout tests: %s passed, %s failed\n' "$passed" "$failed"
 [ "$failed" -eq 0 ]

--- a/skills/multi-agent-orchestration/scripts/test-pr-audit.sh
+++ b/skills/multi-agent-orchestration/scripts/test-pr-audit.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+BIN="$TMP_ROOT/bin"; REMOTE="$TMP_ROOT/remote.git"; REPO="$TMP_ROOT/repo"
+mkdir -p "$BIN"
+git init -q --bare "$REMOTE"
+git init -q "$REPO"
+git -C "$REPO" config user.name Audit
+git -C "$REPO" config user.email audit@example.invalid
+printf 'base\n' > "$REPO/file.txt"
+git -C "$REPO" add file.txt && git -C "$REPO" commit -qm base
+git -C "$REPO" branch -M main
+git -C "$REPO" remote add origin "$REMOTE"
+git -C "$REPO" push -qu origin main
+git -C "$REPO" checkout -qb feat/audit
+printf 'worker\n' >> "$REPO/file.txt"
+git -C "$REPO" commit -qam worker
+HEAD_SHA=$(git -C "$REPO" rev-parse HEAD)
+BASE_SHA=$(git -C "$REPO" rev-parse origin/main)
+git -C "$REPO" diff "$BASE_SHA" "$HEAD_SHA" > "$TMP_ROOT/diff"
+
+cat > "$BIN/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1 $2" in
+  "pr list")
+    [ "${AUDIT_LIST_FAIL:-0}" -eq 0 ] || { echo 'failed https://user:super-secret@ghe.example/acme/repo?token=also-secret' >&2; exit 43; }
+    cat "$AUDIT_FIXTURE"
+    ;;
+  "pr diff") [ "${AUDIT_DIFF_FAIL:-0}" -eq 0 ] || exit 41; cat "$AUDIT_DIFF" ;;
+  *) exit 42 ;;
+esac
+SH
+chmod +x "$BIN/gh"
+export PATH="$BIN:$PATH" AUDIT_DIFF="$TMP_ROOT/diff" AUDIT_FIXTURE="$TMP_ROOT/prs.json"
+
+pass=0; fail=0
+ok() { echo "  ✓ $1"; pass=$((pass+1)); }
+bad() { echo "  ✗ $1" >&2; fail=$((fail+1)); }
+decision() { python3 "$SCRIPT_DIR/pr-audit.py" --repo "$REPO" --base-ref main --head-ref feat/audit --head-sha "$HEAD_SHA" --task-id Task-097 --agent-id agent-a | jq -r '.decision'; }
+
+printf '[]\n' > "$AUDIT_FIXTURE"
+[ "$(decision)" = create ] && ok "zero candidates permits create" || bad "zero classification"
+
+printf '[{"number":1,"url":"https://example/pull/1","baseRefName":"main","baseRefOid":"%s","headRefName":"feat/audit","headRefOid":"%s","headRepositoryOwner":{"login":"repository"},"isCrossRepository":false,"title":"Task-097 by agent-a","body":"Task: Task-097\\nAgent: agent-a","reviewDecision":"APPROVED","statusCheckRollup":[]}]\n' "$BASE_SHA" "$HEAD_SHA" > "$AUDIT_FIXTURE"
+OUT=$(python3 "$SCRIPT_DIR/pr-audit.py" --repo "$REPO" --base-ref main --head-ref feat/audit --head-sha "$HEAD_SHA" --task-id Task-097 --agent-id agent-a)
+[ "$(printf '%s' "$OUT" | jq -r '.decision')" = adopt ] && [ "$(printf '%s' "$OUT" | jq -r '.counts.exact')" = 1 ] && ok "one exact PR is adopted" || bad "exact adoption"
+[ "$(printf '%s' "$OUT" | jq -r '.exact[0].reasons[0]')" = base_ref_oid_head_ref_oid_repository_task_agent_match ] \
+  && ok "exact reason names every authoritative match" || bad "exact reason is inaccurate"
+[ "$(AUDIT_DIFF_FAIL=1 decision)" = ambiguous ] && ok "exact metadata with unknown PR diff remains ambiguous" || bad "exact diff failure was adopted"
+
+printf 'diff --git a/file.txt b/file.txt\n--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-base\n+different worker\n' > "$TMP_ROOT/different.diff"
+MISMATCH=$(AUDIT_DIFF="$TMP_ROOT/different.diff" python3 "$SCRIPT_DIR/pr-audit.py" --repo "$REPO" --base-ref main --head-ref feat/audit --head-sha "$HEAD_SHA" --task-id Task-097 --agent-id agent-a)
+[ "$(printf '%s' "$MISMATCH" | jq -r '.decision')" = ambiguous ] && \
+  [ "$(printf '%s' "$MISMATCH" | jq -r '.counts.suspected')" = 1 ] && \
+  [ "$(printf '%s' "$MISMATCH" | jq -r '.suspected[0].reasons[]' | grep -c '^pr_diff_mismatch$')" = 1 ] \
+  && ok "exact metadata with a different PR diff is suspected" || bad "PR diff mismatch was adopted or reason unreachable"
+
+WRONG_SHA=$(printf 'f%.0s' {1..40})
+printf '[{"number":2,"url":"https://example/pull/2","baseRefName":"main","baseRefOid":"%s","headRefName":"feat/audit","headRefOid":"%s","headRepositoryOwner":{"login":"repository"},"isCrossRepository":false,"title":"Task-097 by agent-a","body":"Task: Task-097\\nAgent: agent-a","reviewDecision":"APPROVED","statusCheckRollup":[]}]\n' "$BASE_SHA" "$WRONG_SHA" > "$AUDIT_FIXTURE"
+[ "$(decision)" = ambiguous ] && ok "same head with different SHA is ambiguous" || bad "same-head SHA mismatch"
+
+printf '[{"number":3,"url":"https://example/pull/3","baseRefName":"main","baseRefOid":"%s","headRefName":"feat/other","headRefOid":"%s","headRepositoryOwner":{"login":"repository"},"isCrossRepository":false,"title":"other","body":"other","reviewDecision":"APPROVED","statusCheckRollup":[]}]\n' "$BASE_SHA" "$WRONG_SHA" > "$AUDIT_FIXTURE"
+[ "$(AUDIT_DIFF_FAIL=1 decision)" = ambiguous ] && ok "unknown PR diff fails closed" || bad "diff unknown classification"
+
+printf '[{"number":4,"url":"https://example/pull/4","baseRefName":"main","baseRefOid":"%s","headRefName":"feat/audit","headRefOid":"%s","headRepositoryOwner":{"login":"repository"},"isCrossRepository":false,"title":"Task-97 by agent-a","body":"Task: Task-97\\nAgent: agent-a","reviewDecision":"APPROVED","statusCheckRollup":[]}]\n' "$BASE_SHA" "$HEAD_SHA" > "$AUDIT_FIXTURE"
+[ "$(python3 "$SCRIPT_DIR/pr-audit.py" --repo "$REPO" --base-ref main --head-ref feat/audit --head-sha "$HEAD_SHA" --task-id Task-9 --agent-id agent-a | jq -r '.decision')" = ambiguous ] && ok "ownership uses token boundaries" || bad "ownership substring collision"
+
+printf '[{"number":41,"url":"https://example/pull/41","baseRefName":"main","baseRefOid":"%s","headRefName":"feat/audit","headRefOid":"%s","headRepositoryOwner":{"login":"repository"},"isCrossRepository":false,"title":"lookalike trailers","body":"Task: Task-097-old\\nAgent: agent-a-copy","reviewDecision":"APPROVED","statusCheckRollup":[]}]\n' "$BASE_SHA" "$HEAD_SHA" > "$AUDIT_FIXTURE"
+[ "$(decision)" = ambiguous ] && ok "Task/Agent trailers require exact independent values" || bad "trailer prefix collision"
+
+printf '[{"number":42,"url":"https://example/pull/42","baseRefName":"main","baseRefOid":"%s","headRefName":"feat/audit","headRefOid":"%s","headRepositoryOwner":{"login":"fork-owner"},"isCrossRepository":true,"title":"same refs from fork","body":"Task: Task-097\\nAgent: agent-a","reviewDecision":"APPROVED","statusCheckRollup":[]}]\n' "$BASE_SHA" "$HEAD_SHA" > "$AUDIT_FIXTURE"
+[ "$(decision)" = ambiguous ] && ok "fork/cross-repository head cannot be exact" || bad "repository ownership was ignored"
+
+printf '[{"number":43,"url":"https://example/pull/43","baseRefName":"main","baseRefOid":"%s","headRefName":"feat/same-content","headRefOid":"%s","headRepositoryOwner":{"login":"repository"},"isCrossRepository":false,"title":"other branch","body":"other","reviewDecision":"APPROVED","statusCheckRollup":[]}]\n' "$BASE_SHA" "$WRONG_SHA" > "$AUDIT_FIXTURE"
+SAME_CONTENT=$(python3 "$SCRIPT_DIR/pr-audit.py" --repo "$REPO" --base-ref main --head-ref feat/audit --head-sha "$HEAD_SHA" --task-id Task-097 --agent-id agent-a)
+[ "$(printf '%s' "$SAME_CONTENT" | jq -r '.decision')" = ambiguous ] && \
+  [ "$(printf '%s' "$SAME_CONTENT" | jq -r '.suspected[0].reasons[]' | grep -c same_content_different_head)" = 1 ] \
+  && ok "same content on a different branch is suspected" || bad "same-content branch was missed"
+
+printf '[{"number":5,"url":"https://example/pull/5","baseRefName":"main","baseRefOid":"%s","headRefName":"feat/audit","headRefOid":"%s","headRepositoryOwner":{"login":"repository"},"isCrossRepository":false,"title":"Task-097 by agent-a","body":"Task: Task-097\\nAgent: agent-a","reviewDecision":"APPROVED","statusCheckRollup":[]},{"number":6,"url":"https://example/pull/6","baseRefName":"main","baseRefOid":"%s","headRefName":"feat/audit","headRefOid":"%s","headRepositoryOwner":{"login":"repository"},"isCrossRepository":false,"title":"Task-097 by agent-a","body":"Task: Task-097\\nAgent: agent-a","reviewDecision":"APPROVED","statusCheckRollup":[]}]\n' "$BASE_SHA" "$HEAD_SHA" "$BASE_SHA" "$HEAD_SHA" > "$AUDIT_FIXTURE"
+[ "$(decision)" = ambiguous ] && ok "multiple exact PRs are ambiguous" || bad "multiple exact classification"
+
+python3 - "$AUDIT_FIXTURE" <<'PY'
+import json,sys
+rows=[]
+for number in range(1,102):
+    rows.append({"number":number,"url":f"https://example/pull/{number}",
+      "baseRefName":"other","baseRefOid":"0"*40,"headRefName":f"feat/other-{number}",
+      "headRefOid":"f"*40,"headRepositoryOwner":{"login":"repository"},
+      "isCrossRepository":False,"title":"other","body":"other",
+      "reviewDecision":"APPROVED","statusCheckRollup":[]})
+with open(sys.argv[1],"w",encoding="utf-8") as f: json.dump(rows,f)
+PY
+TRUNCATED=$(python3 "$SCRIPT_DIR/pr-audit.py" --repo "$REPO" --base-ref main --head-ref feat/audit --head-sha "$HEAD_SHA")
+[ "$(printf '%s' "$TRUNCATED" | jq -r '.decision')" = ambiguous ] && \
+  [ "$(printf '%s' "$TRUNCATED" | jq -r '.candidate_set_truncated')" = true ] \
+  && ok "101-row candidate page fails closed as truncated" || bad "truncation permitted create"
+
+REMOTE_FORMS=$(python3 - "$SCRIPT_DIR/pr-audit.py" <<'PY'
+import importlib.util,sys
+spec=importlib.util.spec_from_file_location("pr_audit",sys.argv[1]); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
+for url in ("https://user:secret@ghe.example/acme/repo.git", "git@ghe.example:acme/repo.git", "ssh://git@ghe.example/acme/repo.git"):
+    print(mod.canonical_remote(url))
+PY
+)
+[ "$REMOTE_FORMS" = $'ghe.example/acme/repo\nghe.example/acme/repo\nghe.example/acme/repo' ] \
+  && ok "HTTPS credentials, SCP SSH and ssh:// canonicalize without userinfo" || bad "GHE remote canonicalization"
+
+printf '[]\n' > "$AUDIT_FIXTURE"
+set +e
+AUDIT_LIST_FAIL=1 python3 "$SCRIPT_DIR/pr-audit.py" --repo "$REPO" --base-ref main --head-ref feat/audit --head-sha "$HEAD_SHA" \
+  > "$TMP_ROOT/fail.stdout" 2> "$TMP_ROOT/fail.stderr"
+command_fail_rc=$?
+set -e
+[ "$command_fail_rc" -eq 2 ] && [ ! -s "$TMP_ROOT/fail.stdout" ] && \
+  grep -q 'PR_AUDIT_ERROR: command_failed command=gh pr list exit=43' "$TMP_ROOT/fail.stderr" && \
+  ! grep -Eq 'super-secret|also-secret|Traceback' "$TMP_ROOT/fail.stderr" \
+  && ok "command failure is stable, stderr-only and credential-redacted" || bad "command failure leaked or traced back"
+
+ONLY_GIT="$TMP_ROOT/only-git"; mkdir -p "$ONLY_GIT"
+ln -s "$(command -v git)" "$ONLY_GIT/git"
+PYTHON_BIN=$(command -v python3)
+set +e
+PATH="$ONLY_GIT" "$PYTHON_BIN" "$SCRIPT_DIR/pr-audit.py" --repo "$REPO" --base-ref main --head-ref feat/audit --head-sha "$HEAD_SHA" \
+  > "$TMP_ROOT/missing.stdout" 2> "$TMP_ROOT/missing.stderr"
+missing_rc=$?
+set -e
+[ "$missing_rc" -eq 2 ] && [ ! -s "$TMP_ROOT/missing.stdout" ] && \
+  grep -qx 'PR_AUDIT_ERROR: dependency_missing command=gh' "$TMP_ROOT/missing.stderr" && \
+  ! grep -q Traceback "$TMP_ROOT/missing.stderr" \
+  && ok "missing gh dependency has a stable no-traceback error" || bad "missing dependency error contract"
+
+STDERR="$TMP_ROOT/orchestrate.err"
+JSON=$(bash "$SCRIPT_DIR/pm-orchestrate.sh" pr-audit --worktree "$REPO" --base-ref main --head-ref feat/audit --head-sha "$HEAD_SHA" --task-id Task-097 --agent-id agent-a 2>"$STDERR")
+printf '%s' "$JSON" | jq -e '.schema_version=="pr-audit.v1"' >/dev/null && ok "pm-orchestrate stdout is one JSON document" || bad "pm-orchestrate JSON stdout"
+grep -q '^PM_ORCHESTRATE_PR_AUDIT:' "$STDERR" && ok "pm-orchestrate receipt is stderr-only" || bad "pm-orchestrate receipt channel"
+
+printf 'pr-audit tests: %s passed, %s failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## 变更

- 新增 `pr-audit.v1`，按 repo、base/head OID、head repository、真实 diff 和独立 Task/Agent trailer 机械区分 exact、suspected 与 unrelated PR。
- 将 `pm-closeout` 改为 PR-first，支持 `local-after-pr`、`remote-pr`、`validate-only`，并用两阶段候选绑定授权保护 create/push/merge/close。
- 从 fresh main 在隔离 clone 构造三方候选，复核 branch protection、merge queue、PR/checks 漂移及最终 merge parent/tree。
- 为分布式 commit point 增加 `OUTCOME_UNKNOWN`、`REVIEW_REQUIRED`、`LOCAL_PENDING` 回执，禁止盲重试；统一脱敏 Git 与 PR diff 错误。
- 更新 Skill 版本、说明、参考文档、README 与变更记录。

## 验证

- `test-pm-closeout.sh`: 118/118
- `test-pr-audit.sh`: 18/18
- `test-pm-monitor.sh`: 23/23
- `test-pm-orchestrate-handoff.sh`: 31/31
- `quick_validate.py`: PASS
- `security_scan.py`: 0 critical / 0 high
- 独立 reviewer: ACCEPT，reviewed HEAD `105918c0c96384df0e28bb212d508449490f5f60`
- `review-acceptance-gate.v1`: PASS（如实标记 `pm_implementation` 例外）

## 未验证

- 真实 GitHub 非保护仓的“PR → 隔离 main push → 本地 main 快进 → PR close”完整脚本路径。
- 真实 GitHub 保护仓的“PR → 本地候选 → GitHub merge”完整脚本路径。

Task: Task-097
Agent: Codex PM
