### PR TITLE
fix(workbuddy-checkin): Windows 兼容性修复（BOM / UTF-8 编码 / 路径归一化 / .gitattributes）

### DIFF
--- a/skills/workbuddy-checkin/.gitattributes
+++ b/skills/workbuddy-checkin/.gitattributes
@@ -1,0 +1,3 @@
+# Windows 兼容性：Git for Windows 默认 core.autocrlf=true，会把 .sh 检出为 CRLF，
+# bash 执行时报 "bad interpreter: /bin/bash^M"。强制本 skill 目录下 .sh 一律 LF。
+*.sh text eol=lf

--- a/skills/workbuddy-checkin/CHANGELOG.md
+++ b/skills/workbuddy-checkin/CHANGELOG.md
@@ -1,5 +1,25 @@
 # 变更日志
 
+## [1.0.4] - 2026-09-04
+
+### 修复（Windows 兼容性，PR #125）
+
+1.0.3 及之前版本的验证全部在 macOS 完成，Windows（Git Bash / PowerShell 5.1）实跑时脚本完全无法工作。本版修复 4 处：
+
+- **`checkin.ps1` 补 UTF-8 BOM**：文件原为无 BOM 的 UTF-8，PS 5.1 在中文 Windows 按 GBK 解析，中文注释变乱码破坏语法，直接报 `表达式或语句中包含意外的标记"}"`。补 BOM 后正常（零代码改动）。
+- **`checkin.ps1` JSON 解析编码**：`[Console]::OutputEncoding` 中文 Windows 默认 GB2312，接口返回的 UTF-8 JSON 按其解码会变乱码且吃掉闭合引号，`ConvertFrom-Json` 抛错被外层 catch 成 `PARSE_ERR`。现 `Invoke-CheckinApi` 在调用 curl.exe 期间临时切 UTF-8、结束后还原。
+- **`checkin.sh` 路径归一化**：MSYS 的 `SCRIPT_DIR`（`/c/...` 形式）原样传给原生 `node.exe` 被拼成 `C:\c\Users\...` → `Cannot find module` → 令牌为空 → 误报「未找到 Node 运行时」（真实报错被 `2>/dev/null` 吞掉）。现经 `cygpath -w` 归一化后再传给原生程序；JSON 解析改为 Node 优先、python3 回退（Node 本就是必需依赖，避免缺 python3 时无法解析结果）。
+- **新增本 skill 目录 `.gitattributes`**（`*.sh text eol=lf`）：Git for Windows 默认 `core.autocrlf=true` 会把 `.sh` 检出为 CRLF，bash 执行报 `bad interpreter: /bin/bash^M`。
+
+### 修复（review 期间发现）
+
+- **`checkin.sh` 已签到快速短路失效**：Node 分支解析 `today_checked_in` 原输出 JS 小写 `true`，与下游 `[ "$CHECKED" = "True" ]`（对齐 python3 的 `True`，bash `=` 大小写敏感）不匹配。后果：已签到用户每次多打一次 `daily-checkin` 请求（由 `code=10001` 兜底保住幂等，不会重复领取，但「省一次请求」的短路优化在装有 Node 的机器上全部失效）。已改为输出与 python3 分支一致的 `True` / `False`。
+
+### 验证
+
+- 贡献者在 Windows 11 / PowerShell 5.1 / Git Bash 实机跑通 `checkin.sh` 与 `checkin.ps1`；重复签到幂等正确（以业务码 `code=10001` 判定）。
+- 维护者合并前复核：`bash -n` 通过；Node 解析分支对 `today_checked_in` 为 `true` / `false` / 字段缺失 / 非法 JSON 四种输入实测输出 `True` / `False` / `False` / `unknown`，与 python3 分支语义一致；`checkin.ps1` BOM（`EF BB BF`）确认存在且未破坏。
+
 ## [1.0.3] - 2026-08-12
 
 ### 修复

--- a/skills/workbuddy-checkin/SKILL.md
+++ b/skills/workbuddy-checkin/SKILL.md
@@ -181,6 +181,24 @@ Windows PowerShell 执行策略用 `-ExecutionPolicy Bypass`；需 `curl.exe`（
 - **Windows 提示不是内部或外部命令**：用 `powershell -ExecutionPolicy Bypass -File …` 运行；确认 `curl.exe` 存在。
 - **沙箱里 `require('electron')` 报错**：Agent 沙箱默认设 `ELECTRON_RUN_AS_NODE=1`，脚本已用 `env -u`（sh）/ `Remove-Item Env:`（ps1）处理；v5.3.8+ 主路径用纯 Node，不受此影响。
 
+## 本机已打补丁（Windows）⚠️
+
+上游 1.0.3 的验证全部在 macOS 完成（见 CHANGELOG「已知限制」）。本机（Windows / Git Bash / PS 5.1）实跑暴露 3 处问题，均已修复：
+
+| # | 文件 | 症状 | 根因 | 修复 |
+|---|---|---|---|---|
+| 1 | `checkin.ps1` | `表达式或语句中包含意外的标记"}"`，脚本完全跑不起来 | 文件是**无 BOM 的 UTF-8**，PS 5.1 按 GBK 解析，中文注释变乱码破坏语法 | 补 UTF-8 BOM（零代码改动） |
+| 2 | `checkin.ps1` | `签到未成功：PARSE_ERR` | `[Console]::OutputEncoding` 中文 Windows 默认 GB2312，把 UTF-8 JSON 解成乱码并**吃掉闭合引号**，`ConvertFrom-Json` 抛错 | `Invoke-CheckinApi` 内调用 curl.exe 期间临时切 UTF-8，结束后还原 |
+| 3 | `checkin.sh` | `未找到 Node 或 Electron 运行时`（但 `node -v` 正常） | `SCRIPT_DIR` 是 MSYS 的 `/c/...`，传给原生 `node.exe` 被拼成 `C:\c\Users\...` → `Cannot find module` → 令牌为空 | 用 `cygpath -w` 归一化传给 Node 的路径；JSON 解析改为 **Node 优先、python3 回退**（Node 本就是必需依赖） |
+
+> **排错提示**：第 3 条的报错文案极具误导性——它让你去装 Node.js，但 Node 是好的，真实原因被 `decrypt` 调用的 `2>/dev/null` 吞掉。遇到这条，**先直接跑 `node "<脚本绝对路径>/decrypt-token.js"` 看真实报错**。
+
+原文件备份在 `scripts/checkin.sh.bak` / `scripts/checkin.ps1.bak`。**若上游更新覆盖了这两个脚本，请按上表重新打补丁。**
+
+### 已知行为（非 bug）
+
+- 重复签到时 `daily-checkin` 返回 **HTTP 400**（首次签到才是 200），业务体为 `code=10001`。判定依据始终是业务体的 `code=10001`，两个脚本均已将其视为成功。
+
 ## 安全说明
 
 > ⚠️ **凭据即账号密码**：本 skill 解密的 `accessToken` 等同你的 WorkBuddy 账号密码，具有高敏感性。请务必遵守以下红线：

--- a/skills/workbuddy-checkin/SKILL.md
+++ b/skills/workbuddy-checkin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workbuddy-checkin
 description: WorkBuddy 每日积分自动签到。自动解密本地登录令牌，调用官方签到 API 完成每日积分领取（100 积分/天，连续第 7 天 1000 积分），并支持配置定时任务。触发词：WorkBuddy 签到、每日积分、check-in、credits。
-version: "1.0.3"
+version: "1.0.4"
 license: MIT
 ---
 
@@ -181,9 +181,9 @@ Windows PowerShell 执行策略用 `-ExecutionPolicy Bypass`；需 `curl.exe`（
 - **Windows 提示不是内部或外部命令**：用 `powershell -ExecutionPolicy Bypass -File …` 运行；确认 `curl.exe` 存在。
 - **沙箱里 `require('electron')` 报错**：Agent 沙箱默认设 `ELECTRON_RUN_AS_NODE=1`，脚本已用 `env -u`（sh）/ `Remove-Item Env:`（ps1）处理；v5.3.8+ 主路径用纯 Node，不受此影响。
 
-## 本机已打补丁（Windows）⚠️
+## Windows 兼容性修复（1.0.4）
 
-上游 1.0.3 的验证全部在 macOS 完成（见 CHANGELOG「已知限制」）。本机（Windows / Git Bash / PS 5.1）实跑暴露 3 处问题，均已修复：
+1.0.3 及之前版本的验证全部在 macOS 完成（见 CHANGELOG「已知限制」）。1.0.4 修复 Windows（Git Bash / PS 5.1）实跑暴露的 3 处问题：
 
 | # | 文件 | 症状 | 根因 | 修复 |
 |---|---|---|---|---|
@@ -192,8 +192,6 @@ Windows PowerShell 执行策略用 `-ExecutionPolicy Bypass`；需 `curl.exe`（
 | 3 | `checkin.sh` | `未找到 Node 或 Electron 运行时`（但 `node -v` 正常） | `SCRIPT_DIR` 是 MSYS 的 `/c/...`，传给原生 `node.exe` 被拼成 `C:\c\Users\...` → `Cannot find module` → 令牌为空 | 用 `cygpath -w` 归一化传给 Node 的路径；JSON 解析改为 **Node 优先、python3 回退**（Node 本就是必需依赖） |
 
 > **排错提示**：第 3 条的报错文案极具误导性——它让你去装 Node.js，但 Node 是好的，真实原因被 `decrypt` 调用的 `2>/dev/null` 吞掉。遇到这条，**先直接跑 `node "<脚本绝对路径>/decrypt-token.js"` 看真实报错**。
-
-原文件备份在 `scripts/checkin.sh.bak` / `scripts/checkin.ps1.bak`。**若上游更新覆盖了这两个脚本，请按上表重新打补丁。**
 
 ### 已知行为（非 bug）
 

--- a/skills/workbuddy-checkin/scripts/checkin.ps1
+++ b/skills/workbuddy-checkin/scripts/checkin.ps1
@@ -1,4 +1,4 @@
-# ============================================================
+﻿# ============================================================
 # WorkBuddy 每日积分签到（Windows PowerShell 版，兼容 PS 5.1）
 #
 # 流程：读取本地令牌 -> 查询签到状态 -> 未签到则领取 -> 写日志
@@ -129,7 +129,18 @@ function Invoke-CheckinApi([string]$Path) {
     if ($AccDomain) { $a += "-H"; $a += "X-Domain: $AccDomain" }
     if ($EntId) { $a += "-H"; $a += "X-Enterprise-Id: $EntId"; $a += "-H"; $a += "X-Tenant-Id: $EntId" }
     $a += "-d"; $a += "{}"
-    $raw = & curl.exe @a 2>$null
+    # 关键：PowerShell 解码原生进程输出用的是 [Console]::OutputEncoding，中文 Windows
+    # 默认为 GB2312/GBK。接口返回的是 UTF-8 JSON，按 GBK 解码会把中文 msg 转成乱码，
+    # 且乱码字节可能吃掉闭合引号 —— 结果是 ConvertFrom-Json 抛
+    # 「传入的对象无效，应为“:”或“}”」，被外层 catch 成 PARSE_ERR，误报「签到未成功」。
+    # 因此在调用 curl.exe 期间临时切到 UTF-8，结束后还原。
+    $prevEnc = [Console]::OutputEncoding
+    try {
+        [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+        $raw = & curl.exe @a 2>$null
+    } finally {
+        [Console]::OutputEncoding = $prevEnc
+    }
     # 末行是 HTTP 状态码，其余为响应体；返回 [状态码, 响应体]
     if (-not $raw) { return @("000", "") }
     $lines = @($raw)

--- a/skills/workbuddy-checkin/scripts/checkin.sh
+++ b/skills/workbuddy-checkin/scripts/checkin.sh
@@ -24,8 +24,24 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DECRYPT_JS="$SCRIPT_DIR/decrypt-token.js"
 LOG_DIR="$SCRIPT_DIR/../logs"
+
+# ---------- Windows / Git Bash 路径归一化 ----------
+# MSYS 的 pwd 返回 /c/... 形式，原样传给原生 node.exe 会被拼成 C:\c\Users\... ，
+# 报 "Cannot find module '<path>'" → 取不到令牌 → 误报「未找到 Node 运行时」
+# （真实原因被 decrypt 调用的 2>/dev/null 吞掉，排查方向完全跑偏）。
+# 凡是要交给原生 Windows 程序（node.exe / electron.exe）的路径，都先转原生形式。
+to_native_path() {
+  local p="$1"
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -w "$p" 2>/dev/null || printf '%s' "$p"
+  else
+    printf '%s' "$p"
+  fi
+}
+
+# 注意：DECRYPT_JS 用原生路径；LOG_DIR 仍用 MSYS 路径（只给 mkdir/tee 用）
+DECRYPT_JS="$(to_native_path "$SCRIPT_DIR")/decrypt-token.js"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/checkin.log"
 
@@ -150,7 +166,20 @@ fi
 # 注意：today_checked_in 字段在 v5.3.8 实测不可靠（签到成功后仍可能为 false）。
 # 此处仅用于「能省一次签到请求就省」的快速短路与 401 探测；真正的幂等兜底
 # 放在下方 daily-checkin 的 code=10001 处理。
-CHECKED=$(echo "$STATUS" | python3 -c "
+# JSON 解析：Node 优先（本脚本已依赖 Node 读取令牌，无额外依赖），python3 仅回退。
+# 原实现只用 python3：缺 python3 时结果为空，会把「已成功」误报成
+# 「签到请求已提交，无法解析结果」，无法确认当日是否真的领到积分。
+NODE_BIN="$(find_node)"
+CHECKED=""
+if [ -n "$NODE_BIN" ]; then
+  CHECKED=$(JSON_PAYLOAD="$STATUS" "$NODE_BIN" -e '
+const s = process.env.JSON_PAYLOAD || "";
+try { const d = JSON.parse(s); console.log(String((d.data || {}).today_checked_in)); }
+catch (e) { console.log("unknown"); }
+' 2>/dev/null)
+fi
+if [ -z "$CHECKED" ]; then
+  CHECKED=$(echo "$STATUS" | python3 -c "
 import sys, json
 try:
     d = json.load(sys.stdin)
@@ -158,6 +187,7 @@ try:
 except Exception:
     print('unknown')
 " 2>/dev/null)
+fi
 
 if [ "$CHECKED" = "True" ]; then
   log "✅ 今日已签到，无需重复领取"
@@ -184,7 +214,25 @@ if [ -z "$RESULT" ]; then
   exit 1
 fi
 
-CREDIT=$(echo "$RESULT" | python3 -c "
+CREDIT=""
+if [ -n "$NODE_BIN" ]; then
+  CREDIT=$(JSON_PAYLOAD="$RESULT" "$NODE_BIN" -e '
+const s = process.env.JSON_PAYLOAD || "";
+try {
+  const d = JSON.parse(s);
+  if (d.code === 0) {
+    const dd = d.data || {};
+    console.log("OK credit=" + dd.credit + " streak_days=" + dd.streak_days);
+  } else if (d.code === 10001) {
+    console.log("ALREADY today");   // 当日已签到：接口幂等拒绝，视为成功
+  } else {
+    console.log("FAIL code=" + d.code + " msg=" + d.msg);
+  }
+} catch (e) { console.log("PARSE_ERR"); }
+' 2>/dev/null)
+fi
+if [ -z "$CREDIT" ]; then
+  CREDIT=$(echo "$RESULT" | python3 -c "
 import sys, json
 try:
     d = json.load(sys.stdin)
@@ -199,6 +247,7 @@ try:
 except Exception:
     print('PARSE_ERR')
 " 2>/dev/null)
+fi
 
 if [[ "$CREDIT" == OK* ]]; then
   log "🎉 签到成功！领取 $CREDIT"

--- a/skills/workbuddy-checkin/scripts/checkin.sh
+++ b/skills/workbuddy-checkin/scripts/checkin.sh
@@ -172,9 +172,13 @@ fi
 NODE_BIN="$(find_node)"
 CHECKED=""
 if [ -n "$NODE_BIN" ]; then
+  # 输出协议与下方 python3 分支对齐：True / False / unknown。
+  # 必须输出大写 True（JS 原生 String(true) 是小写 true，与下游
+  # [ "$CHECKED" = "True" ] 大小写敏感比较不匹配，会让已签到快速短路失效，
+  # 每次多打一次 daily-checkin 请求、只能靠 code=10001 兜底）。
   CHECKED=$(JSON_PAYLOAD="$STATUS" "$NODE_BIN" -e '
 const s = process.env.JSON_PAYLOAD || "";
-try { const d = JSON.parse(s); console.log(String((d.data || {}).today_checked_in)); }
+try { const d = JSON.parse(s); console.log((d.data || {}).today_checked_in === true ? "True" : "False"); }
 catch (e) { console.log("unknown"); }
 ' 2>/dev/null)
 fi


### PR DESCRIPTION
## 目的

`workbuddy-checkin` 在 Windows 上完全跑不起来（作者只在 macOS 验证过，CHANGELOG 1.0.3 也自承“Windows 侧未在实机验证”）。本 PR 修复三个只影响 Windows 的兼容性 bug，并新增 `.gitattributes` 防止 `.sh` 被检出为 CRLF。

## 修复内容

### 1. `scripts/checkin.ps1` 补 UTF-8 BOM（零代码改动）
Windows PowerShell 5.1 默认按 GBK 解析无 BOM 的 UTF-8，脚本中文注释变乱码 → 直接报 `意外的标记"}"` 语法错误，完全无法运行。补 BOM 后正常。

### 2. `scripts/checkin.ps1` 修正 JSON 解析编码
`curl.exe` 返回 UTF-8 响应，但 `[Console]::OutputEncoding` 在中文 Windows 默认是 gb2312，导致中文报错信息被解成乱码并吃掉闭合引号 → `ConvertFrom-Json` 报 PARSE_ERR。已在调用 curl 期间临时把控制台切到 UTF-8，调用后还原。

### 3. `scripts/checkin.sh` 修正 Node 路径（`SCRIPT_DIR` 归一化）
`SCRIPT_DIR` 是 Git Bash 的 `/c/...` 路径，原样传给原生 `node.exe` 会被拼成 `C:\c\Users\...` → `Cannot find module`，脚本误报“未找到 Node 运行时”（真实报错被 `2>/dev/null` 吞掉），实际 Node 是好的。改用 `cygpath -w` 归一化为 Windows 路径；JSON 解析改为 Node 优先、python3 回退（Node 本就是必需依赖，更稳）。

### 4. 新增 `scripts/../.gitattributes`
仓库根 `.gitattributes` 无 `eol` 规则，而 Git for Windows 默认 `core.autocrlf=true`，会把 `.sh` 检出为 CRLF，bash 执行时报 `bad interpreter: /bin/bash^M`。新增仅作用于本 skill 目录的规则：`*.sh text eol=lf`。

## 验证

- `bash scripts/checkin.sh` 与 `powershell -File scripts/checkin.ps1` 在 Windows 11 / PowerShell 5.1 / Git Bash 下均跑通。
- 幂等性验证：当天已签到时两者都正确跳过、不重复领取（接口重复签到返回 `code=10001`，已做兜底判定；`today_checked_in` 字段实测不可靠，故以业务码为准）。
- 日志 `logs/checkin.log` 经扫描不含任何 token / cookie / 账号信息。

## 说明

- 未改动任何业务逻辑、未改动 `decrypt-token.js` / `setup.sh` / `setup.ps1` / 文档其余部分。
- 仅 `checkin.sh`、`checkin.ps1`、`SKILL.md`（新增 Windows 排错章节）三个文件有改动，外加新增 `.gitattributes`。
