### PR TITLE
feat(dsh-plugin-lint): 增加版本感知机械审计 v2

### DIFF
--- a/skills/dsh-plugin-lint/CHANGELOG.md
+++ b/skills/dsh-plugin-lint/CHANGELOG.md
@@ -1,5 +1,40 @@
 # 变更日志
 
+## [1.0.0] - 2026-09-04
+
+> 版本号从 0.1.0 跳至 1.0.0：本技能位于 `skills/` 正式目录，按项目规范正式版本使用 1.x.x；同时本次为行为级重构（新增多条规则、事实源改为运行时溯源），语义变化显著。
+
+### 新增
+
+- **harness 溯源（§0）**：`--harness-root` 参数 / `DSH_HARNESS_ROOT` 环境变量 / `config/harness-path.local.yaml` 三级解析；DSH 版本优先经官方可执行门（`apps/cli/lib/bin.js --version`）读取并与根 manifest 交叉核对，git commit 一并报告；官方门与 manifest 不一致出 WARN
+- **产物 bare require ↔ 模块表对账（§5）**：注释感知扫描 `lib/client.js`，未知 bare require（不在平台基线也不在 `dsh.client.external`）FAIL；内联安全层被外置 FAIL（纯度正则从 harness `tsdown.client.ts` 运行时提取）；bare builtin require 出 WARN 转人工确认
+- **构建配置 external 对账（§5）**：从 `tsdown.client.config.ts` 的 externals 语义声明体提取说明符，越界（非基线 ∪ `dsh.client.external`）FAIL；找不到声明体 WARN 转人工
+- **dsh.client.inject/external 声明检查（§4）**：inject 目标必须在 harness workspace 或本地 node_modules 声明 `dsh.client`（否则 FAIL——该边永远等不到工厂）；inject ↔ devDep 类型双保险缺失 WARN；`dsh.client.external` 自引用 FAIL（harness 会拒绝启动）、基线冗余行 WARN、产物无对应 require 的死行 WARN
+- **主题变量对账（§6）**：从 harness `ui-theme/src/styles/*.css` 收集当前声明集，插件引用不存在的 `--dsw-*`/`--ds-*`/`--shiki-*` 变量 FAIL（回退值会掩盖主题断链）
+- **硬编码文案与类型化 locale（§7）**：JSX 文本位置/用户可见属性硬编码 CJK 文案 FAIL；普通 CJK 字符串字面量 WARN；插件 `locales.ts`（或 `locales/zh.ts`+`en.ts`）zh/en 键集平价校验 FAIL
+- **文档版本声明检查（§9）**：当前态文档（排除 CHANGELOG 与 acceptance 证据）中的冻结 `0.1.0-rc.x` 引用、已移除平台模块 `dsh-client-runtime` 引用出 WARN
+- **DSH 依赖版本漂移（§1）**：`@deepseek-ai/dsh-*` 钉定版本与当前 harness 版本不一致 WARN
+- **自测 `scripts/test-lint.mjs`**：自包含 fixture（运行时合成迷你 harness + 有效/无效插件对照），23 项断言证明每条规则抓得住无效样本、放行有效对照
+- `--json` 输出（`__DSH_LINT_JSON__` 行）供脚本化消费
+
+### 改进
+
+- 平台模块表（`PLATFORM_MODULES`/`PRELOADED_CLIENT_EXTERNALS`）、纯度正则（`INLINE_SAFE` 等）、主题变量集、client 包 manifest 全部改为**运行时从 `--harness-root` 当前源码读取**，替换冻结的 0.1.0-rc.7 假设；技能内不再预置任何版本号事实
+- 头部 manifest 失败即提前退出的行为保留，但 harness 缺失时其余检查继续、相关项标 NOT_VERIFIED，不再崩溃也不假 PASS
+- 退出码语义保持 = FAIL 数；WARN/NOT_VERIFIED 不阻塞但正式验收必须逐条人工结论
+
+### 技术优化
+
+- 自研注释感知 JS 扫描器（字符串/模板/正则字面量状态机），支撑产物与源码的确定性规则；零第三方依赖（Node ≥ 18.6，`node:module.isBuiltin`）
+- findings 结构化（level + message），文本与 JSON 双通道输出
+
+### 文档完善
+
+- SKILL.md：新增 harness 根解析、§1 规则清单、依赖章节（开箱即用声明）、已知限制重写；HMR 结论标注为历史观察需按版本复核；版本号升 1.0.0
+- references/dsh-plugin-development-standards.md：事实基线更新为 0.1.2-rc.1（commit 76fda729）；lossless JSON 路径更正为 `packages/util/values/src/index.ts`；新增 `dsh.client` 字段语义表、平台基线唯一事实源（`platform.ts`）、类型化 slot catalog（`contract/slots.ts`）、主题变量、类型化 locale 章节；实测坑清单增补 4 条（externals 手抄漂移、external 自引用、主题变量 fallback 掩盖、裸写文案）
+- templates/plugin-quality-report.md：新增 harness 溯源章节与全部新检查行
+- config/harness-path.example.yaml：记录解析优先级与官方版本门说明
+
 ## [0.1.0] - 2026-08-19
 
 ### Added

--- a/skills/dsh-plugin-lint/SKILL.md
+++ b/skills/dsh-plugin-lint/SKILL.md
@@ -2,29 +2,47 @@
 name: dsh-plugin-lint
 homepage: https://github.com/cat-xierluo/legal-skills
 author: 杨卫薪律师（微信ywxlaw）
-version: "0.1.0"
+version: "1.0.0"
 license: MIT
-description: DeepSeek Harness（DSH）插件的设计预检、质量审查与发布验收工具。在用户创建、重大改造或审查 DSH 插件（dsh.bundle / dsh.client 双面包），需要核对 harness 事实引用、工件契约、lossless JSON、fail-loud 语义，或发布前验收 boot/浏览器证据时使用。开发规范见 references/dsh-plugin-development-standards.md。不要用于：普通 npm 包审查、与 DSH 无关的 agent 项目。
+description: DeepSeek Harness（DSH）插件的设计预检、质量审查与发布验收工具（版本感知）。在用户创建、重大改造或审查 DSH 插件（dsh.bundle / dsh.client 双面包），需要核对 harness 事实引用、工件契约、inject/external 对账、主题变量、类型化 locale、lossless JSON、fail-loud 语义，或发布前验收 boot/浏览器证据时使用。开发规范见 references/dsh-plugin-development-standards.md。不要用于：普通 npm 包审查、与 DSH 无关的 agent 项目。
 ---
 
 # DSH Plugin Lint
 
 审查一个 DSH 插件是否：声明与工件一致、对 harness 的引用真实存在、契约坑已规避、文档已同步、验收证据可绑定候选。
 
-开发与范式依据：[references/dsh-plugin-development-standards.md](references/dsh-plugin-development-standards.md)（插件形态、分发、工具/事件/slot、client 工件契约、harness 参考文件索引）。
+开发与范式依据：[references/dsh-plugin-development-standards.md](references/dsh-plugin-development-standards.md)（插件形态、分发、工具/事件/slot、client 工件契约、类型化 locale、主题变量、harness 参考文件索引）。
 
 本技能不代替实现者。创建插件时先做设计预检，实现后回来做正式验收——审查器与生产者不混同责任。
 
 配套文件：
-- `config/harness-path.example.yaml` → 复制为 `config/harness-path.local.yaml` 填本地 harness 仓库路径与基线版本（§2 溯源用）
+- `scripts/lint.mjs` → §1 机械层（版本感知，规则清单见下）
+- `scripts/test-lint.mjs` → 自测（自包含 fixture，证明每条规则抓得住无效样本、放行有效对照）
+- `config/harness-path.example.yaml` → 复制为 `config/harness-path.local.yaml` 填本地 harness 仓库路径（不提交）
 - `templates/plugin-quality-report.md` → 正式审查的报告模板（结论带 NOT_VERIFIED 语义）
+
+## 依赖
+
+- Node ≥ 18.6（用到 `node:module.isBuiltin`），无第三方包——脚本开箱即用，无需安装。
+- harness 溯源需要本地有一份 DSH 源码仓库（`git` 可用时同时报告 commit；不可用则该项 NOT_VERIFIED）。
 
 ## 工作原则
 
-- 先机械后语义：脚本能查的（声明/工件）不浪费人工。
-- **对 harness 的每个 API/事件/slot 引用必须溯源到源码路径**——不采信文档记忆，DSH 处于 rc 阶段，文档会超前或滞后于代码（实测案例：SKILL.md 写过不存在的 CLI flag、插件设计稿写过不存在的 `agent/post-step` 事件）。
+- 先机械后语义：脚本能查的（声明/工件/对账）不浪费人工。
+- **版本感知，不冻结假设**：平台模块表、内联安全正则、主题变量、包 manifest 全部从当前 harness 源码声明读取；版本与 commit 优先走官方 dsh 可执行门（`apps/cli/lib/bin.js --version`）+ git 溯源。规范文档里的实测结论一律标注核对版本。
+- **对 harness 的每个 API/事件/slot 引用必须溯源到源码路径**——不采信文档记忆（实测案例：文档写过不存在的 CLI flag、不存在的 `agent/post-step` 事件、已被移除的 `dsh-client-runtime`）。
 - 不采信自报 PASS；正式验收必须绑定当前 commit 的 boot 证据 + 浏览器渲染证据。
-- 客观缺陷 fail-closed；无法确认的标 `NOT_VERIFIED`。
+- 客观缺陷 fail-closed；**语义不确定只出 WARN / NOT_VERIFIED，绝不出假 PASS**。
+
+## harness 根解析
+
+`lint.mjs` 按以下优先级解析 DSH 源码仓库（harness root）：
+
+1. `--harness-root <路径>` 参数
+2. 环境变量 `DSH_HARNESS_ROOT`
+3. `config/harness-path.local.yaml`（技能目录内，不提交）
+
+三者皆缺时，版本相关检查项标 `NOT_VERIFIED`（进程不崩，其余检查继续）。解析成功后报告：DSH 版本（官方门 + 根 manifest，两者不一致时 WARN）、git commit、平台模块表项数。所有 harness 依赖检查以该版本为准。
 
 ## 模式
 
@@ -34,37 +52,60 @@ description: DeepSeek Harness（DSH）插件的设计预检、质量审查与发
 | 快速审查 | 第三方/草稿 | §1 机械 + §2 事实 + §3 契约；结论带 NOT_VERIFIED |
 | 正式验收 | 发布/声称完成前 | 全部 + §5 候选绑定证据 |
 
-## §1 机械层（跑 `scripts/lint.mjs <插件目录>`）
+## §1 机械层（跑 `scripts/lint.mjs`）
 
-声明一致性 + 工件契约（banner/footer、后缀、文件存在性）。FAIL 即阻塞，退出码 = FAIL 数。
+```bash
+node skills/dsh-plugin-lint/scripts/lint.mjs <插件目录> --harness-root <DSH 源码仓库>
+node skills/dsh-plugin-lint/scripts/test-lint.mjs   # 自测，退出码 0 = 全部规则自证有效
+```
+
+`--json` 会在文末追加一行 `__DSH_LINT_JSON__{...}` 机器可读结果。退出码 = FAIL 数。
+
+| 节 | 检查内容 |
+|---|---|
+| §0 harness 溯源 | 版本（官方门 + manifest 交叉）、git commit、平台模块表/纯度正则可解析性、config 基线漂移 |
+| §1 package.json | name 解析；`@deepseek-ai/dsh-*` 依赖钉定版本与当前 harness 版本漂移 |
+| §2 dsh.bundle | patch 文件存在、row 引用包名 |
+| §3 exports["."] | node half 入口存在 |
+| §4 dsh.client | platform=web；inject 目标在 harness workspace / 本地 node_modules 声明了 `dsh.client`（否则该边永远等不到工厂，FAIL）；inject ↔ devDep 类型双保险（WARN）；`dsh.client.external` 字段类型、自引用（FAIL）、基线冗余行（WARN） |
+| §5 client 工件 | 存在性、`.cjs` 后缀、banner/footer 契约；**产物 bare require ↔ 模块表对账**（注释感知扫描：未知说明符 FAIL——模块表无法应答必抛；内联安全层被外置 FAIL；bare builtin require WARN——须人工确认在 inliner 特征探测内）；**构建配置 external ↔ 平台基线 ∪ dsh.client.external 对账**（越界 FAIL，未找到 externals 声明体 WARN 转人工）；external 死行（WARN） |
+| §6 主题变量 | 对 `var(--…)` 引用做声明集对账（声明源：harness `ui-theme/src/styles/*.css` + 插件自身声明）：不存在的 DSH 变量 FAIL（回退值会掩盖主题断链）；未用变量不报 |
+| §7 文案与 locale | JSX 文本/用户可见属性硬编码 CJK 文案 FAIL；普通 CJK 字符串字面量 WARN；`locales.ts`（或 `locales/zh.ts`+`en.ts`）zh/en 键集平价 FAIL |
+| §8 卫生 | scoped 包 publishConfig.access、scripts.build/test |
+| §9 文档版本声明 | 当前态文档（README/AGENTS/CLAUDE/docs，排除 CHANGELOG 与 acceptance 证据）中的冻结 `0.1.0-rc.x` 引用与已移除模块 `dsh-client-runtime` 引用（WARN） |
+
+FAIL 即阻塞。WARN 与 NOT_VERIFIED 不阻塞，但正式验收报告必须逐条给出人工结论。
 
 ## §2 事实层（对照 harness 源码逐条核对）
 
 | 审查项 | 溯源方法 |
 |---|---|
 | 事件名存在且语义对 | `packages/core/agent/src/runtime-types.ts`（注意：**没有 `agent/post-step`**） |
-| slot 名真实声明过 | `packages/client/ui-*/src` 里 grep `slots.inject('` / `renderSlot('`；slot 的**类型声明**在所属 client 包（如 ui-conversation），out-of-tree 需 devDep + `dsh.client.inject` |
+| slot 名真实声明过 | `packages/client/ui-*/src` 里 grep `slots.inject('` / `renderSlot('`；slot 的**类型声明**在所属 client 包，out-of-tree 需 devDep（类型）+ `dsh.client.inject`（加载顺序）双保险 |
 | 工具 API 形状 | `docs/cookbook/adding-a-tool.md` + `packages/core/tools/src/index.ts` |
+| lossless JSON 校验 | `packages/util/values/src/index.ts`（`walkJsonValue`；旧路径 `packages/core/session/src/json.ts` 已不存在） |
 | 生命周期/服务 | `ctx.get`（可选）vs `inject`（硬依赖，缺则整个插件不激活） |
 
-harness 仓库路径与完整索引见开发规范 §参考文件索引。
+harness 仓库路径与完整索引见开发规范 §参考文件索引。核对时以 `--harness-root` 指向的仓库为准，并在报告记录其版本与 commit。
 
 ## §3 契约层（实测踩过的坑，逐条核对）
 
 1. **lossless JSON**：tool 返回值任何属性值为 `undefined` 都被拒（递归）——返回前深度剥离。
 2. **DSL 限制**：`parameters` 不支持对象嵌套对象；独立 const 的 schema 字面量要 `as const`。
-3. **client 工件**：banner 必须构造 `var module = { exports: {} }; var exports = module.exports;`；`"type":"module"` 包内 cjs 产物须 `outExtensions` 强制 `.js`。
-4. **client 纯度**：非平台表的 `@deepseek-ai/*` 值导入禁止（type-only 会被擦除，不受限）。
+3. **client 工件**：banner 必须构造 `var module = { exports: {} }; var exports = module.exports;`；`"type":"module"` 包内 cjs 产物须 `outExtensions` 强制 `.js`；产物 bare require 只能请求平台基线或 `dsh.client.external` 声明的说明符。
+4. **client 纯度**：非基线、非 `dsh.client.external`、非内联安全表的 `@deepseek-ai/*` 值导入禁止（type-only 会被擦除，不受限）——构建 purity gate 会直接报错。
 5. **子进程**：长任务异步 `spawn` + `exec.signal`；`spawnSync` 冻结整个 harness。
 6. **显式传参**：不依赖被调 CLI 的静默默认值（实测案例：contract-copilot 的 review_intensity 缺省静默变"强势"）。
 7. **fail-loud**：配置错在 apply 里 throw；可选服务缺省要明示降级路径。
 8. **退码分类**：域结果（partial/rejected）进 canonical value 不 throw；基础设施失败才 throw。
 9. **构建管线**：不要用会吞退出码的管道（`cmd | grep | head && next` 曾让 tsc 失败静默、旧 bundle 留盘数小时）。
-10. **HMR 边界**：out-of-tree 插件更新 client bundle 后必须重启 dsh web（rev 不被重扫）。
+10. **HMR 边界（历史结论，按版本复核）**：0.1.0-rc.7 时期双向实测 out-of-tree 插件两个 half 都不热加载、更新后必须重启 dsh；该结论未在后续版本复测——审查时作为待验证假设处理（WARN 语义），以当前 harness 的 `packages/client/hmr` 行为实测为准。
+11. **主题变量**：只引用 harness 主题声明集里的变量；回退值（`var(--x, #fff)`）只是兜底显示，掩盖不了暗色主题断链。
+12. **类型化 locale**：产品 UI 文案走插件自有命名空间词典（zh 为键集真值、en 对齐），组件经 `PropsLocale<'ns'>` 的 `t()` 消费；JSX 文本/属性里裸写文案即违约。
 
 ## §4 文档层
 
-目标插件仓库的 CHANGELOG / DECISIONS / ROADMAP / ARCHITECTURE 与本次改动同步；决策可追溯（编号连续、含撤回记录）。
+目标插件仓库的 CHANGELOG / DECISIONS / ROADMAP / ARCHITECTURE 与本次改动同步；决策可追溯（编号连续、含撤录）。当前态文档不得残留已过期版本声明（§1 §9 会给 WARN 清单）。
 
 ## §5 正式验收（候选绑定）
 
@@ -80,7 +121,8 @@ harness 仓库路径与完整索引见开发规范 §参考文件索引。
 
 ```
 dsh-plugin-lint 报告 <目标> @ <commit>
-§1 机械: [PASS|FAIL...]（脚本输出）
+harness 溯源: <DSH 版本> @ <harness commit>（解析来源）
+§1 机械: [PASS|FAIL|WARN|NOT_VERIFIED...]（脚本输出，退出码 = FAIL 数）
 §2 事实: 每条引用 → 源码路径 → PASS/FAIL
 §3 契约: 逐条 PASS/FAIL/NA
 §4 文档: ...
@@ -88,8 +130,10 @@ dsh-plugin-lint 报告 <目标> @ <commit>
 结论: 可发布 / 需修复（清单）/ 未验证
 ```
 
-## 已知限制（v0.1）
+## 已知限制
 
-- 机械层不解析 YAML 全语法（正则级）；复杂 patch 结构转人工
+- 正则级解析，不构建 AST：复杂 patch 结构、嵌套词典、非扁平 locale 对象转人工（脚本对解析不了的情形出 WARN/NOT_VERIFIED，不出 PASS）
+- 产物 bare builtin require 只能提示人工确认（inliner 的 try/catch 特征探测合法，无法机械判定）
+- JSX 文本位置的 CJK 检测是启发式（`>…<` 区间含 CJK），不含 `{}` 表达式内部
+- 平台模块表/纯度正则/主题变量集/包 manifest 均为运行时从 `--harness-root` 读取的当前事实；不随本技能分发，也不预置任何版本号
 - 不自动执行目标仓库的 build/test（报告应跑的命令，防误伤）
-- 平台模块表与 slot 清单以 harness 0.1.0-rc.7 为准；DSH 升级后先更新开发规范再审查

--- a/skills/dsh-plugin-lint/config/harness-path.example.yaml
+++ b/skills/dsh-plugin-lint/config/harness-path.example.yaml
@@ -1,13 +1,20 @@
 # DSH Plugin Lint 审查配置示例。
 # 复制为 config/harness-path.local.yaml 后填写本地路径；local 文件不提交。
-# §2 事实层溯源与（规划中的）facts.mjs 都从这里读 harness 仓库位置。
+#
+# harness 根解析优先级（高→低）：
+#   1. lint.mjs 的 --harness-root 参数
+#   2. 环境变量 DSH_HARNESS_ROOT
+#   3. 本文件（harness_root 字段）
+#
+# 版本溯源优先走官方可执行门（<harness_root>/apps/cli/lib/bin.js --version），
+# 并以根 package.json 交叉核对；git 仓库会额外报告 commit。
 
 schema_version: 1
 
 # harness 源码仓库的绝对路径（含 packages/ apps/ docs/）。
-# 事实核对（事件/slot/工具契约）都以此仓库为准。
+# 平台模块表、纯度正则、主题变量、包 manifest 等全部对账以此仓库当前源码为准。
 harness_root: "/path/to/deepseek-harness"
 
-# 记录审查基线版本（package.json 的 @deepseek-ai/dsh-base 版本）。
-# 规范的"实测坑清单/slot 表"以 0.1.0-rc.7 为准；基线不同时先复核规范再审查。
-harness_baseline: "0.1.0-rc.7"
+# 可选：记录审查时参考的基线版本。与当前 harness 版本不一致时 lint 会出
+# WARN 提醒先复核规范再审查；不写此字段则不做该提醒。
+harness_baseline: "0.1.2-rc.1"

--- a/skills/dsh-plugin-lint/references/dsh-plugin-development-standards.md
+++ b/skills/dsh-plugin-lint/references/dsh-plugin-development-standards.md
@@ -1,16 +1,16 @@
 # DSH 插件开发规范（dsh-plugin-development-standards）
 
-DeepSeek Harness（DSH）out-of-tree 插件的开发范式。事实核对于 2026-08-19，对应 harness 版本 **0.1.0-rc.7**（npm 已发布同版本）。DSH 处于 rc 阶段——**升级后按 §参考文件索引 逐条复核**，不采信本文记忆。
+DeepSeek Harness（DSH）out-of-tree 插件的开发范式。事实核对于 **2026-09-04，对应 harness 0.1.2-rc.1（commit `76fda729`）**；0.1.0-rc.7 时期的历史结论单独标注。DSH 处于 rc 阶段——**升级后按 §参考文件索引 逐条复核**，不采信本文记忆。机械层核查可用 `dsh-plugin-lint/scripts/lint.mjs --harness-root <DSH 源码仓库>` 自动对账（版本、平台模块表、inject/external、主题变量均从当前源码声明读取）。
 
-来源：dsh-contract-copilot 插件全程开发实测（含多轮 e2e 与浏览器验证），踩坑记录见文末"实测坑清单"。
+来源：dsh-contract-copilot 插件全程开发实测（含多轮 e2e 与浏览器验证）+ 0.1.2-rc.1 源码核对，踩坑记录见文末"实测坑清单"。
 
 ## 1. 插件形态与分发
 
 - **function plugin**：`export const name / inject / Config / apply(ctx, config)`（命名导出，无 default export）
 - **声明 bundle**：`package.json` 的 `"dsh": { "bundle": { "patch": "./cordis.patch.yml" } }`
 - **patch 层**：`cordis.patch.yml` 里 `- insert: [{id, name}]` 插入插件 row；profile/用户层可用裸 `- id:` + `config:` 按 id 覆盖整行 config（**必须重述该 row 全部键**，patch 是整行替换不深合并）
-- **安装链**（publish.md 全部核实）：
-  - `dsh plugin --profile <name> add ./<dir>` → pnpm link → `reconcilePlugins`（`apps/cli/src/plugin.ts:59`）把包追加进 `dsh.profile.bundles`
+- **安装链**（publish.md 核对过）：
+  - `dsh plugin --profile <name> add ./<dir>` → pnpm link → `reconcilePlugins`（`apps/cli/src/plugin.ts`）把包追加进 `dsh.profile.bundles`
   - GitHub 安装：`dsh plugin --profile <name> add github:<owner>/<repo>`；需包自带**自包含** `prepare` 脚本（不假设 monorepo）+ 用户侧 `pnpm-workspace.yaml` 加 `allowBuilds: { '<pkg-full-name>': true }`
   - tarball（`pnpm pack`）与 npm publish 是免 allowBuilds 的替代；scoped 包 npm 发布需 `publishConfig.access: "public"`
 - **配置**：schemastery `z.object({...})` 导出 `Config`；误配 fail loud（apply 里校验并 throw）
@@ -31,7 +31,7 @@ ctx.tools.register(defineTool({
 
 硬约束（全部实测）：
 
-- **lossless JSON**：返回值任何属性值为 `undefined` 都被 `walkJsonValue` 拒（**递归**，`packages/core/session/src/json.ts`）——返回前深度剥离 undefined
+- **lossless JSON**：返回值任何属性值为 `undefined` 都被 `walkJsonValue` 拒（**递归**，0.1.2 位于 `packages/util/values/src/index.ts`；旧路径 `packages/core/session/src/json.ts` 已不存在）——返回前深度剥离 undefined
 - **DSL 限制**：`parameters` 不支持对象嵌套对象（拍平为顶层字段）；独立 const 的 schema 字面量要 `as const`（否则字面量类型被拓宽、判型失败）
 - `execute(args, exec)`：`exec.signal` 必须响应（长任务传给 spawn 的 AbortSignal）
 - 长任务可前台 await（耦合 signal）；后台任务用 `ctx.jobs.start`
@@ -39,8 +39,8 @@ ctx.tools.register(defineTool({
 
 ## 3. 事件与上下文注入
 
-- 事件表：`packages/core/agent/src/runtime-types.ts`。`agent/pre-step` 是 waterfall，payload `{agent, messages, turn, step, signal}`，返回 `PreStepDecision`。**没有 `agent/post-step`**——状态写盘放 tool handler 内
-- 参照实现：`packages/context/time-context/src/index.ts:170`（`{prepend:true}` + `createUserMessage({content:[{type:'text',text}], source:{kind:'plugin',...}})`）
+- 事件表：`packages/core/agent/src/runtime-types.ts`（0.1.2 复核存在）。`agent/pre-step` 是 waterfall，payload `{agent, messages, turn, step, signal}`，返回 `PreStepDecision`。**没有 `agent/post-step`**——状态写盘放 tool handler 内
+- 参照实现：`packages/context/time-context/src/index.ts`（`{prepend:true}` + `createUserMessage({content:[{type:'text',text}], source:{kind:'plugin',...}})`）
 - 工具结果观察：`tools/post-execute`（waterfall 可替换 value，但失败路径拿不到 value）
 - ask 用户：内置 `ask_user_question` tool（`packages/interaction/tool-ask-user`）
 
@@ -48,78 +48,103 @@ ctx.tools.register(defineTool({
 
 把插件 UI 长进 DSH web app 的**官方路径**：
 
-1. **声明**：`package.json` 加 `"dsh": { "client": { "platform": "web", "inject": [...] } }` + `exports["./client"]` 指向 `./lib/client.js`
-2. **扫描与服务**：`packages/client/modules`（`ClientModuleRegistry`）扫 loader 全部 entries（**out-of-tree link 的包同样命中**，`createRequire(ctx.baseUrl).resolve`），写入 `window.__DSH_BOOT__`，按 `/plugins/<id>/client.js` serve 磁盘路径
+1. **声明**：`package.json` 加 `"dsh": { "client": { "platform": "web", "inject": [...], "external": [...] } }` + `exports["./client"]` 指向 `./lib/client.js`
+2. **扫描与服务**：`packages/client/modules`（`ClientModuleRegistry`）扫 loader 全部 entries（**out-of-tree link 的包同样命中**），写入 `window.__DSH_BOOT__`，按 `/plugins/<id>/client.js` serve 磁盘路径；manifest 解析器对畸形字段整包抛错拒绝激活
 3. **client half**：`src/client/index.ts(x)` 是浏览器端 cordis function plugin，`ctx.slots.inject('<slot>', () => ctx.slots.register({...}, ReactComponent))`
 4. **host↔client 数据**：host half 用 `ctx.webServer.register({kind:'prefix', path, handler})` 注册同源路由，client 直接 fetch（session-log-export 先例）；**可选服务用 `ctx.get('webServer')`**（硬 `inject` 会在无该服务的 profile 里让整个插件不激活）
-5. **slot 类型来源**：slot 的运行时声明与 TS 类型都在所属 client 包（如 `conversation.*` 在 `@deepseek-ai/dsh-client-ui-conversation`）——out-of-tree 需要 devDep（类型）+ `dsh.client.inject`（加载顺序）双保险
+5. **slot 类型来源**：slot 的运行时声明与 TS 类型在所属 client 包的**类型化 slot catalog**（`packages/client/<pkg>/src/client/contract/slots.ts`，0.1.2 起的声明权威）——out-of-tree 需要 devDep（类型）+ `dsh.client.inject`（加载顺序）双保险
 
-### 真实 slot 名（rc.7 实测枚举）
+### dsh.client 字段语义（0.1.2 manifest.ts 核对）
 
-| slot | 用途 | 先例 |
+| 字段 | 语义 | 错误后果 |
 |---|---|---|
-| `settings.general.item` / `settings.section` | 设置页行/区 | ui-theme、ui-agent-preset |
-| `conversation.session.header.utilities` / `.actions` | 会话头部按钮区 | session-log-export |
-| `conversation.input.dock` | 输入区 dock 面板 | TodoPanel、QueueDock、ui-goal |
-| `conversation.chat.node` | 聊天消息节点渲染 | ui-conversation、ui-goal |
-| `conversation.chat.turnTail` / `assistant-actions` | 消息尾部动作 | ui-conversation |
-| `conversation.view` | 会话主视图（chain） | ui-conversation |
-| `conversation.details.tool` | 详情面板 tool 区 | ui-conversation |
-| `sidebar` / `sidebar.workspaces.directoryFlow` | 侧栏 | ui-layout、directory-picker |
-| `conversation.hero.workspace` / `.agentPreset` | 空态 hero | ConversationRoot |
+| `platform` | 必须字符串 `"web"` | 非字符串抛错 |
+| `inject` | 包名依赖边：工厂先达 + cordis 组合 | 非字符串数组抛错；指向未声明 `dsh.client` 的包则该边永远等不到 |
+| `external` | 精确的非基线模块表请求（`<pkg>/client` 与 `<pkg>` 归一等价） | 非字符串数组抛错；**声明自身包名 harness 直接抛错拒绝启动** |
+| `immediately` | 一阶段预取标记（boolean） | 非 boolean 抛错 |
+
+### 真实 slot 名（0.1.2-rc.1 catalog 复核；以所属包 `contract/slots.ts` 为准）
+
+| slot | 声明 catalog（0.1.2） |
+|---|---|
+| `settings.general.item` / `settings.section` | `ui-settings/src/client/contract/slots.ts` |
+| `conversation.session.header` / `.actions` / `.utilities` / `.lineage` | `ui-conversation/.../contract/slots.ts` |
+| `conversation.input.dock` | `ui-conversation/.../contract/slots.ts` |
+| `conversation.chat.node` / `conversation.chat.turnTail` / `conversation.chat.assistant-actions` | `ui-chat/.../contract/slots.ts`（0.1.2 起归 ui-chat） |
+| `conversation.view` / `conversation.details.tool` | `ui-conversation/.../contract/slots.ts` |
+| `sidebar` / `sidebar.workspaces.directoryFlow` | `ui-sidebar/.../contract/slots.ts` |
+| `conversation.hero.workspace` / `.agentPreset` | `ui-conversation/.../contract/slots.ts` |
+
+升级后先对 catalog 复核（`grep -r "contract/slots.ts" packages/client`），不采信本表。
 
 ### client bundle 构建契约（out-of-tree 必须复刻）
 
-harness 的共享预设 `packages/client/tsdown.client.ts` 不对外发布，自行用 tsdown 复刻：
+harness 的共享预设 `packages/client/tsdown.client.ts` 不对外发布，自行用 tsdown 复刻（0.1.2 dsh-contract-copilot 的 `tsdown.client.config.ts` 是可用蓝本）：
 
-- `format: 'cjs'`、`platform: 'browser'`、entry `src/client/index.tsx` → 产物 `lib/client.js`
-- **banner**：`window.__ModuleLoader__.load({ id: <JSON包名>, factory: (require) => {` + **换行 + `var module = { exports: {} }; var exports = module.exports;`**
-- **footer**：`return module.exports; } });`
-- **externals**（冻结模块表提供，不打包）：`react`、`react/jsx-runtime`、`react-dom`、`react-dom/client`、`@deepseek-ai/cordis`、`@deepseek-ai/dsh-client-ui-slots`、`@deepseek-ai/dsh-client-web-react`、`@deepseek-ai/dsh-client-ui-primitives`、`@deepseek-ai/dsh-client-ui-attachment`、`@deepseek-ai/dsh-client-schema-form`、`@deepseek-ai/dsh-client-runtime/client`；**其余依赖全部 inline**
+- `format: 'cjs'`、`platform: 'browser'`、entry `src/client/index.tsx` → 产物 `lib/client.js`（`entryFileNames` 钉死 `client.js`）
+- **banner**：`window.__ModuleLoader__.load({ id: <JSON包名>, factory: (require) => {`；**intro**（换行）：`var module = { exports: {} }; var exports = module.exports;`；**footer**：`return module.exports; } });`
+- **externals = 平台基线 ∪ 本包 `dsh.client.external` 声明**，二者精确匹配（其余依赖全部 inline）。平台基线唯一事实源是 `packages/client/web/src/platform.ts` 的 `PLATFORM_MODULES` + `PRELOADED_CLIENT_EXTERNALS`（0.1.2-rc.1 为 8 项：`react`、`react/jsx-runtime`、`react-dom`、`react-dom/client`、`@deepseek-ai/cordis`、`@deepseek-ai/dsh-client-store`、`@deepseek-ai/dsh-client-ui-slots`、`@deepseek-ai/dsh-client-ui-primitives`；`PRELOADED` 为空）。**不要在插件里手抄冻结副本**——升级即漂移；lint.mjs 会把构建配置 external 对当前基线对账
 - `define`：`process.env.NODE_ENV`、`import.meta.env(.MODE)` 静态替换
 - `sourcemap: true`；`clean: false`（别清掉同目录 node half 产物）
-- **纯度规则**：非平台表的 `@deepseek-ai/*` 值导入禁止（跨插件协作走 cordis 服务；type-only import 被擦除不受限）
+- **纯度规则**（`tsdown.client.ts` 的 build-time gate）：非基线、非 `dsh.client.external` 的 `@deepseek-ai/*` 值导入 = 构建错误，除非命中 `INLINE_SAFE`（wire 层，如 `dsh-file-reference`/`dsh-session`/`dsh-llm`/`dsh-tools`/`dsh-util-*` 等内联即无害的层）、`VENDORED_LIBRARY`（`cosmokit`/`schemastery`）或 `<pkg>/remote` 生成贡献——正则的当前事实源同样是 `packages/client/tsdown.client.ts`；type-only import 被擦除不受限。跨插件协作走 cordis 服务
+
+### 主题变量（0.1.2 新增审查维度）
+
+DSH 平台 CSS 自定义属性（`--dsw-*` 设计平台、`--ds-*` 基础、`--shiki-*` 代码高亮）的**唯一声明集**在 `packages/client/ui-theme/src/styles/*.css`（`design-platform.css` 数百个 token + `base.css`/`scrollbar.css` 等）。插件只能引用其中存在的变量；`var(--x, fallback)` 的回退值只是兜底显示，变量名不存在时主题（如暗色）链路已断。lint.mjs §6 按当前 harness 声明集对账。
+
+### 类型化 locale（0.1.2 起的产品文案归属）
+
+- 每个插件自带命名空间词典（先例 `packages/client/ui-theme/src/client/locales.ts`）：**zh 是键集真值**，`en` 用 `satisfies Record<ThemeKey, string>` 对齐 zh 键集（缺键/多键编译报错）
+- 组件经 `PropsLocale<'namespace'>` 注入翻译座席，`t('key')` 消费；`Translate`/`LocaleNamespaceMap` 类型由 `@deepseek-ai/dsh-client-ui-slots` 提供，词典 owner 声明 `declare module` 合并自己的命名空间
+- **JSX 文本/用户可见属性裸写产品文案即违约**；lint.mjs §7 检查 CJK 硬编码与 zh/en 平价
 
 ## 5. 运行与 provider
 
-- 从源码跑：harness 仓库内 `pnpm dsh --profile <name> [task]`（headless 单任务）或 `pnpm dsh web --port <n>`
+- 从源码跑：harness 仓库内 `pnpm dsh --profile <name> [task]`（headless 单任务）或 `pnpm dsh web --port <n>`；已构建产物可用 `node apps/cli/lib/bin.js --version` 直接取官方版本门
 - LLM provider：`DEEPSEEK_BASE_URL` / `DEEPSEEK_API_KEY` 指向任何 OpenAI 协议兼容网关（实测 127.0.0.1:8787 网关 + deepseek-v4-flash）
-- **HMR 边界（2026-08-19 双向实测）**：out-of-tree 插件**两个 half 都不热加载**——node half 改 `lib/` 后长驻进程不重载 apply（base 的 hmr `root` 不覆盖 link 目录，且 web/headless surface 禁用模块级 hmr row）；client half 的 `__DSH_BOOT__` rev 只在启动时重扫（`rebuilt()` 只被 harness 仓库 `dev:web` watcher 触发）。**更新后必须重启 dsh**。唯一热的是 profile `cordis.patch.yml` 配置层（launcher 兜底的 watch-only hmr）
+- **HMR 边界（历史结论，未随版本复测）**：0.1.0-rc.7 时期双向实测 out-of-tree 插件两个 half 都不热加载——node half 改 `lib/` 后长驻进程不重载 apply；client half 的 `__DSH_BOOT__` rev 只在启动时重扫；唯一热的是 profile `cordis.patch.yml` 配置层。**该结论未在 0.1.2 复测**：作为待验证假设处理，更新 bundle 后先重启 dsh 再取证，并以当前 `packages/client/hmr` 实测为准
 
 ## 6. 实测坑清单（契约层审查项的出处）
 
 1. banner 缺 `var module = { exports: {} }` → 浏览器端 `exports is not defined`
 2. `"type":"module"` 包 cjs 产物默认 `.cjs` 后缀 → registry 找不到 exports 指向的 `./lib/client.js`
 3. tool 返回值嵌套 undefined → `value is not lossless JSON`（ToolOutputError）
-4. SlotMap 类型只在 slot 所属 client 包声明 → typecheck 报 slot 只认 `'root'`
+4. SlotMap 类型只在 slot 所属 client 包声明 → typecheck 报 slot 只认 `'root'`（0.1.2 声明权威是所属包 `contract/slots.ts`）
 5. 长 CLI 任务用 `spawnSync` → 冻结整个 harness（HMR/UI/listener 全停）
 6. 被调 CLI 的非交互静默默认值（如"强势"口径）→ 必须插件层显式传参
 7. `ctx.effect` 回调必须**返回** disposer（`() => () => {...}`）
 8. 可选服务用硬 `inject` → headless profile 里整个插件不激活
 9. shell 管道 `cmd | grep | head && next` 吞掉构建失败 → 旧 bundle 静默留盘
 10. JSX 文本里的 `<中文>` 被当标签解析 → 转义 `{'<…>'}`
+11. 构建配置手抄平台基线副本 → harness 升级后基线漂移，产物 bare require 模块表无法应答（浏览器必抛）——externals 集合只准"基线 ∪ dsh.client.external"推导
+12. `dsh.client.external` 声明自身包名或拼错说明符 → host 端抛错/边等待，插件整包不激活
+13. 引用不存在的 `--dsw-*` 主题变量（靠 fallback 显示）→ 暗色主题断链，且机械层不报错——只准引用 `ui-theme/src/styles` 声明集
+14. 产品文案裸写 JSX/属性 → 无语言切换、无词典平价保护——迁入命名空间 locale 词典
 
-## 参考文件索引（harness 仓库内）
+## 参考文件索引（harness 仓库内，0.1.2-rc.1 复核）
 
 | 主题 | 路径 |
 |---|---|
 | 插件教程（function plugin/工具/配置） | `docs/user/develop/basic/index.md`、`tool.md`、`config.md` |
 | 打包与安装（bundle/profile/GitHub） | `docs/user/develop/basic/publish.md` |
-| 插件 CLI（reconcilePlugins） | `apps/cli/src/plugin.ts` |
+| 插件 CLI（reconcilePlugins） | `apps/cli/src/plugin.ts`；官方版本门 `apps/cli/lib/bin.js --version` |
 | 工具契约（execute/output/后台任务/Code Mode） | `docs/cookbook/adding-a-tool.md` |
 | 工具运行时源码 | `packages/core/tools/src/index.ts` |
-| lossless JSON 校验 | `packages/core/session/src/json.ts` |
+| lossless JSON 校验（walkJsonValue） | `packages/util/values/src/index.ts` |
 | agent 事件声明 | `packages/core/agent/src/runtime-types.ts` |
 | pre-step 参照 | `packages/context/time-context/src/index.ts` |
 | ask_user 工具 | `packages/interaction/tool-ask-user/src/index.ts` |
-| client 模块扫描（dsh.client） | `packages/client/modules/src/index.ts` |
-| slot 注册表（ui-slots） | `packages/client/ui-slots/` |
+| client 模块扫描（dsh.client 字段语义） | `packages/client/modules/src/index.ts`、`packages/client/modules/src/client/manifest.ts` |
+| 平台模块表（externals 基线唯一事实源） | `packages/client/web/src/platform.ts` |
+| client 构建预设与纯度正则（契约蓝本） | `packages/client/tsdown.client.ts` |
+| slot 类型化 catalog（声明权威） | `packages/client/<pkg>/src/client/contract/slots.ts` |
 | slot 注入先例 | `packages/client/ui-theme/src/client/index.ts`、`packages/session-query/session-log-export/src/client/index.ts` |
-| client 构建预设（契约蓝本） | `packages/client/tsdown.client.ts`、`packages/client/web/src/platform.ts`、`packages/client/web/src/seed.ts` |
+| 类型化 locale 体系 | `packages/client/locale/src/`（含 `locales/zh.ts` 键集真值） |
+| 主题变量声明集 | `packages/client/ui-theme/src/styles/*.css` |
 | 动态插件运行器（进阶） | `packages/extensions/cordis-client-runner/` |
 | base bundle（默认插件清单） | `packages/bundle/base/cordis.patch.yml` |
 | web bundle | `packages/bundle/web-app/cordis.patch.yml` |
 
 ## 范式实例
 
-完整双面包实例见 dsh-contract-copilot 插件仓库（`legal-dsh-plugin/dsh-contract-copilot`）：host half（`src/index.ts`、`src/tools/*`、`src/host-api.ts`）、client half（`src/client/`）、构建（`tsdown.client.config.ts`）、文档四件套。
+完整双面包实例见 dsh-contract-copilot 插件仓库（`legal-dsh-plugin/dsh-contract-copilot`）：host half（`src/index.ts`、`src/tools/*`、`src/host-api.ts`）、client half（`src/client/`，0.1.2 工作台版）、构建（`tsdown.client.config.ts`，externals 从基线推导）、文档四件套。

--- a/skills/dsh-plugin-lint/scripts/lint.mjs
+++ b/skills/dsh-plugin-lint/scripts/lint.mjs
@@ -1,46 +1,438 @@
 #!/usr/bin/env node
 /**
- * dsh-plugin-lint §1 机械层：声明一致性 + client 工件契约。
- * 用法: node lint.mjs <插件目录>
- * 退出码 = FAIL 数（0 为全过）。
+ * dsh-plugin-lint §1 机械层 v2：声明一致性 + client 工件契约 + harness 溯源 + 版本感知规则。
+ * 用法: node lint.mjs <插件目录> [--harness-root <DSH 源码仓库>] [--json]
+ *
+ * harness 根解析优先级：--harness-root > 环境变量 DSH_HARNESS_ROOT >
+ * config/harness-path.local.yaml。解析不到时 harness 依赖项检查标 NOT_VERIFIED（不误判 PASS）。
+ *
+ * 事实源全部来自当前 harness 源码声明（platform.ts / tsdown.client.ts / ui-theme styles / 包 manifest），
+ * 或官方 dsh 可执行门（apps/cli/lib/bin.js --version）；不冻结任何版本号假设。
+ *
+ * 退出码 = FAIL 数（0 为全过）。语义不确定的结论只出 WARN / NOT_VERIFIED，不出 PASS。
  */
 
-import { readFileSync, existsSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs'
+import { isBuiltin } from 'node:module'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const target = process.argv[2]
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url))
+const SKILL_DIR = path.resolve(SCRIPT_DIR, '..')
+
+// ── CLI 参数 ────────────────────────────────────────────────────────────────
+function parseArgv(argv) {
+  const parsed = { target: undefined, harnessRoot: undefined, json: false }
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '--harness-root') {
+      parsed.harnessRoot = argv[i + 1]
+      i += 1
+    } else if (arg.startsWith('--harness-root=')) {
+      parsed.harnessRoot = arg.slice('--harness-root='.length)
+    } else if (arg === '--json') {
+      parsed.json = true
+    } else if (parsed.target === undefined) {
+      parsed.target = arg
+    }
+  }
+  return parsed
+}
+
+const argv = parseArgv(process.argv.slice(2))
+const target = argv.target
 if (target === undefined || !existsSync(target)) {
-  console.error('用法: node lint.mjs <插件目录>')
+  console.error('用法: node lint.mjs <插件目录> [--harness-root <DSH 源码仓库>] [--json]')
   process.exit(1)
 }
 const dir = path.resolve(target)
 
+// ── 结果收集 ────────────────────────────────────────────────────────────────
 let fails = 0
 let warns = 0
-const fail = (msg) => { fails += 1; console.log(`  [FAIL] ${msg}`) }
-const pass = (msg) => console.log(`  [PASS] ${msg}`)
-const warn = (msg) => { warns += 1; console.log(`  [WARN] ${msg}`) }
+let notVerified = 0
+const findings = []
+const emit = (level, message) => {
+  findings.push({ level, message })
+  if (level === 'FAIL') { fails += 1; console.log(`  [FAIL] ${message}`) }
+  else if (level === 'WARN') { warns += 1; console.log(`  [WARN] ${message}`) }
+  else if (level === 'NOT_VERIFIED') { notVerified += 1; console.log(`  [NOT_VERIFIED] ${message}`) }
+  else console.log(`  [PASS] ${message}`)
+}
+const fail = (msg) => emit('FAIL', msg)
+const pass = (msg) => emit('PASS', msg)
+const warn = (msg) => emit('WARN', msg)
+const unverifiable = (msg) => emit('NOT_VERIFIED', msg)
+const na = (msg) => console.log(`  [NA] ${msg}`)
 
-// ── package.json ────────────────────────────────────────────────────────────
-console.log('§ package.json')
+// ── harness 根解析 ──────────────────────────────────────────────────────────
+function readHarnessConfig() {
+  const local = path.join(SKILL_DIR, 'config', 'harness-path.local.yaml')
+  if (!existsSync(local)) return {}
+  const text = readFileSync(local, 'utf8')
+  const root = text.match(/^harness_root:\s*["']?([^"'\n#]+)["']?\s*$/m)?.[1]?.trim()
+  const baseline = text.match(/^harness_baseline:\s*["']?([^"'\n#]+)["']?\s*$/m)?.[1]?.trim()
+  return { root, baseline, configPath: local }
+}
+
+function resolveHarnessRoot() {
+  if (argv.harnessRoot !== undefined) {
+    return { root: path.resolve(argv.harnessRoot), source: '--harness-root 参数' }
+  }
+  if (process.env.DSH_HARNESS_ROOT) {
+    return { root: path.resolve(process.env.DSH_HARNESS_ROOT), source: '环境变量 DSH_HARNESS_ROOT' }
+  }
+  const config = readHarnessConfig()
+  if (config.root) {
+    return { root: path.resolve(config.root), source: `config (${path.basename(config.configPath)})`, baseline: config.baseline }
+  }
+  return { root: undefined, source: '未解析' }
+}
+
+const harness = resolveHarnessRoot()
+const harnessAvailable = harness.root !== undefined && existsSync(harness.root)
+
+// ── harness 事实源读取 ──────────────────────────────────────────────────────
+function runNode(scriptPath, args) {
+  return execFileSync(process.execPath, [scriptPath, ...args], { timeout: 20_000, encoding: 'utf8' })
+}
+
+function runGit(root, args) {
+  return execFileSync('git', ['-C', root, ...args], { timeout: 10_000, encoding: 'utf8' })
+}
+
+function readJsonSafe(file) {
+  try {
+    return JSON.parse(readFileSync(file, 'utf8'))
+  } catch {
+    return undefined
+  }
+}
+
+function readTextSafe(file) {
+  try {
+    return readFileSync(file, 'utf8')
+  } catch {
+    return undefined
+  }
+}
+
+/** 平台模块表：来自当前 harness 的 packages/client/web/src/platform.ts 声明。 */
+function loadPlatformModules(root) {
+  const file = path.join(root, 'packages', 'client', 'web', 'src', 'platform.ts')
+  const text = readTextSafe(file)
+  if (text === undefined) return undefined
+  const extract = (name) => text.match(new RegExp(`${name}\\s*=\\s*\\[([^\\]]*)\\]`, 's'))?.[1] ?? ''
+  const literals = [...extract('PLATFORM_MODULES').matchAll(/['"]([^'"]+)['"]/g)].map(m => m[1])
+  const preloaded = [...extract('PRELOADED_CLIENT_EXTERNALS').matchAll(/['"]([^'"]+)['"]/g)].map(m => m[1])
+  if (literals.length === 0) return undefined
+  return { baseline: [...literals, ...preloaded], file }
+}
+
+/** 内联安全/内置库正则：来自当前 harness 的 packages/client/tsdown.client.ts 声明。 */
+function loadPurityPatterns(root) {
+  const file = path.join(root, 'packages', 'client', 'tsdown.client.ts')
+  const text = readTextSafe(file)
+  if (text === undefined) return undefined
+  const extract = (name) => {
+    const m = text.match(new RegExp(`(?:export )?const ${name}\\s*=\\s*/((?:\\\\.|[^/\\\\])*)/([a-z]*)`, 's'))
+    if (m === null) return undefined
+    try {
+      return new RegExp(m[1], m[2].replace('g', ''))
+    } catch {
+      return undefined
+    }
+  }
+  const inlineSafe = extract('INLINE_SAFE')
+  const vendored = extract('VENDORED_LIBRARY')
+  const generatedRemote = extract('GENERATED_REMOTE')
+  if (inlineSafe === undefined && vendored === undefined) return undefined
+  return { inlineSafe, vendored, generatedRemote, file }
+}
+
+const PLATFORM_DIR = path.join('packages', 'client')
+
+/** harness workspace 内声明了 dsh.client 的包名 → manifest 映射（供 inject 目标核对）。 */
+function loadClientPackageIndex(root) {
+  const index = new Map()
+  const packagesDir = path.join(root, 'packages')
+  if (!existsSync(packagesDir)) return index
+  const walk = (current, depth) => {
+    if (depth > 4) return
+    let entries
+    try {
+      entries = readdirSync(current)
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      const full = path.join(current, entry)
+      let st
+      try {
+        st = statSync(full)
+      } catch {
+        continue
+      }
+      if (st.isDirectory()) {
+        walk(full, depth + 1)
+      } else if (entry === 'package.json') {
+        const manifest = readJsonSafe(full)
+        if (manifest?.name !== undefined && manifest.dsh?.client !== undefined) {
+          index.set(manifest.name, { manifest, file: full })
+        }
+      }
+    }
+  }
+  walk(packagesDir, 0)
+  return index
+}
+
+const platform = harnessAvailable ? loadPlatformModules(harness.root) : undefined
+const purity = harnessAvailable ? loadPurityPatterns(harness.root) : undefined
+const clientPackages = harnessAvailable ? loadClientPackageIndex(harness.root) : new Map()
+
+const harnessProvenance = { root: harness.root, source: harness.source, version: undefined, binVersion: undefined, commit: undefined }
+if (harnessAvailable) {
+  const rootManifest = readJsonSafe(path.join(harness.root, 'package.json'))
+  harnessProvenance.version = typeof rootManifest?.version === 'string' ? rootManifest.version : undefined
+  const binJs = path.join(harness.root, 'apps', 'cli', 'lib', 'bin.js')
+  if (existsSync(binJs)) {
+    try {
+      harnessProvenance.binVersion = runNode(binJs, ['--version']).trim()
+    } catch {
+      harnessProvenance.binVersion = undefined
+    }
+  }
+  try {
+    harnessProvenance.commit = runGit(harness.root, ['rev-parse', 'HEAD']).trim()
+  } catch {
+    harnessProvenance.commit = undefined
+  }
+}
+
+// ── 工具函数 ────────────────────────────────────────────────────────────────
+/** 逐字符剥离 JS/TS 注释（字符串/模板/正则感知），供产物与源码扫描用。 */
+function stripJsComments(code) {
+  let out = ''
+  let i = 0
+  const n = code.length
+  let prevMeaningful = ''
+  while (i < n) {
+    const ch = code[i]
+    const next = i + 1 < n ? code[i + 1] : ''
+    if (ch === '/' && next === '/') {
+      while (i < n && code[i] !== '\n') i += 1
+      continue
+    }
+    if (ch === '/' && next === '*') {
+      i += 2
+      while (i < n && !(code[i] === '*' && i + 1 < n && code[i + 1] === '/')) i += 1
+      i += 2
+      continue
+    }
+    if (ch === '\'' || ch === '"') {
+      const quote = ch
+      out += ch
+      i += 1
+      while (i < n) {
+        if (code[i] === '\\') { out += code.slice(i, i + 2); i += 2; continue }
+        out += code[i]
+        if (code[i] === quote || code[i] === '\n') { i += 1; break }
+        i += 1
+      }
+      prevMeaningful = quote
+      continue
+    }
+    if (ch === '`') {
+      out += ch
+      i += 1
+      while (i < n) {
+        if (code[i] === '\\') { out += code.slice(i, i + 2); i += 2; continue }
+        out += code[i]
+        if (code[i] === '`') { i += 1; break }
+        i += 1
+      }
+      prevMeaningful = '`'
+      continue
+    }
+    if (ch === '/' && '({[=,:;!&|?<>+-*%~^'.includes(prevMeaningful) || (ch === '/' && prevMeaningful === '')) {
+      // 正则字面量启发式：跳过到收尾 /（避免把除号误当正则的常见情形由 prev 约束）
+      let j = i + 1
+      let closed = false
+      let inClass = false
+      while (j < n) {
+        const c = code[j]
+        if (c === '\\') { j += 2; continue }
+        if (c === '\n') break
+        if (inClass) { if (c === ']') inClass = false }
+        else if (c === '[') inClass = true
+        else if (c === '/') { closed = true; break }
+        j += 1
+      }
+      if (closed) {
+        out += ' '
+        i = j + 1
+        while (i < n && /[a-z]/i.test(code[i])) i += 1
+        prevMeaningful = 'x'
+        continue
+      }
+    }
+    out += ch
+    if (!/\s/.test(ch)) prevMeaningful = ch
+    i += 1
+  }
+  return out
+}
+
+/** stripClientSuffix：与 harness manifest.ts 同语义（<pkg>/client 与 <pkg> 归一）。 */
+function stripClientSuffix(spec) {
+  return spec.endsWith('/client') ? spec.slice(0, -'/client'.length) : spec
+}
+
+/** 从产物/源码中提取 bare require 的模块说明符。 */
+function extractBareRequires(js) {
+  const code = stripJsComments(js)
+  const specs = new Set()
+  const re = /(?:^|[^\w$.])require\s*\(\s*(["'])([^"'\n]+?)\1\s*\)/g
+  for (const m of code.matchAll(re)) {
+    const spec = m[2]
+    if (spec.startsWith('.') || spec.startsWith('/') || spec.startsWith('\0')) continue
+    specs.add(spec)
+  }
+  return [...specs]
+}
+
+const CJK_RE = /[\u3000-\u303f\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]/
+
+/** 从 TS/TSX 源提取含 CJK 的字符串字面量与 JSX 文本位置（注释已剥离）。 */
+function findHardcodedCopy(tsx) {
+  const code = stripJsComments(tsx)
+  const literals = []
+  const jsxTexts = []
+  const attrTexts = []
+  const litRe = /(["'])((?:\\.|(?!\1)[^\\])*)\1/g
+  for (const m of code.matchAll(litRe)) {
+    if (CJK_RE.test(m[2])) literals.push(m[2].trim())
+  }
+  const tplRe = /`((?:\\.|[^`\\])*)`/g
+  for (const m of code.matchAll(tplRe)) {
+    if (CJK_RE.test(m[1])) literals.push(m[1].trim())
+  }
+  const jsxRe = />([^<>{}]*\n?[^<>{}]*)</g
+  for (const m of code.matchAll(jsxRe)) {
+    if (CJK_RE.test(m[1])) jsxTexts.push(m[1].trim())
+  }
+  const attrRe = /\b(placeholder|title|aria-label|alt|label)\s*=\s*(["'])((?:\\.|(?!\2)[^\\])*)\2/g
+  for (const m of code.matchAll(attrRe)) {
+    if (CJK_RE.test(m[3])) attrTexts.push(`${m[1]}="${m[3].trim()}"`)
+  }
+  return { literals, jsxTexts, attrTexts }
+}
+
+/** 从 locale 词典源码提取导出对象键集（zh/en 平价校验用）。 */
+function extractDictKeys(source, constName) {
+  const code = stripJsComments(source)
+  const start = code.match(new RegExp(`(?:export )?const ${constName}\\s*=\\s*\\{`))
+  if (start === undefined) return undefined
+  const open = start.index + start[0].length
+  let depth = 1
+  let i = open
+  while (i < code.length && depth > 0) {
+    if (code[i] === '{') depth += 1
+    else if (code[i] === '}') depth -= 1
+    i += 1
+  }
+  const body = code.slice(open, i - 1)
+  const keys = new Set()
+  for (const m of body.matchAll(/['"]?([A-Za-z0-9_.-]+)['"]?\s*:/g)) keys.add(m[1])
+  return keys
+}
+
+function listClientSourceFiles(rootDir) {
+  const files = []
+  const clientDir = path.join(rootDir, 'src', 'client')
+  const walk = (current) => {
+    if (!existsSync(current)) return
+    for (const entry of readdirSync(current)) {
+      const full = path.join(current, entry)
+      if (statSync(full).isDirectory()) walk(full)
+      else if (/\.(ts|tsx|css)$/.test(entry)) files.push(full)
+    }
+  }
+  walk(clientDir)
+  return files
+}
+
+function rel(file) {
+  return path.relative(dir, file).split(path.sep).join('/')
+}
+
+// ── 报告头 ──────────────────────────────────────────────────────────────────
+console.log(`dsh-plugin-lint v2 — 目标: ${dir}`)
+console.log(`harness: ${harnessAvailable ? `${harness.root}（溯源: ${harness.source}）` : '未解析'}`)
+
+// ══ §0 harness 溯源 ═══════════════════════════════════════════════════════
+console.log('\n§ 0 harness 溯源')
+if (!harnessAvailable) {
+  unverifiable('未解析 harness 根：--harness-root / DSH_HARNESS_ROOT / config/harness-path.local.yaml 均未提供；版本相关检查将标 NOT_VERIFIED')
+} else {
+  const versions = [harnessProvenance.binVersion, harnessProvenance.version].filter(v => v !== undefined)
+  const unique = [...new Set(versions)]
+  if (unique.length > 1) {
+    warn(`官方 dsh 门版本（${harnessProvenance.binVersion}）与根 manifest 版本（${harnessProvenance.version}）不一致——以官方门为准并核对 harness 构建新鲜度`)
+  }
+  if (unique.length === 0) {
+    unverifiable('无法读取 harness 版本（根 package.json 与 apps/cli/lib/bin.js 均不可用）')
+  } else {
+    harnessProvenance.dshVersion = unique[0]
+    pass(`DSH 版本 = ${unique[0]}${harnessProvenance.binVersion !== undefined ? '（官方 dsh --version 门）' : ''}`)
+  }
+  if (harnessProvenance.commit !== undefined) pass(`harness git commit = ${harnessProvenance.commit}`)
+  else unverifiable('harness 所在目录不是 git 仓库或 git 不可用，commit 未知')
+  if (platform === undefined) unverifiable('无法从 packages/client/web/src/platform.ts 解析平台模块表——基线对账类检查降级')
+  else pass(`平台模块表 ${platform.baseline.length} 项（${path.relative(harness.root, platform.file)}）`)
+  if (purity === undefined) unverifiable('无法从 packages/client/tsdown.client.ts 解析内联安全正则——纯度复核降级')
+  if (harness.baseline !== undefined && harnessProvenance.dshVersion !== undefined && harness.baseline !== harnessProvenance.dshVersion) {
+    warn(`config 声明的基线版本 ${harness.baseline} 与当前 harness 版本 ${harnessProvenance.dshVersion} 不一致——先复核规范再审查`)
+  }
+}
+
+// ══ §1 package.json ═══════════════════════════════════════════════════════
+console.log('\n§ 1 package.json')
 let pkg
 try {
   pkg = JSON.parse(readFileSync(path.join(dir, 'package.json'), 'utf8'))
   pass(`name = ${pkg.name}`)
 } catch (error) {
   fail(`package.json 解析失败: ${error instanceof Error ? error.message : String(error)}`)
+  console.log(`\n结论: ${fails} FAIL / ${warns} WARN / ${notVerified} NOT_VERIFIED — 修复后重跑`)
   process.exit(fails)
 }
 
-// ── dsh.bundle ──────────────────────────────────────────────────────────────
-console.log('§ dsh.bundle')
+// DSH 依赖与当前 harness 版本漂移（cordis 等独立版本线包不参与对账）
+if (harnessProvenance.dshVersion !== undefined) {
+  const depSections = ['dependencies', 'devDependencies', 'peerDependencies']
+  const drifted = []
+  for (const section of depSections) {
+    for (const [name, range] of Object.entries(pkg[section] ?? {})) {
+      if (!name.startsWith('@deepseek-ai/dsh-')) continue
+      const pinned = String(range).match(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/)?.[0]
+      if (pinned !== undefined && pinned !== harnessProvenance.dshVersion) drifted.push(`${name}@${range}`)
+    }
+  }
+  if (drifted.length > 0) warn(`以下 @deepseek-ai/dsh-* 依赖钉定版本与当前 harness ${harnessProvenance.dshVersion} 不同: ${drifted.join(', ')}`)
+  else pass('@deepseek-ai/dsh-* 依赖钉定版本与当前 harness 版本一致')
+}
+
+// ══ §2 dsh.bundle ═════════════════════════════════════════════════════════
+console.log('\n§ 2 dsh.bundle')
 const bundlePatch = pkg.dsh?.bundle?.patch
 if (typeof bundlePatch === 'string') {
   const patchFile = path.join(dir, bundlePatch)
   if (existsSync(patchFile)) {
     pass(`patch 文件存在: ${bundlePatch}`)
     const patchText = readFileSync(patchFile, 'utf8')
-    // cordis.patch.yml 里引用本包名的 row 应与 package.json name 一致
     if (patchText.includes(pkg.name)) pass(`patch row 引用了 ${pkg.name}`)
     else fail(`cordis.patch.yml 中未找到包名 ${pkg.name}（row name 不一致则 Loader 解析不到）`)
   } else fail(`dsh.bundle.patch 指向的文件不存在: ${bundlePatch}`)
@@ -48,24 +440,68 @@ if (typeof bundlePatch === 'string') {
   warn('无 dsh.bundle 声明（纯库可忽略；插件必须有）')
 }
 
-// ── exports["."] ────────────────────────────────────────────────────────────
-console.log('§ exports["."]')
+// ══ §3 exports["."] ═══════════════════════════════════════════════════════
+console.log('\n§ 3 exports["."]')
 const mainExport = pkg.exports?.['.']?.default ?? pkg.main
 if (typeof mainExport === 'string' && existsSync(path.join(dir, mainExport))) {
   pass(`node half 入口存在: ${mainExport}`)
 } else fail(`exports["."].default / main 指向的文件不存在: ${String(mainExport)}`)
 
-// ── dsh.client + 工件契约 ──────────────────────────────────────────────────
-console.log('§ dsh.client')
+// ══ §4 dsh.client + inject/external 对账 ══════════════════════════════════
+console.log('\n§ 4 dsh.client（inject/external 对账）')
 const clientDecl = pkg.dsh?.client
+const declaredExternal = new Set()
 if (clientDecl === undefined) {
-  console.log('  [NA] 无浏览器 half')
+  na('无浏览器 half')
 } else {
   if (clientDecl.platform !== 'web') fail(`dsh.client.platform 应为 "web"，实际 ${JSON.stringify(clientDecl.platform)}`)
   else pass('platform = web')
   if (!Array.isArray(clientDecl.inject) || clientDecl.inject.length === 0) warn('dsh.client.inject 为空（依赖 slot 声明包时应列出）')
 
-  const clientExport = pkg.exports?.['./client']?.default ?? pkg.exports?.['./client']
+  const inject = Array.isArray(clientDecl.inject) ? clientDecl.inject : []
+  for (const entry of inject) {
+    if (typeof entry !== 'string' || entry.length === 0) {
+      fail(`dsh.client.inject 含非字符串项: ${JSON.stringify(entry)}`)
+      continue
+    }
+    if (entry === pkg.name) fail('dsh.client.inject 声明了自身包名（自注入边）')
+    const inHarness = clientPackages.has(entry)
+    const localManifest = readJsonSafe(path.join(dir, 'node_modules', entry, 'package.json'))
+    if (inHarness || localManifest?.dsh?.client !== undefined) {
+      pass(`inject 目标声明了 dsh.client: ${entry}${inHarness ? '（harness workspace）' : '（本地 node_modules）'}`)
+    } else {
+      fail(`inject 目标 ${entry} 在 harness workspace 与本地 node_modules 均未声明 dsh.client——该边永远等不到工厂`)
+    }
+    const devDeps = pkg.devDependencies ?? {}
+    if (devDeps[entry] === undefined && pkg.dependencies?.[entry] === undefined) {
+      warn(`inject 目标 ${entry} 不在 dependencies/devDependencies（类型声明双保险缺失）`)
+    }
+  }
+
+  if (clientDecl.external !== undefined && !Array.isArray(clientDecl.external)) {
+    fail('dsh.client.external 存在但不是字符串数组（harness 会整包拒绝激活）')
+  } else if (Array.isArray(clientDecl.external)) {
+    for (const entry of clientDecl.external) {
+      if (typeof entry !== 'string' || entry.length === 0) {
+        fail(`dsh.client.external 含非字符串项: ${JSON.stringify(entry)}`)
+        continue
+      }
+      declaredExternal.add(entry)
+      if (entry === pkg.name || stripClientSuffix(entry) === pkg.name) {
+        fail('dsh.client.external 声明了自身包名（harness 会抛错拒绝启动）')
+      }
+      if (platform !== undefined && (platform.baseline.includes(entry) || platform.baseline.includes(stripClientSuffix(entry)))) {
+        warn(`dsh.client.external "${entry}" 已在平台基线中（基线请求是隐式的，声明为冗余行）`)
+      }
+    }
+  }
+}
+
+// ══ §5 client 工件契约 + 产物 bare require 对账 ═══════════════════════════
+console.log('\n§ 5 client 工件（banner/footer/后缀/bare require）')
+const clientExport = pkg.exports?.['./client']?.default ?? pkg.exports?.['./client']
+let artifactText
+if (clientDecl !== undefined) {
   if (typeof clientExport !== 'string') {
     fail('声明了 dsh.client 但 exports["./client"] 缺失或非字符串 default')
   } else {
@@ -76,19 +512,191 @@ if (clientDecl === undefined) {
       pass(`client 工件存在: ${clientExport}`)
       if (clientFile.endsWith('.cjs')) fail('工件后缀是 .cjs——registry 只认 exports 指向路径；"type":"module" 包需 outExtensions 强制 .js')
       else pass('工件后缀 .js')
-      const head = readFileSync(clientFile, 'utf8').slice(0, 400)
-      const tail = readFileSync(clientFile, 'utf8').slice(-200)
+      artifactText = readFileSync(clientFile, 'utf8')
+      const head = artifactText.slice(0, 4000)
+      const tail = artifactText.slice(-2000)
       if (!head.includes('window.__ModuleLoader__.load(')) fail('banner 缺 __ModuleLoader__.load（非 closure-factory 工件）')
       else if (!head.includes('var module = { exports: {} }')) fail('banner 缺 module/exports 构造（浏览器端会 exports is not defined）')
       else pass('banner 契约完整（load + module/exports 构造）')
       if (!tail.includes('return module.exports;')) fail('footer 缺 return module.exports')
       else pass('footer 契约完整')
+
+      // bare require ↔ 平台基线 / dsh.client.external 对账
+      const bare = extractBareRequires(artifactText)
+      const builtins = []
+      let externalsOk = 0
+      const unknowns = []
+      const impure = []
+      for (const spec of bare) {
+        if (isBuiltin(spec) || spec.startsWith('node:')) { builtins.push(spec); continue }
+        const normalized = stripClientSuffix(spec)
+        if (
+          platform !== undefined
+          && (platform.baseline.includes(spec) || platform.baseline.includes(normalized))
+        ) { externalsOk += 1; continue }
+        if (declaredExternal.has(spec) || declaredExternal.has(normalized)) { externalsOk += 1; continue }
+        if (
+          purity !== undefined
+          && ((purity.inlineSafe?.test(spec) ?? false) || (purity.vendored?.test(spec) ?? false) || (purity.generatedRemote?.test(spec) ?? false))
+        ) { impure.push(spec); continue }
+        unknowns.push(spec)
+      }
+      if (externalsOk > 0) pass(`bare require 与模块表对账通过 ${externalsOk} 项`)
+      if (unknowns.length > 0) {
+        for (const spec of unknowns) {
+          fail(`产物 bare require("${spec}") 不在平台基线也不在 dsh.client.external——模块表无法应答，浏览器端必抛`)
+        }
+      }
+      if (impure.length > 0) {
+        for (const spec of impure) {
+          fail(`产物 bare require("${spec}") 属内联安全层却被外置——构建 externals 配置与 dsh.client 声明不一致`)
+        }
+      }
+      if (builtins.length > 0) {
+        warn(`产物含 bare builtin require: ${[...new Set(builtins)].join(', ')}——若位于 inliner 的 try/catch 特征探测内则合法，须人工确认未被顶层依赖`)
+      }
+      for (const entry of declaredExternal) {
+        const normalized = stripClientSuffix(entry)
+        const used = bare.some(spec => spec === entry || stripClientSuffix(spec) === normalized)
+        if (!used) warn(`dsh.client.external "${entry}" 在产物中没有任何对应 require（冗余声明行，徒增 boot 图边）`)
+      }
     }
   }
 }
 
-// ── 常规卫生 ────────────────────────────────────────────────────────────────
-console.log('§ 卫生')
+// 构建配置 externals ↔ 平台基线对账（mission: inject/external 声明与构建 externals 的一致性）
+const buildConfigFile = ['tsdown.client.config.ts', 'tsdown.config.ts', 'tsdown.client.ts']
+  .map(name => path.join(dir, name))
+  .find(file => existsSync(file))
+if (clientDecl !== undefined && buildConfigFile !== undefined) {
+  const configText = readTextSafe(buildConfigFile) ?? ''
+  // 只取 externals 语义的声明体：*external*/EXTERNAL 命名的 Set/数组字面量，或 neverBundle/alwaysBundle 的内联数组。
+  const bodies = []
+  for (const m of configText.matchAll(/[\w$]*external[\w$]*\s*(?::[^=\n]*)?=\s*(?:new\s+Set\s*\(\s*)?\[([^\]]*)\]/gi)) bodies.push(m[1])
+  for (const m of configText.matchAll(/\b(?:neverBundle|alwaysBundle|external)\s*:\s*\[([^\]]*)\]/g)) bodies.push(m[1])
+  const configExternals = new Set()
+  for (const body of bodies) {
+    for (const m of body.matchAll(/['"]([^'"]+)['"]/g)) {
+      const spec = m[1]
+      if (/\.(ts|tsx|js|mjs|cjs|css|json|yml|yaml)$/.test(spec)) continue
+      configExternals.add(spec)
+    }
+  }
+  if (bodies.length === 0) {
+    warn(`构建配置 ${path.basename(buildConfigFile)} 未找到 externals 声明体（external/neverBundle 命名的 Set 或数组）——构建侧对账转人工`)
+  } else {
+    const unknown = [...configExternals].filter(spec =>
+      !isBuiltin(spec)
+      && !(platform !== undefined && (platform.baseline.includes(spec) || platform.baseline.includes(stripClientSuffix(spec))))
+      && !declaredExternal.has(spec) && !declaredExternal.has(stripClientSuffix(spec)))
+    if (unknown.length > 0) {
+      for (const spec of unknown) {
+        fail(`构建配置 ${path.basename(buildConfigFile)} 把 "${spec}" 标为 external，但既非平台基线也未声明 dsh.client.external——运行时模块表无法应答`)
+      }
+    } else {
+      pass(`构建配置 external 集 ⊆ 平台基线 ∪ dsh.client.external（${path.basename(buildConfigFile)}，${configExternals.size} 项）`)
+    }
+  }
+}
+
+// ══ §6 主题变量 ═══════════════════════════════════════════════════════════
+console.log('\n§ 6 主题变量（DSH 声明集对账）')
+const DSH_VAR_PREFIXES = ['--dsw-', '--ds-', '--shiki-']
+const harnessThemeDir = harnessAvailable ? path.join(harness.root, 'packages', 'client', 'ui-theme', 'src', 'styles') : undefined
+const harnessVars = new Set()
+if (harnessThemeDir !== undefined && existsSync(harnessThemeDir)) {
+  for (const entry of readdirSync(harnessThemeDir)) {
+    if (!entry.endsWith('.css')) continue
+    const text = readFileSync(path.join(harnessThemeDir, entry), 'utf8')
+    for (const m of text.matchAll(/(--[A-Za-z0-9-]+)\s*:/g)) harnessVars.add(m[1])
+  }
+} else if (harnessAvailable) {
+  unverifiable(`未找到 harness 主题声明目录 ${path.relative(harness.root, harnessThemeDir ?? '')}——主题变量对账不可用`)
+}
+
+const pluginFiles = listClientSourceFiles(dir)
+const pluginDeclared = new Set()
+const pluginUsed = new Map()
+for (const file of pluginFiles) {
+  const text = readFileSync(file, 'utf8')
+  const code = file.endsWith('.css') ? text.replace(/\/\*[\s\S]*?\*\//g, '') : stripJsComments(text)
+  for (const m of code.matchAll(/(--[A-Za-z0-9-]+)\s*:/g)) pluginDeclared.add(m[1])
+  for (const m of code.matchAll(/var\(\s*(--[A-Za-z0-9-]+)/g)) {
+    if (!pluginUsed.has(m[1])) pluginUsed.set(m[1], [])
+    pluginUsed.get(m[1]).push(rel(file))
+  }
+}
+if (pluginUsed.size === 0) {
+  na('client 源未使用任何 var(--) 主题变量')
+} else if (!harnessAvailable || (harnessVars.size === 0 && harnessThemeDir !== undefined && !existsSync(harnessThemeDir))) {
+  unverifiable(`client 源使用了 ${pluginUsed.size} 个主题变量，但 harness 主题声明集不可用——无法对账`)
+} else {
+  let okCount = 0
+  for (const [varName, files] of [...pluginUsed].sort()) {
+    if (!DSH_VAR_PREFIXES.some(prefix => varName.startsWith(prefix))) continue
+    if (harnessVars.has(varName) || pluginDeclared.has(varName)) { okCount += 1; continue }
+    fail(`不存在的 DSH 主题变量 ${varName}（harness 主题声明集与插件自身声明均无；回退值会掩盖主题断链）——使用处: ${[...new Set(files)].join(', ')}`)
+  }
+  if (okCount > 0) pass(`DSH 主题变量引用对账通过 ${okCount} 项`)
+}
+
+// ══ §7 文案与类型化 locale ════════════════════════════════════════════════
+console.log('\n§ 7 文案与类型化 locale')
+const isExempt = (file) => {
+  const base = path.basename(file)
+  const relPath = rel(file)
+  return /(^|[/.])locales?[/.]/.test(relPath) || /locales\.ts$/.test(base) || /\.(spec|test)\./.test(base)
+}
+const copyFiles = pluginFiles.filter(file => !isExempt(file))
+const cjkFiles = []
+for (const file of copyFiles) {
+  const text = readFileSync(file, 'utf8')
+  const copy = findHardcodedCopy(text)
+  if (copy.jsxTexts.length > 0) {
+    fail(`JSX 文本位置硬编码文案（应走类型化 locale）: ${rel(file)} — 例: ${JSON.stringify(copy.jsxTexts[0])}（共 ${copy.jsxTexts.length} 处）`)
+  }
+  if (copy.attrTexts.length > 0) {
+    fail(`用户可见属性硬编码文案: ${rel(file)} — ${copy.attrTexts.slice(0, 3).join('; ')}（共 ${copy.attrTexts.length} 处）`)
+  }
+  if (copy.literals.length > 0) {
+    cjkFiles.push({ file, samples: copy.literals, count: copy.literals.length })
+  }
+}
+for (const { file, samples, count } of cjkFiles) {
+  warn(`源码含 CJK 字符串字面量 ${count} 处（若渲染为产品文案需迁入 locale 词典）: ${rel(file)} — 例: ${JSON.stringify(samples[0])}`)
+}
+
+// zh/en 词典平价（类型化 locale 所有权正向检查）
+const dictCandidates = [
+  path.join(dir, 'src', 'client', 'locales.ts'),
+  path.join(dir, 'src', 'client', 'locales', 'zh.ts'),
+]
+const dictFile = dictCandidates.find(file => existsSync(file))
+if (dictFile !== undefined) {
+  const zhSource = readFileSync(dictFile, 'utf8')
+  const zhKeys = extractDictKeys(zhSource, 'zh')
+  let enKeys
+  if (path.basename(dictFile) === 'locales.ts') {
+    enKeys = extractDictKeys(zhSource, 'en')
+  } else {
+    const enFile = path.join(path.dirname(dictFile), 'en.ts')
+    enKeys = existsSync(enFile) ? extractDictKeys(readFileSync(enFile, 'utf8'), 'en') : undefined
+  }
+  if (zhKeys === undefined || enKeys === undefined) {
+    unverifiable(`locale 词典存在但无法机械解析 zh/en 键集: ${rel(dictFile)}（转人工核对 en 是否对齐 zh 键集）`)
+  } else {
+    const missingInEn = [...zhKeys].filter(key => !enKeys.has(key))
+    const extraInEn = [...enKeys].filter(key => !zhKeys.has(key))
+    if (missingInEn.length > 0 || extraInEn.length > 0) {
+      fail(`locale 词典 zh/en 键集不平价: en 缺 [${missingInEn.join(', ')}] en 多 [${extraInEn.join(', ')}]（en 必须对齐 zh 键集）`)
+    } else {
+      pass(`locale 词典 zh/en 键集平价（${zhKeys.size} 键）`)
+    }
+  }
+}
+
+// ══ §8 常规卫生 ═══════════════════════════════════════════════════════════
+console.log('\n§ 8 卫生')
 if (pkg.private !== true && pkg.publishConfig?.access !== 'public' && pkg.name?.startsWith('@')) {
   warn('scoped 包名且未声明 publishConfig.access——将来 npm 发布需 --access public')
 }
@@ -97,6 +705,57 @@ for (const script of ['build', 'test']) {
   else pass(`scripts.${script} = ${pkg.scripts[script]}`)
 }
 
-console.log(`\n结论: ${fails} FAIL / ${warns} WARN${fails === 0 ? ' — §1 机械层通过' : ' — 修复后重跑'}`)
+// ══ §9 文档版本声明 ═══════════════════════════════════════════════════════
+console.log('\n§ 9 文档版本声明')
+const FROZEN_PATTERNS = [
+  { re: /0\.1\.0-rc\.\d+/g, why: '冻结的 0.1.0-rc.x 版本假设' },
+  { re: /dsh-client-runtime(?![-\w])/g, why: '引用已移除的平台模块 dsh-client-runtime（0.1.2 起移除）' },
+]
+const docFiles = ['README.md', 'AGENTS.md', 'CLAUDE.md']
+const docsDir = path.join(dir, 'docs')
+if (existsSync(docsDir)) {
+  const walk = (current, depth) => {
+    if (depth > 3) return
+    for (const entry of readdirSync(current)) {
+      const full = path.join(current, entry)
+      if (statSync(full).isDirectory()) {
+        if (path.basename(full) !== 'acceptance') walk(full, depth + 1)
+      } else if (entry.endsWith('.md') && entry !== 'CHANGELOG.md') docFiles.push(path.relative(dir, full))
+    }
+  }
+  walk(docsDir, 0)
+}
+const docHits = []
+for (const relPath of docFiles) {
+  const full = path.join(dir, relPath)
+  const text = readTextSafe(full)
+  if (text === undefined) continue
+  for (const { re, why } of FROZEN_PATTERNS) {
+    re.lastIndex = 0
+    for (const m of text.matchAll(re)) {
+      const lineNo = text.slice(0, m.index).split('\n').length
+      docHits.push(`${relPath}:${lineNo} ${why}（"${m[0]}"）`)
+    }
+  }
+}
+if (docHits.length > 0) {
+  warn(`当前态文档存在过期版本声明 ${docHits.length} 处（CHANGELOG 与 acceptance 证据不在此列）— 例: ${docHits[0]}`)
+} else {
+  pass('当前态文档无冻结版本声明')
+}
+
+// ── 结论 ───────────────────────────────────────────────────────────────────
+console.log(`\n结论: ${fails} FAIL / ${warns} WARN / ${notVerified} NOT_VERIFIED${fails === 0 ? ' — §1 机械层通过' : ' — 修复后重跑'}`)
 console.log('人工续做: §2 事实溯源 / §3 契约清单 / §4 文档 / §5 候选绑定验收（见 SKILL.md）')
+
+if (argv.json) {
+  console.log(`__DSH_LINT_JSON__${JSON.stringify({
+    target: dir,
+    harness: harnessProvenance,
+    fails,
+    warns,
+    notVerified,
+    findings,
+  })}`)
+}
 process.exit(fails)

--- a/skills/dsh-plugin-lint/scripts/test-lint.mjs
+++ b/skills/dsh-plugin-lint/scripts/test-lint.mjs
@@ -1,0 +1,308 @@
+#!/usr/bin/env node
+/**
+ * dsh-plugin-lint 自测：自包含 fixture，证明每条规则抓得住无效样本、放行有效对照。
+ * 用法: node test-lint.mjs
+ * 退出码 0 = 全部断言通过。
+ *
+ * 运行时在临时目录合成一个迷你 harness（platform.ts / tsdown.client.ts / ui-theme styles /
+ * 官方 bin 门 / workspace 包）与两个插件夹具（valid / invalid），用 --json 与
+ * DSH_HARNESS_ROOT 两种 harness 根解析路径跑 lint.mjs 并断言结果。
+ */
+
+import assert from 'node:assert/strict'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const SCRIPT = fileURLToPath(new URL('./lint.mjs', import.meta.url))
+const FAKE_VERSION = '9.8.7-test.1'
+
+let passed = 0
+function ok(name, fn) {
+  if (fn !== undefined) fn()
+  passed += 1
+  console.log(`  ✓ ${name}`)
+}
+
+function write(file, content) {
+  mkdirSync(path.dirname(file), { recursive: true })
+  writeFileSync(file, content)
+}
+
+// ── 合成迷你 harness ────────────────────────────────────────────────────────
+function buildFakeHarness(root) {
+  write(path.join(root, 'package.json'), JSON.stringify({ name: '@deepseek-ai/dsh-root', version: FAKE_VERSION }))
+  // 官方可执行门替身：忽略参数，输出版本
+  write(path.join(root, 'apps', 'cli', 'lib', 'bin.js'), `process.stdout.write(${JSON.stringify(`${FAKE_VERSION}\n`)})\n`)
+  write(
+    path.join(root, 'packages', 'client', 'web', 'src', 'platform.ts'),
+    `export const PLATFORM_MODULES = [\n`
+    + `  'react', 'react/jsx-runtime', '@deepseek-ai/cordis', '@deepseek-ai/dsh-client-ui-slots',\n`
+    + `] as const\n\n`
+    + `export const PRELOADED_CLIENT_EXTERNALS = [\n] as const\n`,
+  )
+  write(
+    path.join(root, 'packages', 'client', 'tsdown.client.ts'),
+    `export const INLINE_SAFE = /^@deepseek-ai\\/dsh-file-reference(?:\\/|$)/\n`
+    + `const VENDORED_LIBRARY = /^@deepseek-ai\\/(cosmokit|schemastery)(\\/|$)/\n`
+    + `const GENERATED_REMOTE = /^@deepseek-ai\\/dsh-[a-z0-9]+(?:-[a-z0-9]+)*\\/remote$/\n`,
+  )
+  write(
+    path.join(root, 'packages', 'client', 'ui-theme', 'src', 'styles', 'design-platform.css'),
+    ':root {\n  --dsw-alias-bg-base: rgb(255, 255, 255);\n  --dsw-alias-border-l2: rgb(229, 227, 221);\n}\n',
+  )
+  // 一个真实声明了 dsh.client 的 workspace 包（合法 inject 目标）
+  write(
+    path.join(root, 'packages', 'client', 'ui-thing', 'package.json'),
+    JSON.stringify({ name: '@deepseek-ai/dsh-client-ui-thing', dsh: { client: { platform: 'web' } } }),
+  )
+  // 让 git commit 可解析；失败则测试回退为不断言 commit
+  try {
+    execFileSync('git', ['init', '-q'], { cwd: root })
+    execFileSync('git', ['add', '-A'], { cwd: root })
+    execFileSync('git', ['-c', 'user.email=t@local', '-c', 'user.name=t', 'commit', '-qm', 'fixture'], { cwd: root })
+    return true
+  } catch {
+    return false
+  }
+}
+
+// ── 有效插件夹具（对照：0 FAIL / 0 WARN）────────────────────────────────────
+const VALID_ARTIFACT = [
+  'window.__ModuleLoader__.load({ id: "@test/valid-plugin", factory: (require) => {',
+  'var module = { exports: {} }; var exports = module.exports;',
+  'const react = require("react");',
+  "const slots = require('@deepseek-ai/dsh-client-ui-slots');",
+  "exports.render = () => react.createElement('div', null, slots.name);",
+  'return module.exports;',
+  '} });',
+  '//# sourceMappingURL=client.js.map',
+].join('\n')
+
+function buildValidPlugin(root) {
+  write(path.join(root, 'package.json'), JSON.stringify({
+    name: '@test/valid-plugin',
+    type: 'module',
+    main: 'lib/index.js',
+    exports: { '.': './lib/index.js', './client': './lib/client.js' },
+    dsh: {
+      bundle: { patch: './cordis.patch.yml' },
+      client: { platform: 'web', inject: ['@deepseek-ai/dsh-client-ui-thing'] },
+    },
+    dependencies: { '@deepseek-ai/dsh-tools': FAKE_VERSION },
+    devDependencies: { '@deepseek-ai/dsh-client-ui-thing': FAKE_VERSION },
+    publishConfig: { access: 'public' },
+    scripts: { build: 'tsc', test: 'vitest run' },
+  }, null, 2))
+  write(path.join(root, 'cordis.patch.yml'), "- insert:\n    - id: valid-plugin\n      name: '@test/valid-plugin'\n")
+  write(path.join(root, 'lib', 'index.js'), 'export const apply = () => {}\n')
+  write(path.join(root, 'lib', 'client.js'), VALID_ARTIFACT)
+  write(
+    path.join(root, 'tsdown.client.config.ts'),
+    'const EXTERNALS = new Set([\n'
+    + "  'react',\n  'react/jsx-runtime',\n  '@deepseek-ai/cordis',\n  '@deepseek-ai/dsh-client-ui-slots',\n"
+    + '])\n'
+    + 'export default { deps: { neverBundle: s => EXTERNALS.has(s) } }\n',
+  )
+  write(
+    path.join(root, 'src', 'client', 'index.tsx'),
+    "import { createElement } from 'react'\n"
+    + "import css from './index.module.css'\n"
+    + 'export function Panel() {\n'
+    + "  return <div className={css.panel} style={{ background: 'var(--dsw-alias-bg-base)' }} />\n"
+    + '}\n',
+  )
+  write(
+    path.join(root, 'src', 'client', 'locales.ts'),
+    "export const zh = { 'panel.title': '面板' }\nexport const en = { 'panel.title': 'Panel' }\n",
+  )
+  write(path.join(root, 'README.md'), '# valid-plugin\n\n对照夹具：全部声明与当前 harness 一致。\n')
+}
+
+// ── 无效插件夹具（每条规则各埋一处违规）─────────────────────────────────────
+const INVALID_ARTIFACT = [
+  'window.__ModuleLoader__.load({ id: "@test/invalid-plugin", factory: (require) => {',
+  'var module = { exports: {} }; var exports = module.exports;',
+  'const react = require("react");',
+  "const ghost = require('@deepseek-ai/dsh-client-ghost-bare');",
+  "const wire = require('@deepseek-ai/dsh-file-reference');",
+  'exports.render = () => ghost.concat(wire, react);',
+  'return module.exports;',
+  '} });',
+].join('\n')
+
+function buildInvalidPlugin(root) {
+  write(path.join(root, 'package.json'), JSON.stringify({
+    name: '@test/invalid-plugin',
+    type: 'module',
+    main: 'lib/index.js',
+    exports: { '.': './lib/index.js', './client': './lib/client.cjs' },
+    dsh: {
+      bundle: { patch: './cordis.patch.yml' },
+      client: {
+        platform: 'web',
+        inject: ['@deepseek-ai/dsh-client-ghost'],
+        external: ['@deepseek-ai/dsh-client-unused', 'react'],
+      },
+    },
+    scripts: { build: 'tsc' },
+  }, null, 2))
+  // cordis.patch.yml 故意缺失 → bundle FAIL
+  write(path.join(root, 'lib', 'index.js'), 'export const apply = () => {}\n')
+  // 后缀 .cjs（banner/footer 本身完整，隔离验证后缀规则）
+  write(path.join(root, 'lib', 'client.cjs'), INVALID_ARTIFACT)
+  write(
+    path.join(root, 'tsdown.client.config.ts'),
+    "const CLIENT_EXTERNALS = new Set(['react', '@deepseek-ai/dsh-client-ghost-bare'])\n"
+    + 'export default { deps: { neverBundle: s => CLIENT_EXTERNALS.has(s) } }\n',
+  )
+  write(
+    path.join(root, 'src', 'client', 'broken.tsx'),
+    'export function Bar() {\n'
+    + "  const LABEL = '中文标签'\n"
+    + '  return (\n'
+    + '    <div>\n'
+    + '      <button placeholder="请输入中文" aria-label="打开面板">确认提交</button>\n'
+    + "      <span title={LABEL}>{LABEL}</span>\n"
+    + '    </div>\n'
+    + '  )\n'
+    + '}\n',
+  )
+  write(
+    path.join(root, 'src', 'client', 'locales.ts'),
+    "export const zh = { 'bar.ok': '确认', 'bar.cancel': '取消' }\nexport const en = { 'bar.ok': 'OK' }\n",
+  )
+  write(
+    path.join(root, 'src', 'client', 'broken.css'),
+    '.card {\n  color: var(--dsw-alias-fg-nonexistent);\n  border-color: var(--dsw-alias-border-l2);\n}\n',
+  )
+  write(path.join(root, 'README.md'), '# invalid-plugin\n\n基于 harness 0.1.0-rc.7 编写，声明已过期。\n')
+}
+
+// ── 运行 lint 并解析 --json ─────────────────────────────────────────────────
+function runLint(target, harnessRoot, viaEnv = false) {
+  const args = [SCRIPT, target]
+  if (!viaEnv) args.push('--harness-root', harnessRoot)
+  args.push('--json')
+  const env = viaEnv ? { ...process.env, DSH_HARNESS_ROOT: harnessRoot } : { ...process.env }
+  const res = spawnSync(process.execPath, args, { env, encoding: 'utf8' })
+  const marker = '__DSH_LINT_JSON__'
+  const line = (res.stdout ?? '').split('\n').find(l => l.startsWith(marker))
+  assert.ok(line !== undefined, `lint 输出缺少 ${marker} 行；stderr: ${res.stderr}`)
+  return { report: JSON.parse(line.slice(marker.length)), exitStatus: res.status }
+}
+
+function findingsOf(report, level) {
+  return report.findings.filter(f => f.level === level).map(f => f.message)
+}
+
+function assertNoFinding(report, level, substring) {
+  const hit = findingsOf(report, level).some(message => message.includes(substring))
+  assert.ok(!hit, `不应出现 ${level}: ${substring}`)
+}
+
+function assertHasFinding(report, level, substring) {
+  const hit = findingsOf(report, level).some(message => message.includes(substring))
+  assert.ok(hit, `应出现 ${level}: ${substring}；实际 ${level} 列表: ${JSON.stringify(findingsOf(report, level))}`)
+}
+
+// ── 执行 ────────────────────────────────────────────────────────────────────
+const workspace = mkdtempSync(path.join(tmpdir(), 'dsh-plugin-lint-test-'))
+try {
+  const harnessRoot = path.join(workspace, 'harness')
+  const gitOk = buildFakeHarness(harnessRoot)
+  const validDir = path.join(workspace, 'plugin-valid')
+  const invalidDir = path.join(workspace, 'plugin-invalid')
+  buildValidPlugin(validDir)
+  buildInvalidPlugin(invalidDir)
+
+  console.log('有效夹具（--harness-root 参数解析）')
+  const valid = runLint(validDir, harnessRoot)
+  ok('0 FAIL', () => assert.equal(valid.report.fails, 0, JSON.stringify(findingsOf(valid.report, 'FAIL'))))
+  ok('0 WARN', () => assert.equal(valid.report.warns, 0, JSON.stringify(findingsOf(valid.report, 'WARN'))))
+  ok('退出码 = FAIL 数 = 0', () => assert.equal(valid.exitStatus, 0))
+  ok('harness 版本经官方 bin 门溯源', () => {
+    assert.equal(valid.report.harness.dshVersion, FAKE_VERSION)
+    assert.equal(valid.report.harness.binVersion, FAKE_VERSION)
+  })
+  ok('平台模块表从源码解析（4 项基线）', () => {
+    assert.ok(findingsOf(valid.report, 'PASS').some(message => message.includes('平台模块表 4 项')))
+  })
+  if (gitOk) {
+    ok('harness git commit 溯源', () => assert.match(valid.report.harness.commit ?? '', /^[0-9a-f]{40}$/))
+  }
+
+  console.log('无效夹具（DSH_HARNESS_ROOT 环境变量解析）')
+  const invalid = runLint(invalidDir, harnessRoot, true)
+  const { report } = invalid
+  ok('harness 根经环境变量解析', () => {
+    assert.equal(report.harness.source, '环境变量 DSH_HARNESS_ROOT')
+    assert.equal(report.harness.dshVersion, FAKE_VERSION)
+  })
+  ok('退出码 = FAIL 数', () => assert.equal(invalid.exitStatus, report.fails))
+
+  // 规则 1：bundle patch 文件缺失
+  assertHasFinding(report, 'FAIL', 'dsh.bundle.patch 指向的文件不存在')
+  ok('规则 bundle: patch 缺失被抓')
+  // 规则 2：工件后缀 .cjs
+  assertHasFinding(report, 'FAIL', '工件后缀是 .cjs')
+  ok('规则 工件后缀: .cjs 被抓（banner 完整仍放行 banner 规则）', () => {
+    assert.ok(findingsOf(report, 'PASS').some(message => message.includes('banner 契约完整')))
+  })
+  // 规则 3：模块表无法应答的 bare require
+  assertHasFinding(report, 'FAIL', 'bare require("@deepseek-ai/dsh-client-ghost-bare")')
+  ok('规则 产物 bare require: 未知说明符被抓')
+  // 规则 4：内联安全层被外置
+  assertHasFinding(report, 'FAIL', 'bare require("@deepseek-ai/dsh-file-reference")')
+  ok('规则 纯度对账: INLINE_SAFE 说明符被外置被抓')
+  // 规则 5：构建配置 external 越界
+  assertHasFinding(report, 'FAIL', '把 "@deepseek-ai/dsh-client-ghost-bare" 标为 external')
+  ok('规则 构建配置 external ↔ 声明对账: 越界被抓')
+  // 规则 6：inject 目标无 dsh.client
+  assertHasFinding(report, 'FAIL', '@deepseek-ai/dsh-client-ghost 在 harness workspace 与本地 node_modules 均未声明 dsh.client')
+  ok('规则 inject 目标存在性: 幽灵包被抓')
+  assertHasFinding(report, 'WARN', '不在 dependencies/devDependencies')
+  ok('规则 inject ↔ devDep 双保险缺失被抓（WARN）')
+  // 规则 7：基线冗余 external + 死行 external
+  assertHasFinding(report, 'WARN', '"react" 已在平台基线中')
+  assertHasFinding(report, 'WARN', '"@deepseek-ai/dsh-client-unused" 在产物中没有任何对应 require')
+  ok('规则 external 声明: 基线冗余与死行都被抓（WARN）')
+  // 规则 8：不存在的主题变量（有效对照中的合法变量不报）
+  assertHasFinding(report, 'FAIL', '不存在的 DSH 主题变量 --dsw-alias-fg-nonexistent')
+  ok('规则 主题变量: 不存在的变量被抓')
+  // 规则 9/10：JSX 文本与用户可见属性硬编码
+  assertHasFinding(report, 'FAIL', 'JSX 文本位置硬编码文案')
+  assertHasFinding(report, 'FAIL', 'placeholder="请输入中文"')
+  assertHasFinding(report, 'FAIL', 'aria-label="打开面板"')
+  ok('规则 硬编码文案: JSX 文本 / placeholder / aria-label 都被抓')
+  // 规则 11：CJK 字面量 WARN（有效夹具同位置不报）
+  assertHasFinding(report, 'WARN', "CJK 字符串字面量")
+  ok('规则 CJK 字面量: 字符串常量出 WARN（非 FAIL）')
+  // 规则 12：zh/en 词典平价
+  assertHasFinding(report, 'FAIL', 'zh/en 键集不平价')
+  ok('规则 locale 词典平价: en 缺键被抓')
+  // 规则 13：文档冻结版本声明
+  assertHasFinding(report, 'WARN', '0.1.0-rc')
+  ok('规则 文档版本声明: 冻结 rc 版本被抓（WARN）')
+  // 规则 14：scripts 卫生
+  assertHasFinding(report, 'WARN', '缺 scripts.test')
+  ok('规则 卫生: 缺 scripts.test 被抓（WARN）')
+
+  // 有效对照必须不放行无效夹具命中的同类缺陷
+  for (const [level, substring] of [
+    ['FAIL', 'dsw-alias-fg-nonexistent'],
+    ['FAIL', 'JSX 文本位置硬编码'],
+    ['FAIL', '键集不平价'],
+    ['WARN', '已在平台基线中'],
+    ['WARN', '0.1.0-rc'],
+  ]) {
+    assertNoFinding(valid.report, level, substring)
+  }
+  ok('有效对照对全部同类检查项保持沉默')
+
+  console.log(`\n自测通过：${passed} 项断言全部成立（夹具: ${workspace}）`)
+} finally {
+  rmSync(workspace, { recursive: true, force: true })
+}

--- a/skills/dsh-plugin-lint/templates/plugin-quality-report.md
+++ b/skills/dsh-plugin-lint/templates/plugin-quality-report.md
@@ -13,40 +13,62 @@
 
 **一句话理由**：`<最关键的一条>`
 
-## 二、§1 机械层（scripts/lint.mjs 输出摘要）
+## 二、harness 溯源（lint.mjs §0 输出）
+
+| 项 | 值 |
+|---|---|
+| harness 根 | `<路径>`（解析来源：--harness-root / DSH_HARNESS_ROOT / config） |
+| DSH 版本 | `<x.y.z-rc.n>`（官方 `dsh --version` 门 + 根 manifest 交叉） |
+| harness git commit | `<rev-parse HEAD>` |
+| 平台模块表 | `<N> 项（packages/client/web/src/platform.ts）` |
+
+> 本报告全部对账结论只对该版本 + commit 有效；harness 升级后须重跑 §1。
+
+## 三、§1 机械层（scripts/lint.mjs 输出摘要，退出码 = FAIL 数）
 
 | 检查 | 结果 |
 |---|---|
 | 声明一致性（bundle/client/exports） | PASS / FAIL |
+| DSH 依赖钉定版本 ↔ harness 版本 | PASS / WARN 清单 |
 | client 工件契约（banner/footer/后缀） | PASS / FAIL / NA |
+| 产物 bare require ↔ 模块表对账 | PASS / FAIL / WARN（builtin 待人工确认） |
+| 构建配置 external ↔ 基线 ∪ dsh.client.external | PASS / FAIL / WARN（声明体未识别转人工） |
+| dsh.client.inject 目标存在性 + devDep 双保险 | PASS / FAIL / WARN 清单 |
+| dsh.client.external（自引用/基线冗余/死行） | PASS / FAIL / WARN 清单 |
+| 主题变量声明集对账 | PASS / FAIL / NA |
+| 硬编码文案与 zh/en 词典平价 | PASS / FAIL / WARN 清单 |
 | 入口与脚本卫生 | PASS / WARN 清单 |
+| 当前态文档版本声明 | PASS / WARN 清单 |
 
-## 三、§2 事实层（引用 → 源码溯源）
+## 四、§2 事实层（引用 → 源码溯源）
 
 | 引用（事件/slot/API） | harness 源码位置 | 判定 |
 |---|---|---|
 | `agent/pre-step` | `packages/core/agent/src/runtime-types.ts` | PASS / FAIL |
 
-## 四、§3 契约层
+## 五、§3 契约层
 
 | # | 契约项 | 结果 | 备注 |
 |---|---|---|---|
 | 1 | lossless JSON（无 undefined 泄漏） | PASS / FAIL / NA | |
 | 2 | DSL 限制（无嵌套对象/as const） | | |
-| 3 | client 工件契约 | | |
+| 3 | client 工件契约（含 externals 推导） | | |
 | 4 | client 纯度（无越界值导入） | | |
 | 5 | 子进程异步 + signal | | |
 | 6 | 显式传参（无静默默认依赖） | | |
 | 7 | fail-loud / 可选服务降级明示 | | |
 | 8 | 退码分类（域结果不 throw） | | |
 | 9 | 构建管线不吞退出码 | | |
-| 10 | HMR 边界已知（更新需重启） | | |
+| 10 | HMR 边界已知（历史结论，按当前版本复核；更新需重启取证） | | |
+| 11 | 主题变量仅引用 harness 声明集 | | |
+| 12 | 产品文案走类型化 locale | | |
 
-## 五、§4 文档层
+## 六、§4 文档层
 
 CHANGELOG / DECISIONS / ROADMAP / ARCHITECTURE 与实际改动同步情况：`<逐项>`
+当前态文档过期版本声明（lint.mjs §9 WARN 清单）：`<逐项>`
 
-## 六、§5 候选绑定证据（正式验收）
+## 七、§5 候选绑定证据（正式验收）
 
 | 证据 | 状态 |
 |---|---|
@@ -56,10 +78,10 @@ CHANGELOG / DECISIONS / ROADMAP / ARCHITECTURE 与实际改动同步情况：`<�
 | `__DSH_BOOT__` 含本包 + bundle 可下 | |
 | 浏览器渲染截图 | |
 
-## 七、需修复清单
+## 八、需修复清单
 
 1. `<FAIL 项 + 修复建议>`
 
-## 八、NOT_VERIFIED 项
+## 九、NOT_VERIFIED 项
 
 `<无法确认的能力/未取得的证据，明示不推断>`


### PR DESCRIPTION
## 摘要
- 从当前 DeepSeek Harness 源码与官方 CLI 版本读取审计事实，替换冻结版本假设
- 新增 client externals、slot、主题变量、locale、依赖版本及文档漂移检查
- 增加自包含合成 Harness/插件夹具，覆盖有效与无效样本

## 测试计划
- [x] `node skills/dsh-plugin-lint/scripts/test-lint.mjs`（23/23）
- [x] worker 对 Contract Copilot 候选运行 lint，并产生明确 FAIL/WARN 而非假 PASS

## Agent 归属
- Agent ID: `dsh-plugin-lint-v2-glm`
- Backend/model: ZCode / GLM-5.3-Flash
- Git author: 杨卫薪 <yangweixin@yangweixin.law>
- Trigger: Contract Copilot v3.0.1 收口波

## 关联任务
- Task: `DSH-PLUGIN-LINT-V2`
- Consumer: Contract Copilot 发布门禁与后续 DSH 插件项目

## 风险与回退
- 新规则可能把旧插件中的冻结假设提升为 WARN/FAIL；报告保留 NOT_VERIFIED，语义不确定时不输出假 PASS。
- 回退方式为 revert 本 PR；不改任何插件业务代码或凭据。

Task: DSH-PLUGIN-LINT-V2
Agent: dsh-plugin-lint-v2-glm