### PR TITLE
feat(multi-agent-orchestration): post-merge cleanup gate 合并后即时清理

### DIFF
--- a/skills/git-workflow/CHANGELOG.md
+++ b/skills/git-workflow/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 变更日志
 
+## [1.7.1] - 2026-09-05
+
+### 改进
+
+- 「分支清理」的 24h 时间过滤段新增机械执行指引：PR 已 `MERGED` 且分支无消费者时的即时清理，由 `multi-agent-orchestration` 的 `scripts/post-merge-cleanup.sh` 按 git-workflow 删除资格真值机械化（唯一 MERGED PR + headRefOid 精确一致 + 无 stacked child + worktree 干净 + 非长期/默认分支 + 生命周期已结算，删除后强制零残留验证）。明确即时清理是「已合并且无消费者」对 24h 规则的显式例外，只针对显式指定的单个分支；批量审计仍必须走本节完整流程。本 Skill 未改脚本与规则本身。
+
 ## [1.7.0] - 2026-09-04
 
 ### 新增

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -168,6 +168,8 @@ git for-each-ref --sort=committerdate refs/remotes/origin/ \
 
 **默认阈值:最后提交 < 24h 的分支一律保留(活跃,可能是刚开展/重跑的工作),不得删除。** 只有 > 24h(可配置,如 7 天更稳)的才进删除候选。时间过滤 + PR 状态 + 下面三查,缺一不可。
 
+**合并后即时清理的机械执行**:当 PR 已确认 `state == MERGED` 且分支无消费者时,上述审计可以由 `multi-agent-orchestration` 的 `scripts/post-merge-cleanup.sh` 机械化:唯一 MERGED PR 且 `headRefOid` 与本地 tip 精确一致、无开放 stacked child PR 以该分支为 base、worktree 无未提交改动、非 `main/master/develop`/长期集成分支、session 生命周期已结算——门禁全过才删本地+远端分支并强制零残留验证,任一不确定即 fail-closed 保留现场。即时清理是「已合并且无消费者」对 24h 规则的**显式例外**,只针对显式指定的单个已合并分支;批量审计仍必须走本节完整流程,没有 MERGED 证据的分支(<24h 或身份不明)继续被保护。
+
 #### 审计流程
 
 ```bash

--- a/skills/multi-agent-orchestration/CHANGELOG.md
+++ b/skills/multi-agent-orchestration/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.16.0] - 2026-09-05
+
+### 新增（post-merge cleanup gate，合并后即时清理）
+
+- **职责单一的 `scripts/post-merge-cleanup.sh`**：PR 确认合并后当场回收一个 worker 分支的 worktree/本地/远端短分支。删除资格真值来自 git-workflow 分支清理规则，全部门禁机械判定、fail-closed：① 分支不是 `main/master/develop`、`--base` 或 `--protected-branch`（名称或 glob，长期集成分支）匹配项；② 存在唯一 `state == MERGED` 的 PR 且其 `headRefOid` 与本地分支 tip 精确一致——squash/rebase merge 的唯一权威证据，head 漂移视为身份不明；③ 无开放 stacked child PR 以该分支为 base（gh 查询失败也拒绝）；④ worktree 无未提交改动；⑤ session 生命周期可证结算——tmux 存活且无 supervised dispatch、terminal accounting 为 active/reclaimable/release_pending/release_unknown/unknown 一律拒绝；⑥ 远端状态必须 `ls-remote` 可验证。门禁不过输出 `POST_MERGE_CLEANUP_DEFERRED: reason=...`（exit 2）保留现场。
+- **生命周期顺序执行**：execute 时先经 `clean-worktree.sh --execute --delete-branch`（worker-release → 关 terminal/lease → 删 worktree → 删本地分支），再 `git push origin --delete` 远端短分支（push 报错但 follow-up `ls-remote` 证明远端已删时按并发竞态幂等放行），最后机械零残留验证（本地 ref、worktree 注册与目录、tmux session、远端 ref）；远端删除失败或任一残留以 exit 9 报告，绝不把部分成功冒充完成。执行前复核分支 tip 未移动（TOCTOU）。默认 dry-run 零副作用；即时清理是「已合并且无消费者」对 <24h 规则的显式例外，只处理显式传入的单个分支，不批量扫描。
+- **`clean-worktree.sh` 新增 `--force-delete-branch`**：squash/rebase merge 后分支 tip 不可达 main，安全 `git branch -d` 必拒；该开关允许在 `-d` 拒绝后升级 `-D`，仅供持有独立 MERGED+head 证据的调用方（即 post-merge-cleanup.sh 门禁通过后）使用，不带开关时行为不变（拒绝并 exit 2，不再依赖 set -e 的裸失败）。
+- **文档同步**：SKILL.md §8 新增 post-merge-cleanup 段并纳入验收测试清单与 `gh` 依赖说明；`references/14-pm-orchestrate.md` §4.4 的「自动清理属于 Task-103」占位替换为实际工具指引。版本 2.15.1 → 2.16.0。
+
 ## [2.15.1] - 2026-09-04
 
 ### 修复（reauthorize 已结算 task 的 TASK_REUSED 误判，Task-113）

--- a/skills/multi-agent-orchestration/SKILL.md
+++ b/skills/multi-agent-orchestration/SKILL.md
@@ -399,6 +399,8 @@ bash scripts/clean-worktree.sh --project "$PROJECT" --branch feat/worker-a --ses
 
 active、release_pending、release_unknown 或生命周期不明的 supervised worker 一律拒绝删除 worktree。
 
+PR 已确认合并（GitHub `state == MERGED`）后要当场回收该 worker 的分支与 worktree 时，跑 `post-merge-cleanup.sh`：删除资格真值按 git-workflow 分支清理规则机械判定——分支不是 `main/master/develop`、`--base` 或 `--protected-branch`（长期集成分支）匹配项；存在唯一 MERGED PR 且其 `headRefOid` 与本地分支 tip 精确一致（head 漂移=身份不明，一律 deferred）；无开放 stacked child PR 以该分支为 base；worktree 无未提交改动；session 生命周期可证结算（tmux 存活且无 supervised dispatch、terminal accounting 为 active/release_pending 一律拒绝）。全过才按生命周期顺序执行：经 `clean-worktree.sh --execute`（先 release/关 terminal/lease，再删 worktree 与本地分支；squash merge 后 `-d` 必拒的场景凭上述 MERGED 证据升级 `-D`），随后删远端短分支，最后机械验证零残留（本地 ref/worktree 注册/tmux/远端 ref 任一残留 → exit 9，不冒充完成）。任何门禁不确定输出 `POST_MERGE_CLEANUP_DEFERRED: reason=...` 并保持现场；默认 dry-run。即时清理是「已合并且无消费者」的显式例外：只处理显式传入的单个分支，绝不批量扫描，<24h 规则继续保护没有 MERGED 证据的对象。回归：`scripts/test-post-merge-cleanup.sh`。
+
 ## 9. Backend 与配置
 
 默认优先与 PM 同宿主，只有额度、模型能力或用户明确要求时跨工具；跨工具仍不得越过 §3.1 的 Harness 白名单。个人偏好写入 ignored 的 `config/orchestration-personal.json`，模板为 `.example.json`；项目 trunk、任务源、验证命令和 provider slots 可写入 `.claude/orchestration.config.json`。个人配置只能选择白名单以内的 backend，不能扩张宿主权限。
@@ -485,7 +487,7 @@ session id（authority receipt 每会话唯一，fail-closed），切 provider �
 | `bash` 4+ | macOS: `brew install bash`；Linux: 包管理器安装 |
 | `git` | macOS: `xcode-select --install` 或 `brew install git` |
 | `jq` | macOS: `brew install jq`；Linux: `sudo apt-get install jq` |
-| `gh` | `pr-audit` 的只读 PR 事实与 `pm-closeout.sh` 的授权式 PR 创建/合并需要；macOS: `brew install gh`；Linux: 按 GitHub CLI 官方包安装 |
+| `gh` | `pr-audit` 的只读 PR 事实、`pm-closeout.sh` 的授权式 PR 创建/合并与 `post-merge-cleanup.sh` 的 MERGED 证据/child PR 查询需要；macOS: `brew install gh`；Linux: 按 GitHub CLI 官方包安装 |
 | `tmux` | 仅 tmux 路径需要；macOS: `brew install tmux` |
 | `python3` | 安装门禁和 scope guard 需要 |
 
@@ -562,6 +564,7 @@ bash scripts/test-settle-command.sh
 bash scripts/test-recover-unconfigured.sh
 bash scripts/test-pr-audit.sh
 bash scripts/test-pm-closeout.sh
+bash scripts/test-post-merge-cleanup.sh
 python3 scripts/test-autopilot-controller.py
 python3 scripts/test-autopilot-facts.py
 bash scripts/smoke-sentinel.sh

--- a/skills/multi-agent-orchestration/references/14-pm-orchestrate.md
+++ b/skills/multi-agent-orchestration/references/14-pm-orchestrate.md
@@ -169,7 +169,7 @@ Task-097 不消费 GitHub 原生 merge queue：远端 mutation 前必须读到�
 
 - 本地集成提交成功推入 main 后，原 PR 若未被 GitHub 自动标为 merged，使用包含 main commit SHA 的说明关闭；不得把 `CLOSED` 伪报成 GitHub `MERGED`。
 - GitHub 合并路径以 `state == MERGED`、非空 `mergedAt` 和 `mergeCommit.oid` 为成功证据。
-- 只有远端结果已确认且 worker/worktree 无未提交改动，才进入 release、分支和 worktree 清理。自动清理仍属于 Task-103，当前不得假装已实现。
+- 只有远端结果已确认且 worker/worktree 无未提交改动，才进入 release、分支和 worktree 清理。合并确认后的自动化清理由 `scripts/post-merge-cleanup.sh` 承担：git-workflow 删除资格门禁（唯一 MERGED PR + head 精确一致 + 无 stacked child + 非长期分支）全过才经 `clean-worktree.sh` 执行，远端删除失败或残留验证不过以 exit 9 报告；门禁不过则输出 deferred 理由保留现场。清理前仍需先 dry-run 审阅计划。
 
 ## 5. 安全边界
 

--- a/skills/multi-agent-orchestration/scripts/clean-worktree.sh
+++ b/skills/multi-agent-orchestration/scripts/clean-worktree.sh
@@ -18,6 +18,7 @@ KEEP_SESSION=0
 KEEP_WORKTREE=0
 DELETE_BRANCH=0
 FORCE_DIRTY=0
+FORCE_DELETE_BRANCH=0
 
 usage() {
   cat >&2 <<'USAGE'
@@ -33,6 +34,9 @@ Options:
   --keep-worktree       Do not remove git worktree
   --delete-branch       Delete local branch after worktree removal
   --force-remove-dirty  Allow removing a dirty worktree
+  --force-delete-branch Escalate to git branch -D when safe -d refuses; only for
+                        callers holding independent MERGED+head evidence (e.g.
+                        post-merge-cleanup.sh). Never use it to "align with remote".
 
 This script never deletes a remote branch and never runs git reset.
 USAGE
@@ -74,6 +78,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --force-remove-dirty)
       FORCE_DIRTY=1
+      shift
+      ;;
+    --force-delete-branch)
+      FORCE_DELETE_BRANCH=1
       shift
       ;;
     -h|--help)
@@ -344,7 +352,20 @@ fi
 
 if [ "$DELETE_BRANCH" -eq 1 ]; then
   if git -C "$PROJECT_DIR" show-ref --verify --quiet "refs/heads/$BRANCH"; then
-    run git -C "$PROJECT_DIR" branch -d "$BRANCH"
+    if [ "$EXECUTE" -eq 0 ]; then
+      echo "CLEAN_WORKTREE_RUN: git -C $PROJECT_DIR branch -d $BRANCH"
+    elif git -C "$PROJECT_DIR" branch -d "$BRANCH" >/dev/null 2>&1; then
+      echo "CLEAN_WORKTREE_BRANCH_DELETED: branch=$BRANCH"
+    elif [ "$FORCE_DELETE_BRANCH" -eq 1 ]; then
+      # squash/rebase merge 后分支 tip 不可达 main，安全 -d 必拒。只有调用方已独立
+      # 证明 MERGED + head 精确一致（如 post-merge-cleanup.sh 的门禁）才允许 -D。
+      echo "CLEAN_WORKTREE_BRANCH_FORCE_DELETED: branch=$BRANCH reason=safe_delete_refused_caller_merge_evidence"
+      git -C "$PROJECT_DIR" branch -D "$BRANCH" >/dev/null
+      echo "CLEAN_WORKTREE_BRANCH_DELETED: branch=$BRANCH mode=force"
+    else
+      echo "CLEAN_WORKTREE_BRANCH_REFUSED: git branch -d refused branch=$BRANCH; escalate with --force-delete-branch only after independent MERGED evidence" >&2
+      exit 2
+    fi
   else
     echo "CLEAN_WORKTREE_BRANCH: missing branch=$BRANCH"
   fi

--- a/skills/multi-agent-orchestration/scripts/post-merge-cleanup.sh
+++ b/skills/multi-agent-orchestration/scripts/post-merge-cleanup.sh
@@ -1,0 +1,411 @@
+#!/usr/bin/env bash
+# post-merge-cleanup.sh — fail-closed post-merge cleanup gate for ONE merged worker branch.
+#
+# 职责边界（与 git-workflow 分工）：删除资格真值来自 git-workflow 的分支清理规则
+# （PR state == MERGED、精确 head 一致、无 stacked child、worktree 干净、非长期集成/
+# 默认分支）；本脚本是 multi-agent-orchestration 的生命周期执行者：先经
+# clean-worktree.sh 释放 terminal/lease/worktree/本地分支，再删除远端短分支，最后
+# 机械验证零残留。任何门禁不确定或失败都输出 deferred-cleanup 理由并保持现场不动。
+#
+# 即时清理是「已合并且无消费者」的显式例外：只处理显式传入的单个分支，绝不批量
+# 扫描；git-workflow 的 <24h 保留规则继续保护没有 MERGED 证据的对象——无 MERGED
+# 证据一律 deferred，与分支年龄无关。远端删除失败或残留验证不过以 exit 9 报告，
+# 绝不把部分成功冒充为完成。
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=orca-runtime.sh
+source "$SCRIPT_DIR/orca-runtime.sh"
+
+PROJECT_DIR=""
+BRANCH=""
+SESSION=""
+WORKTREE=""
+BASE_REF="main"
+EXECUTE=0
+KEEP_REMOTE=0
+REPO_SLUG=""
+PROTECTED_PATTERNS=()
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  post-merge-cleanup.sh --project PATH --branch NAME --session NAME [options]
+
+Default is dry-run: every gate is evaluated read-only and the plan is printed.
+
+Options:
+  --worktree PATH        Override worktree path if branch lookup is unavailable
+  --base REF             Base ref the worker PR merged into (default main)
+  --repo SLUG            OWNER/REPO passed to gh; default: gh infers from project remote
+  --protected-branch PAT Long-lived/protected branch name or glob; repeatable
+  --keep-remote          Do not delete the remote branch
+  --execute              Perform the cleanup (still fail-closed on every gate)
+
+Gates (all must hold; the first miss prints POST_MERGE_CLEANUP_DEFERRED and exits 2):
+  - branch is not main/master/develop, the --base ref, or a --protected-branch pattern
+  - exactly one MERGED PR exists for the branch and its headRefOid equals the local
+    branch tip (a moved or unknown head is an identity mismatch, never cleaned)
+  - no open PR uses the branch as its base (stacked child consumer)
+  - the worktree, when present and registered, is clean
+  - the session lifecycle is provably settled: no alive unaccounted tmux session, and
+    any supervised dispatch reads released/retained — never active/release_pending
+
+With --execute the deletions run in lifecycle order via clean-worktree.sh
+(terminal/lease/worktree/local branch; squash-safe delete escalation only after the
+MERGED gate above), then the remote branch, then a mechanical zero-residue
+verification. Remote deletion failure or leftover state exits 9 and never reports
+success. This script never deletes a remote branch in dry-run and never runs
+git reset or git worktree remove --force.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project)
+      PROJECT_DIR="$2"
+      shift 2
+      ;;
+    --branch)
+      BRANCH="$2"
+      shift 2
+      ;;
+    --session)
+      SESSION="$2"
+      shift 2
+      ;;
+    --worktree)
+      WORKTREE="$2"
+      shift 2
+      ;;
+    --base)
+      BASE_REF="$2"
+      shift 2
+      ;;
+    --repo)
+      REPO_SLUG="$2"
+      shift 2
+      ;;
+    --protected-branch)
+      PROTECTED_PATTERNS+=("$2")
+      shift 2
+      ;;
+    --keep-remote)
+      KEEP_REMOTE=1
+      shift
+      ;;
+    --execute)
+      EXECUTE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 64
+      ;;
+  esac
+done
+
+[ -n "$PROJECT_DIR" ] || { usage; exit 64; }
+[ -n "$BRANCH" ] || { usage; exit 64; }
+[ -n "$SESSION" ] || { usage; exit 64; }
+[ -n "$BASE_REF" ] || { usage; exit 64; }
+for dependency in git jq gh; do
+  command -v "$dependency" >/dev/null 2>&1 || { echo "POST_MERGE_CLEANUP_DEPENDENCY_MISSING: $dependency" >&2; exit 64; }
+done
+
+PROJECT_DIR=$(cd "$PROJECT_DIR" && pwd -P)
+case "$WORKTREE" in
+  "") ;;
+  /*) ;;
+  *) WORKTREE="$PROJECT_DIR/$WORKTREE" ;;
+esac
+
+defer() {
+  echo "POST_MERGE_CLEANUP_DEFERRED: reason=$1${2:+ detail=$2}" >&2
+  exit 2
+}
+
+# exact-match against `git worktree list --porcelain` output (no substring hits).
+worktree_listed() {
+  [ -n "$1" ] || return 1
+  git -C "$PROJECT_DIR" worktree list --porcelain 2>/dev/null | \
+    awk -v wt="$1" '/^worktree / { if (substr($0, 10) == wt) { found = 1 } } END { exit !found }'
+}
+
+gh_pr_list() {
+  local state="$1"
+  shift
+  if [ -n "$REPO_SLUG" ]; then
+    (cd "$PROJECT_DIR" && gh pr list --state "$state" "$@" --repo "$REPO_SLUG" \
+      --json number,url,state,headRefName,headRefOid --limit 50 2>/dev/null)
+  else
+    (cd "$PROJECT_DIR" && gh pr list --state "$state" "$@" \
+      --json number,url,state,headRefName,headRefOid --limit 50 2>/dev/null)
+  fi
+}
+
+echo "POST_MERGE_CLEANUP_MODE: $([ "$EXECUTE" -eq 1 ] && echo execute || echo dry-run)"
+echo "POST_MERGE_CLEANUP_TARGET: branch=$BRANCH session=$SESSION base=$BASE_REF worktree=${WORKTREE:-auto}"
+
+# ---- Gate 1: 删除资格真值（git-workflow）——默认/长期集成分支永不删除 -------------
+case "$BRANCH" in
+  main|master|develop|"$BASE_REF")
+    defer "protected_branch" "branch=$BRANCH is a default/integration trunk"
+    ;;
+esac
+if [ "${#PROTECTED_PATTERNS[@]}" -gt 0 ]; then
+  for pattern in "${PROTECTED_PATTERNS[@]}"; do
+    # shellcheck disable=SC2254  # pattern matching on purpose
+    case "$BRANCH" in
+      $pattern) defer "protected_branch" "branch=$BRANCH matches protected pattern=$pattern" ;;
+    esac
+  done
+fi
+echo "POST_MERGE_CLEANUP_PROTECTED: clear branch=$BRANCH"
+
+# ---- Gate 2: MERGED 证据 + 精确 head 一致（squash/rebase merge 的唯一权威证据）----
+BRANCH_TIP=$(git -C "$PROJECT_DIR" rev-parse --verify --quiet "refs/heads/$BRANCH" 2>/dev/null || true)
+[ -n "$BRANCH_TIP" ] || defer "branch_missing_local" "refs/heads/$BRANCH is not resolvable; remote-only residue needs manual review"
+echo "POST_MERGE_CLEANUP_BRANCH_TIP: $BRANCH_TIP"
+
+set +e
+MERGED_JSON=$(gh_pr_list merged --head "$BRANCH")
+GH_MERGED_RC=$?
+set -e
+[ "$GH_MERGED_RC" -eq 0 ] || defer "pr_evidence_unavailable" "gh pr list --state merged exited $GH_MERGED_RC"
+printf '%s' "$MERGED_JSON" | jq -e 'type == "array"' >/dev/null 2>&1 || \
+  defer "pr_evidence_unavailable" "gh pr list --state merged did not return a JSON array"
+
+MERGED_FOR_BRANCH=$(printf '%s' "$MERGED_JSON" | jq -c --arg br "$BRANCH" \
+  '[.[] | select(.state == "MERGED" and .headRefName == $br)]')
+MERGED_COUNT=$(printf '%s' "$MERGED_FOR_BRANCH" | jq 'length')
+if [ "$MERGED_COUNT" -eq 0 ]; then
+  defer "no_merged_pr_evidence" "no MERGED PR for head=$BRANCH; <24h and unknown branches stay protected"
+fi
+MERGED_AT_TIP=$(printf '%s' "$MERGED_FOR_BRANCH" | jq -c --arg tip "$BRANCH_TIP" '[.[] | select(.headRefOid == $tip)]')
+TIP_COUNT=$(printf '%s' "$MERGED_AT_TIP" | jq 'length')
+if [ "$TIP_COUNT" -ne 1 ]; then
+  pr_head_oids=$(printf '%s' "$MERGED_FOR_BRANCH" | jq -c '[.[].headRefOid]')
+  defer "head_mismatch" "merged_pr_oids=$pr_head_oids local_tip=$BRANCH_TIP; branch identity is uncertain after merge"
+fi
+PR_NUMBER=$(printf '%s' "$MERGED_AT_TIP" | jq -r '.[0].number | tostring')
+PR_URL=$(printf '%s' "$MERGED_AT_TIP" | jq -r '.[0].url // ""')
+echo "POST_MERGE_CLEANUP_MERGED_PR: number=$PR_NUMBER url=$PR_URL head=$BRANCH_TIP"
+
+# ---- Gate 3: 无 stacked child 消费者（开放 PR 以该分支为 base）--------------------
+set +e
+CHILD_JSON=$(gh_pr_list open --base "$BRANCH")
+GH_CHILD_RC=$?
+set -e
+[ "$GH_CHILD_RC" -eq 0 ] || defer "child_pr_query_unavailable" "gh pr list --state open --base exited $GH_CHILD_RC"
+printf '%s' "$CHILD_JSON" | jq -e 'type == "array"' >/dev/null 2>&1 || \
+  defer "child_pr_query_unavailable" "gh pr list --state open did not return a JSON array"
+CHILD_COUNT=$(printf '%s' "$CHILD_JSON" | jq 'length')
+[ "$CHILD_COUNT" -eq 0 ] || \
+  defer "open_child_pr" "children=$(printf '%s' "$CHILD_JSON" | jq -c '[.[].number]') use $BRANCH as base"
+echo "POST_MERGE_CLEANUP_CHILD_PRS: zero"
+
+# ---- Gate 4: worktree 干净（未提交工作永不清）------------------------------------
+if [ -z "$WORKTREE" ]; then
+  WORKTREE=$(git -C "$PROJECT_DIR" worktree list --porcelain 2>/dev/null | awk -v target="refs/heads/$BRANCH" '
+    /^worktree / { wt = substr($0, 10) }
+    /^branch / {
+      if (substr($0, 8) == target) {
+        print wt
+        exit
+      }
+    }
+  ')
+fi
+
+WORKTREE_LISTED=0
+WORKTREE_PRESENT=0
+if worktree_listed "$WORKTREE"; then
+  WORKTREE_LISTED=1
+fi
+if [ -n "$WORKTREE" ] && [ -d "$WORKTREE" ]; then
+  WORKTREE_PRESENT=1
+fi
+if [ "$WORKTREE_LISTED" -eq 1 ] && [ "$WORKTREE_PRESENT" -eq 0 ]; then
+  defer "worktree_stale_registration" "worktree=$WORKTREE is registered but missing on disk; run git worktree prune manually first"
+fi
+if [ "$WORKTREE_PRESENT" -eq 1 ]; then
+  [ "$WORKTREE" != "$PROJECT_DIR" ] || defer "worktree_is_project_dir" "refusing to treat the project directory as a worker worktree"
+  dirty_count=$(git -C "$WORKTREE" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+  [ "$dirty_count" = "0" ] || defer "dirty_worktree" "worktree=$WORKTREE has $dirty_count uncommitted changes"
+  echo "POST_MERGE_CLEANUP_WORKTREE: present path=$WORKTREE dirty=0"
+else
+  echo "POST_MERGE_CLEANUP_WORKTREE: missing path=${WORKTREE:-unresolved}"
+fi
+
+# ---- Gate 5: session 生命周期可证结算（active/release_pending 一律拒绝）----------
+METADATA_FILE=""
+DISPATCH_ID=""
+if [ "$WORKTREE_PRESENT" -eq 1 ]; then
+  METADATA_FILE="$WORKTREE/.claude/agent-sessions/$SESSION/METADATA.json"
+  [ -f "$METADATA_FILE" ] || defer "session_metadata_missing" "file=$METADATA_FILE; orchestration workers always carry METADATA"
+  jq -e 'type == "object"' "$METADATA_FILE" >/dev/null 2>&1 || \
+    defer "session_metadata_invalid" "file=$METADATA_FILE; retain for recovery"
+  DISPATCH_ID=$(jq -r '.session.orca.supervised.dispatch_id // ""' "$METADATA_FILE" 2>/dev/null || echo "")
+fi
+
+TMUX_ALIVE=0
+if command -v tmux >/dev/null 2>&1 && tmux has-session -t "$SESSION" 2>/dev/null; then
+  TMUX_ALIVE=1
+fi
+if [ "$TMUX_ALIVE" -eq 1 ] && [ -z "$DISPATCH_ID" ]; then
+  defer "tmux_session_alive_unaccounted" "session=$SESSION is alive without supervised dispatch to prove settlement"
+fi
+
+TERMINAL_STATE="no-dispatch"
+if [ -n "$DISPATCH_ID" ]; then
+  if orca_runtime_init >/dev/null 2>&1; then
+    worker_json=$(orca_cli orchestration worker-list --json 2>/dev/null || echo '{}')
+    worker_row=$(printf '%s' "$worker_json" | jq -c --arg disp "$DISPATCH_ID" '
+      [(.result.workers // [])[]? | select((.dispatch_id // .dispatchId // .id) == $disp)][0] // {}' 2>/dev/null || echo '{}')
+    TERMINAL_STATE=$(printf '%s' "$worker_row" | jq -r '.terminal_state // .terminalState // .accounting_state // .accountingState // "unknown"' 2>/dev/null || echo "unknown")
+    [ -n "$TERMINAL_STATE" ] || TERMINAL_STATE="unknown"
+    case "$TERMINAL_STATE" in
+      released|retained)
+        # retained 的 external 所有权证明由 clean-worktree.sh 在 execute 时权威复核。
+        ;;
+      active|reclaimable|release_pending|release_unknown)
+        defer "terminal_accounting_$TERMINAL_STATE" "dispatch=$DISPATCH_ID; settle the worker first"
+        ;;
+      *)
+        defer "terminal_accounting_unknown" "dispatch=$DISPATCH_ID state=$TERMINAL_STATE; recover exact worker-release first"
+        ;;
+    esac
+  else
+    defer "orca_cli_unavailable" "dispatch=$DISPATCH_ID cannot be accounted; lifecycle unknown"
+  fi
+fi
+echo "POST_MERGE_CLEANUP_LIFECYCLE: dispatch=${DISPATCH_ID:-none} terminal=$TERMINAL_STATE tmux=$([ "$TMUX_ALIVE" -eq 1 ] && echo alive || echo absent)"
+
+# ---- 远端分支现状（只读）；任何模式都要求可验证，否则拒绝继续 --------------------
+set +e
+LS_REMOTE_OUT=$(git -C "$PROJECT_DIR" ls-remote --heads origin "refs/heads/$BRANCH" 2>/dev/null)
+LS_RC=$?
+set -e
+if [ "$LS_RC" -ne 0 ]; then
+  # 发生在任何 mutation 之前：这是可恢复的拒绝，不是 outcome-unknown。
+  defer "remote_state_unverifiable" "git ls-remote origin exited $LS_RC; refusing an unverifiable cleanup"
+fi
+if [ -n "$LS_REMOTE_OUT" ]; then
+  REMOTE_STATE="present"
+else
+  REMOTE_STATE="absent"
+fi
+echo "POST_MERGE_CLEANUP_REMOTE_STATE: branch=$BRANCH state=$REMOTE_STATE"
+
+# ---- 执行：生命周期顺序 = release/terminal/lease → worktree/本地分支 → 远端 → 残留 --
+if [ "$EXECUTE" -eq 1 ]; then
+  # 删除前的最后身份复核：门禁通过后分支不得再移动。
+  now_tip=$(git -C "$PROJECT_DIR" rev-parse --verify --quiet "refs/heads/$BRANCH" 2>/dev/null || true)
+  [ "$now_tip" = "$BRANCH_TIP" ] || defer "head_mismatch" "branch advanced during cleanup: expected=$BRANCH_TIP actual=${now_tip:-missing}"
+
+  CW_ARGS=(--project "$PROJECT_DIR" --branch "$BRANCH" --session "$SESSION" --execute --delete-branch --force-delete-branch)
+  if [ -n "$WORKTREE" ]; then
+    CW_ARGS+=(--worktree "$WORKTREE")
+  fi
+  set +e
+  bash "$SCRIPT_DIR/clean-worktree.sh" "${CW_ARGS[@]}"
+  CW_RC=$?
+  set -e
+  if [ "$CW_RC" -ne 0 ]; then
+    echo "POST_MERGE_CLEANUP_DEFERRED: reason=clean_worktree_refused detail=clean-worktree.sh exit=$CW_RC" >&2
+    exit 2
+  fi
+
+  REMOTE_OUTCOME="$REMOTE_STATE"
+  if [ "$KEEP_REMOTE" -eq 1 ]; then
+    echo "POST_MERGE_CLEANUP_REMOTE: kept branch=$BRANCH"
+    REMOTE_OUTCOME="kept"
+  elif [ "$REMOTE_STATE" = "present" ]; then
+    set +e
+    git -C "$PROJECT_DIR" push origin --delete "refs/heads/$BRANCH"
+    PUSH_RC=$?
+    set -e
+    if [ "$PUSH_RC" -ne 0 ]; then
+      # 与 clean-worktree.sh 的 terminal close race 同理：push 报错但远端实际已删
+      # （并发清理 / GitHub auto-delete）时，用 follow-up ls-remote 证明后幂等放行。
+      set +e
+      LS_RACE=$(git -C "$PROJECT_DIR" ls-remote --heads origin "refs/heads/$BRANCH" 2>/dev/null)
+      LS_RACE_RC=$?
+      set -e
+      if [ "$LS_RACE_RC" -eq 0 ] && [ -z "$LS_RACE" ]; then
+        echo "POST_MERGE_CLEANUP_REMOTE_ALREADY_ABSENT: branch=$BRANCH reason=delete_race_verified"
+        REMOTE_OUTCOME="absent"
+      else
+        echo "POST_MERGE_CLEANUP_REMOTE_DELETE_FAILED: branch=$BRANCH detail=local cleanup already applied; inspect remote state before retrying" >&2
+        exit 9
+      fi
+    else
+      echo "POST_MERGE_CLEANUP_REMOTE_DELETED: branch=$BRANCH"
+      REMOTE_OUTCOME="deleted"
+    fi
+  else
+    echo "POST_MERGE_CLEANUP_REMOTE_ALREADY_ABSENT: branch=$BRANCH"
+    REMOTE_OUTCOME="absent"
+  fi
+
+  # ---- 机械零残留验证：任何残留都否定完成 --------------------------------------
+  residue=0
+  if git -C "$PROJECT_DIR" show-ref --verify --quiet "refs/heads/$BRANCH"; then
+    echo "POST_MERGE_CLEANUP_RESIDUE: kind=local_branch branch=$BRANCH" >&2
+    residue=1
+  fi
+  if [ "$WORKTREE_LISTED" -eq 1 ] && worktree_listed "$WORKTREE"; then
+    echo "POST_MERGE_CLEANUP_RESIDUE: kind=worktree_registration path=$WORKTREE" >&2
+    residue=1
+  fi
+  if [ "$WORKTREE_PRESENT" -eq 1 ] && [ -e "$WORKTREE" ]; then
+    echo "POST_MERGE_CLEANUP_RESIDUE: kind=worktree_dir path=$WORKTREE" >&2
+    residue=1
+  fi
+  if command -v tmux >/dev/null 2>&1 && tmux has-session -t "$SESSION" 2>/dev/null; then
+    echo "POST_MERGE_CLEANUP_RESIDUE: kind=tmux_session session=$SESSION" >&2
+    residue=1
+  fi
+  if [ "$KEEP_REMOTE" -eq 0 ]; then
+    set +e
+    LS_AFTER=$(git -C "$PROJECT_DIR" ls-remote --heads origin "refs/heads/$BRANCH" 2>/dev/null)
+    LS_AFTER_RC=$?
+    set -e
+    if [ "$LS_AFTER_RC" -ne 0 ]; then
+      echo "POST_MERGE_CLEANUP_RESIDUE_UNVERIFIED: kind=remote_branch reason=ls_remote_failed exit=$LS_AFTER_RC" >&2
+      exit 9
+    fi
+    if [ -n "$LS_AFTER" ]; then
+      echo "POST_MERGE_CLEANUP_RESIDUE: kind=remote_branch branch=$BRANCH still visible on origin" >&2
+      residue=1
+    fi
+  fi
+  if [ "$residue" -ne 0 ]; then
+    echo "POST_MERGE_CLEANUP_RESIDUE_DETECTED: cleanup is incomplete; do not report this branch as settled" >&2
+    exit 9
+  fi
+  echo "POST_MERGE_CLEANUP_RESIDUE_VERIFIED: zero"
+  echo "POST_MERGE_CLEANUP_DONE"
+  echo "POST_MERGE_CLEANUP_RESULT: CLEANED pr=$PR_NUMBER branch=$BRANCH worktree=$([ "$WORKTREE_PRESENT" -eq 1 ] && echo removed || echo absent) local_branch=deleted remote_branch=$REMOTE_OUTCOME residue=zero"
+  exit 0
+fi
+
+# ---- dry-run：输出计划，零副作用 --------------------------------------------------
+if [ "$KEEP_REMOTE" -eq 1 ]; then
+  REMOTE_PLAN="keep"
+elif [ "$REMOTE_STATE" = "present" ]; then
+  REMOTE_PLAN="delete"
+else
+  REMOTE_PLAN="already-absent"
+fi
+echo "POST_MERGE_CLEANUP_PLAN: clean-worktree.sh --execute --delete-branch (terminal/lease → worktree → local branch) then remote branch $REMOTE_PLAN then zero-residue verification"
+echo "POST_MERGE_CLEANUP_DRY_RUN_DONE"
+echo "POST_MERGE_CLEANUP_RESULT: PLAN pr=$PR_NUMBER branch=$BRANCH worktree=$([ "$WORKTREE_PRESENT" -eq 1 ] && echo remove || echo absent) local_branch=delete remote_branch=$REMOTE_PLAN residue=verify-after-execute"
+exit 0

--- a/skills/multi-agent-orchestration/scripts/test-post-merge-cleanup.sh
+++ b/skills/multi-agent-orchestration/scripts/test-post-merge-cleanup.sh
@@ -1,0 +1,485 @@
+#!/usr/bin/env bash
+# Deterministic contract tests for post-merge-cleanup.sh: throwaway local Git
+# remote plus fake gh/tmux/orca/git executables; never reaches the network.
+#
+# 覆盖场景（对应任务合同）：
+#   1. 即时安全清理：dry-run 计划（Case 1）/ execute 全链路（Case 2）/ supervised
+#      released + 存活 tmux 的 release→kill→rm 顺序（Case 3）
+#   2. 开放 child PR 阻止删除（Case 4）
+#   3. 长期集成/默认分支阻止（Case 5：main、--protected-branch 模式、--base 自身）
+#   4. dirty worktree 阻止（Case 6）
+#   5. active / release_pending 阻止（Case 7，supervised accounting fail-closed）
+#   6. 远端删除失败不冒充完成（Case 8，exit 9 无 DONE）
+#   7. dry-run 无副作用（Case 1）
+#   8. 执行后机械零残留验证（Case 9：push 谎报成功时的残留捕获）
+#   9. 24h 规则保护（Case 10-13、15：无 MERGED 证据 / head 漂移 / metadata 缺失 /
+#      tmux 存活未结算 / gh 不可用）
+#  10. squash-merge 后 -d 拒绝时的证据背书 -D 升级（Case 14，clean-worktree.sh
+#      --force-delete-branch）
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+HELPER="$SCRIPT_DIR/post-merge-cleanup.sh"
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+passed=0
+failed=0
+ok() { echo "  ✓ $1"; passed=$((passed + 1)); }
+bad() { echo "  ✗ $1" >&2; failed=$((failed + 1)); }
+assert_eq() {
+  if [ "$1" = "$2" ]; then ok "$3"; else bad "$3 (expected=$2 actual=$1)"; fi
+}
+assert_contains() {
+  if grep -qF -- "$1" "$2"; then ok "$3"; else bad "$3 (missing '$1' in $2)"; fi
+}
+assert_not_contains() {
+  if grep -qF -- "$1" "$2"; then bad "$3 (unexpected '$1' in $2)"; else ok "$3"; fi
+}
+assert_remote_branch_absent() {
+  if git --git-dir="$REMOTE" show-ref --verify --quiet "refs/heads/$1"; then bad "remote branch $1 still exists"; else ok "remote branch $1 absent"; fi
+}
+
+REAL_GIT=$(command -v git)
+world_count=0
+
+build_world() {
+  world_count=$((world_count + 1))
+  WORLD="$TMP_ROOT/world-$world_count"
+  REMOTE="$WORLD/remote.git"
+  SEED="$WORLD/seed"
+  PROJECT="$WORLD/project"
+  BIN="$WORLD/bin"
+  OUT="$WORLD/out.log"
+  ERR="$WORLD/err.log"
+  mkdir -p "$BIN"
+  git init -q --bare "$REMOTE"
+  git init -q "$SEED"
+  git -C "$SEED" config user.name "Cleanup Test"
+  git -C "$SEED" config user.email "cleanup@example.invalid"
+  printf 'base\n' > "$SEED/base.txt"
+  # 与真实 orchestration 仓库一致：session context 不算 dirty。
+  printf '.claude/agent-sessions/\n' > "$SEED/.gitignore"
+  git -C "$SEED" add .
+  git -C "$SEED" commit -q -m base
+  git -C "$SEED" branch -M main
+  git -C "$SEED" remote add origin "$REMOTE"
+  git -C "$SEED" push -q -u origin main
+  git --git-dir="$REMOTE" symbolic-ref HEAD refs/heads/main
+  git clone -q "$REMOTE" "$PROJECT"
+  git -C "$PROJECT" config user.name "Cleanup Test"
+  git -C "$PROJECT" config user.email "cleanup@example.invalid"
+
+  : > "$WORLD/gh.log"
+  printf '[]\n' > "$WORLD/gh-merged.json"
+  printf '[]\n' > "$WORLD/gh-open.json"
+
+  cat > "$BIN/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%q ' "$@" >> "${FAKE_GH_LOG:?}"
+printf '\n' >> "${FAKE_GH_LOG:?}"
+state=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--state" ]; then state="$arg"; fi
+  prev="$arg"
+done
+case "$state" in
+  merged)
+    [ "${FAKE_GH_MERGED_FAIL:-0}" -eq 0 ] || { echo 'gh merged list unavailable' >&2; exit 3; }
+    cat "${FAKE_GH_MERGED_FILE:?}"
+    ;;
+  open)
+    [ "${FAKE_GH_OPEN_FAIL:-0}" -eq 0 ] || { echo 'gh open list unavailable' >&2; exit 3; }
+    cat "${FAKE_GH_OPEN_FILE:?}"
+    ;;
+  *)
+    echo '[]'
+    ;;
+esac
+SH
+  chmod +x "$BIN/gh"
+
+  cat > "$BIN/tmux" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+cmd="$1"
+shift || true
+case "$cmd" in
+  has-session)
+    if [ "${FAKE_TMUX_ALIVE:-0}" = "1" ] && [ ! -e "${FAKE_TMUX_DEAD:?}" ]; then
+      exit 0
+    fi
+    echo "no server running on /tmp/tmt-test" >&2
+    exit 1
+    ;;
+  kill-session)
+    printf '%s\n' "$cmd $*" >> "${FAKE_TMUX_LOG:?}"
+    : > "${FAKE_TMUX_DEAD:?}"
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$BIN/tmux"
+
+  cat > "$BIN/git" <<SH
+#!/usr/bin/env bash
+set -euo pipefail
+# helper 以 git -C <path> push origin --delete 调用，按参数流扫描而非固定下标。
+saw_push=0
+is_push_delete=0
+for arg in "\$@"; do
+  if [ "\$saw_push" -eq 1 ] && [ "\$arg" = "--delete" ]; then is_push_delete=1; fi
+  if [ "\$arg" = "push" ]; then saw_push=1; fi
+done
+if [ "\$is_push_delete" -eq 1 ]; then
+  printf '%s\n' "\$*" >> "\${FAKE_GIT_LOG:?}"
+  case "\${FAKE_GIT_PUSH_DELETE_MODE:-passthrough}" in
+    fail) echo 'remote: refusing delete (test injection)' >&2; exit 5 ;;
+    lie) echo 'fake push claims success without deleting' ; exit 0 ;;
+  esac
+fi
+exec "$REAL_GIT" "\$@"
+SH
+  chmod +x "$BIN/git"
+
+  : > "$WORLD/tmux.log"
+  rm -f "$WORLD/tmux-dead"
+  : > "$WORLD/git.log"
+  # 用例间通过函数前缀赋值传递的环境必须清零，避免向后续用例泄漏状态。
+  unset FAKE_TMUX_ALIVE FAKE_GIT_PUSH_DELETE_MODE FAKE_ORCA_TERMINAL_STATE \
+    FAKE_ORCA_DISPATCH FAKE_GH_MERGED_FAIL FAKE_GH_OPEN_FAIL ORCA_CLI_CMD || true
+
+  cat > "$BIN/orca" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+{
+  for arg in "$@"; do printf '%q ' "$arg"; done
+  printf '\n'
+} >> "${FAKE_ORCA_LOG:?}"
+case "$1 $2" in
+  "orchestration worker-list")
+    printf '{"ok":true,"result":{"workers":[{"dispatch_id":"%s","terminal_state":"%s","worker_state":"succeeded","dispatch_status":"completed"}]}}' \
+      "${FAKE_ORCA_DISPATCH:-ctx-1}" "${FAKE_ORCA_TERMINAL_STATE:-released}"
+    ;;
+  "orchestration worker-release")
+    printf '{"ok":true,"result":{"release":{"dispatch_id":"%s"}}}\n' "${FAKE_ORCA_DISPATCH:-ctx-1}"
+    ;;
+  *)
+    echo '{"ok":true,"result":{}}'
+    ;;
+esac
+SH
+  chmod +x "$BIN/orca"
+  : > "$WORLD/orca.log"
+}
+
+# 建一个 orchestration worker：worktree + 分支 + 上游 + 可选 METADATA。
+make_worker() {
+  BRANCH="$1"
+  SESSION="$2"
+  WT="$WORLD/wt-$SESSION"
+  git -C "$PROJECT" worktree add -q -b "$BRANCH" "$WT"
+  printf 'worker change\n' > "$WT/worker.txt"
+  git -C "$WT" add worker.txt
+  git -C "$WT" commit -q -m "worker work"
+  git -C "$WT" push -q -u origin "$BRANCH"
+  TIP=$(git -C "$PROJECT" rev-parse "refs/heads/$BRANCH")
+}
+
+write_metadata() {
+  mkdir -p "$WT/.claude/agent-sessions/$SESSION"
+  cat > "$WT/.claude/agent-sessions/$SESSION/METADATA.json"
+}
+
+set_merged_pr() {
+  local oid="$1" number="${2:-27}"
+  printf '[{"number":%s,"url":"https://github.invalid/o/r/pull/%s","state":"MERGED","headRefName":"%s","headRefOid":"%s"}]\n' \
+    "$number" "$number" "$BRANCH" "$oid" > "$WORLD/gh-merged.json"
+}
+
+# run_helper [extra args...] — 每个用例内自选 execute/dry-run；rc 落在 HELPER_RC。
+run_helper() {
+  set +e
+  (
+    cd "$PROJECT" && \
+    ORCA_CLI_COMMAND="${ORCA_CLI_CMD:-}" \
+    FAKE_GH_LOG="$WORLD/gh.log" \
+    FAKE_GH_MERGED_FILE="$WORLD/gh-merged.json" \
+    FAKE_GH_OPEN_FILE="$WORLD/gh-open.json" \
+    FAKE_GH_MERGED_FAIL="${FAKE_GH_MERGED_FAIL:-0}" \
+    FAKE_GH_OPEN_FAIL="${FAKE_GH_OPEN_FAIL:-0}" \
+    FAKE_TMUX_ALIVE="${FAKE_TMUX_ALIVE:-0}" \
+    FAKE_TMUX_LOG="$WORLD/tmux.log" \
+    FAKE_TMUX_DEAD="$WORLD/tmux-dead" \
+    FAKE_GIT_LOG="$WORLD/git.log" \
+    FAKE_GIT_PUSH_DELETE_MODE="${FAKE_GIT_PUSH_DELETE_MODE:-passthrough}" \
+    FAKE_ORCA_LOG="$WORLD/orca.log" \
+    FAKE_ORCA_TERMINAL_STATE="${FAKE_ORCA_TERMINAL_STATE:-released}" \
+    FAKE_ORCA_DISPATCH="${FAKE_ORCA_DISPATCH:-ctx-1}" \
+    PATH="$BIN:$PATH" \
+    bash "$HELPER" --project "$PROJECT" --branch "$BRANCH" --session "$SESSION" "$@"
+  ) > "$OUT" 2> "$ERR"
+  HELPER_RC=$?
+  set -e
+}
+
+echo "Case 1: dry-run plans a safe cleanup with zero side effects"
+build_world
+make_worker feat/dry-plan worker-a
+write_metadata <<JSON
+{"session":{"id":"worker-a"},"runtime":{"worker_backend":"codex","provider_lease":{"file":""}}}
+JSON
+set_merged_pr "$TIP"
+run_helper
+assert_eq "$HELPER_RC" "0" "dry-run exits 0"
+assert_contains "POST_MERGE_CLEANUP_MODE: dry-run" "$OUT" "dry-run announces mode"
+assert_contains "POST_MERGE_CLEANUP_MERGED_PR: number=27" "$OUT" "merged PR evidence surfaced"
+assert_contains "POST_MERGE_CLEANUP_DRY_RUN_DONE" "$OUT" "dry-run completion marker"
+assert_contains "remote_branch=delete" "$OUT" "plan includes remote deletion"
+[ -d "$WT" ] && ok "dry-run kept the worktree" || bad "dry-run removed the worktree"
+git -C "$PROJECT" show-ref --verify --quiet "refs/heads/$BRANCH" && ok "dry-run kept the local branch" || bad "dry-run deleted the local branch"
+git --git-dir="$REMOTE" show-ref --verify --quiet "refs/heads/$BRANCH" && ok "dry-run kept the remote branch" || bad "dry-run deleted the remote branch"
+assert_not_contains "CLEAN_WORKTREE_MODE: execute" "$OUT" "dry-run never executes clean-worktree"
+assert_not_contains "push origin --delete" "$WORLD/git.log" "dry-run never deletes the remote branch"
+
+echo "Case 2: execute cleans a merged worker and verifies zero residue"
+run_helper --execute
+assert_eq "$HELPER_RC" "0" "execute exits 0"
+assert_contains "CLEAN_WORKTREE_MODE: execute" "$OUT" "lifecycle executed via clean-worktree.sh"
+assert_contains "CLEAN_WORKTREE_BRANCH_DELETED: branch=$BRANCH" "$OUT" "local branch deleted"
+assert_contains "POST_MERGE_CLEANUP_REMOTE_DELETED: branch=$BRANCH" "$OUT" "remote branch deleted"
+assert_contains "POST_MERGE_CLEANUP_RESIDUE_VERIFIED: zero" "$OUT" "residue verification ran"
+assert_contains "POST_MERGE_CLEANUP_DONE" "$OUT" "completion marker"
+assert_contains "POST_MERGE_CLEANUP_RESULT: CLEANED" "$OUT" "result receipt"
+[ ! -d "$WT" ] && ok "worktree directory removed" || bad "worktree directory still present"
+git -C "$PROJECT" show-ref --verify --quiet "refs/heads/$BRANCH" && bad "local branch residue" || ok "local branch absent"
+assert_remote_branch_absent "$BRANCH"
+
+echo "Case 3: supervised released dispatch is released first, then cleaned"
+build_world
+make_worker feat/supervised worker-s
+write_metadata <<JSON
+{"session":{"id":"worker-s","orca":{"worktree_id":"repo::wt1","terminal_handle":"term-x","mode":"orca","supervised":{"dispatch_id":"ctx-1"}}},"runtime":{"worker_backend":"codex","provider_lease":{"file":""}}}
+JSON
+set_merged_pr "$TIP"
+ORCA_CLI_CMD="$BIN/orca" FAKE_TMUX_ALIVE=1 run_helper
+assert_eq "$HELPER_RC" "0" "supervised dry-run exits 0"
+if grep -q 'orchestration worker-release' "$WORLD/orca.log"; then bad "dry-run released a worker (mutation in dry-run)"; else ok "dry-run never releases the worker"; fi
+assert_contains "terminal=released" "$OUT" "released accounting surfaced in dry-run"
+: > "$WORLD/orca.log"
+: > "$WORLD/tmux.log"
+rm -f "$WORLD/tmux-dead"
+ORCA_CLI_CMD="$BIN/orca" FAKE_TMUX_ALIVE=1 run_helper --execute
+assert_eq "$HELPER_RC" "0" "supervised execute exits 0"
+assert_contains "orchestration worker-release" "$WORLD/orca.log" "worker released before filesystem cleanup"
+release_line=$(grep -n 'orchestration worker-release' "$WORLD/orca.log" | head -1 | cut -d: -f1)
+rm_line=$(grep -n '^worktree rm' "$WORLD/orca.log" | head -1 | cut -d: -f1)
+if [ -n "$rm_line" ] && [ "$release_line" -lt "$rm_line" ]; then ok "release happens before worktree rm"; else bad "release ordering broken (release=$release_line rm=$rm_line)"; fi
+assert_contains "kill-session" "$WORLD/tmux.log" "tmux session killed after accounting released"
+assert_contains "POST_MERGE_CLEANUP_DONE" "$OUT" "supervised cleanup completed"
+[ ! -d "$WT" ] && ok "supervised worktree removed" || bad "supervised worktree still present"
+assert_remote_branch_absent "$BRANCH"
+
+echo "Case 4: an open stacked child PR blocks deletion"
+build_world
+make_worker feat/stacked-base worker-c
+write_metadata <<JSON
+{"session":{"id":"worker-c"},"runtime":{"provider_lease":{"file":""}}}
+JSON
+set_merged_pr "$TIP"
+printf '[{"number":31,"url":"https://github.invalid/o/r/pull/31","state":"OPEN","headRefName":"feat/stacked-child","headRefOid":"%s"}]\n' "$TIP" > "$WORLD/gh-open.json"
+run_helper --execute
+assert_eq "$HELPER_RC" "2" "open child PR defers cleanup"
+assert_contains "POST_MERGE_CLEANUP_DEFERRED: reason=open_child_pr" "$ERR" "child PR deferred reason"
+[ -d "$WT" ] && ok "worktree untouched by deferred cleanup" || bad "worktree removed despite child PR"
+git -C "$PROJECT" show-ref --verify --quiet "refs/heads/$BRANCH" && ok "local branch kept" || bad "local branch deleted despite child PR"
+git --git-dir="$REMOTE" show-ref --verify --quiet "refs/heads/$BRANCH" && ok "remote branch kept" || bad "remote branch deleted despite child PR"
+
+echo "Case 5: default and long-lived integration branches are never deleted"
+build_world
+BRANCH=main
+SESSION=worker-m
+run_helper --execute
+assert_eq "$HELPER_RC" "2" "main branch defers cleanup"
+assert_contains "reason=protected_branch" "$ERR" "main protected reason"
+git -C "$PROJECT" show-ref --verify --quiet refs/heads/main && ok "main survived" || bad "main deleted"
+
+build_world
+make_worker bl-main worker-l
+set_merged_pr "$TIP"
+run_helper --execute --protected-branch 'bl-*'
+assert_eq "$HELPER_RC" "2" "pattern-protected long-lived branch defers cleanup"
+assert_contains "matches protected pattern=bl-*" "$ERR" "protected pattern surfaced"
+
+build_world
+make_worker feat/self worker-b2
+set_merged_pr "$TIP"
+run_helper --execute --base feat/self
+assert_eq "$HELPER_RC" "2" "branch equal to base ref defers cleanup"
+assert_contains "reason=protected_branch" "$ERR" "base-ref protected reason"
+
+echo "Case 6: a dirty worktree blocks cleanup and keeps every artifact"
+build_world
+make_worker feat/dirty worker-d
+write_metadata <<JSON
+{"session":{"id":"worker-d"},"runtime":{"provider_lease":{"file":""}}}
+JSON
+set_merged_pr "$TIP"
+printf 'uncommitted\n' > "$WT/worker.txt"
+run_helper --execute
+assert_eq "$HELPER_RC" "2" "dirty worktree defers cleanup"
+assert_contains "reason=dirty_worktree" "$ERR" "dirty deferred reason"
+[ -d "$WT" ] && ok "dirty worktree kept" || bad "dirty worktree removed"
+[ "$(git -C "$WT" status --porcelain | wc -l | tr -d ' ')" != "0" ] && ok "uncommitted work preserved" || bad "uncommitted work lost"
+git --git-dir="$REMOTE" show-ref --verify --quiet "refs/heads/$BRANCH" && ok "remote branch kept for dirty case" || bad "remote branch deleted for dirty case"
+
+echo "Case 7: active and release_pending accounting refuse filesystem cleanup"
+build_world
+make_worker feat/active worker-p
+write_metadata <<JSON
+{"session":{"id":"worker-p","orca":{"worktree_id":"repo::wt2","terminal_handle":"term-y","supervised":{"dispatch_id":"ctx-1"}}},"runtime":{"provider_lease":{"file":""}}}
+JSON
+set_merged_pr "$TIP"
+ORCA_CLI_CMD="$BIN/orca" FAKE_ORCA_TERMINAL_STATE=active run_helper --execute
+assert_eq "$HELPER_RC" "2" "active terminal accounting defers cleanup"
+assert_contains "reason=terminal_accounting_active" "$ERR" "active deferred reason"
+if grep -q 'orchestration worker-release' "$WORLD/orca.log"; then bad "active worker was released"; else ok "active worker not released"; fi
+[ -d "$WT" ] && ok "active worker worktree kept" || bad "active worker worktree removed"
+
+build_world
+make_worker feat/pending worker-q
+write_metadata <<JSON
+{"session":{"id":"worker-q","orca":{"worktree_id":"repo::wt3","terminal_handle":"term-z","supervised":{"dispatch_id":"ctx-2"}}},"runtime":{"provider_lease":{"file":""}}}
+JSON
+set_merged_pr "$TIP"
+ORCA_CLI_CMD="$BIN/orca" FAKE_ORCA_DISPATCH=ctx-2 FAKE_ORCA_TERMINAL_STATE=release_pending run_helper --execute
+assert_eq "$HELPER_RC" "2" "release_pending accounting defers cleanup"
+assert_contains "reason=terminal_accounting_release_pending" "$ERR" "release_pending deferred reason"
+[ -d "$WT" ] && ok "release_pending worktree kept" || bad "release_pending worktree removed"
+
+echo "Case 8: a failed remote deletion is never reported as completion"
+build_world
+make_worker feat/pushfail worker-f
+write_metadata <<JSON
+{"session":{"id":"worker-f"},"runtime":{"provider_lease":{"file":""}}}
+JSON
+set_merged_pr "$TIP"
+FAKE_GIT_PUSH_DELETE_MODE=fail run_helper --execute
+assert_eq "$HELPER_RC" "9" "remote delete failure exits 9"
+assert_contains "POST_MERGE_CLEANUP_REMOTE_DELETE_FAILED" "$ERR" "remote failure surfaced"
+assert_not_contains "POST_MERGE_CLEANUP_DONE" "$OUT" "no completion marker after remote failure"
+git -C "$PROJECT" show-ref --verify --quiet "refs/heads/$BRANCH" && bad "local branch unexpectedly kept" || ok "local branch deletion acknowledged as partial state"
+git --git-dir="$REMOTE" show-ref --verify --quiet "refs/heads/$BRANCH" && ok "remote branch still present after failed delete" || bad "remote branch vanished without success receipt"
+
+echo "Case 9: residue verification catches a push that lies about deletion"
+build_world
+make_worker feat/liar worker-r
+write_metadata <<JSON
+{"session":{"id":"worker-r"},"runtime":{"provider_lease":{"file":""}}}
+JSON
+set_merged_pr "$TIP"
+FAKE_GIT_PUSH_DELETE_MODE=lie run_helper --execute
+assert_eq "$HELPER_RC" "9" "lying push is caught by residue verification"
+assert_contains "POST_MERGE_CLEANUP_RESIDUE: kind=remote_branch" "$ERR" "remote residue reported"
+assert_not_contains "POST_MERGE_CLEANUP_DONE" "$OUT" "no completion marker with residue"
+git --git-dir="$REMOTE" show-ref --verify --quiet "refs/heads/$BRANCH" && ok "remote branch honestly still present" || bad "remote branch state changed under lie mode"
+
+echo "Case 10: no MERGED evidence keeps the branch (24h rule protection)"
+build_world
+make_worker feat/fresh worker-n
+write_metadata <<JSON
+{"session":{"id":"worker-n"},"runtime":{"provider_lease":{"file":""}}}
+JSON
+run_helper --execute
+assert_eq "$HELPER_RC" "2" "missing MERGED evidence defers cleanup"
+assert_contains "reason=no_merged_pr_evidence" "$ERR" "no-evidence deferred reason"
+git --git-dir="$REMOTE" show-ref --verify --quiet "refs/heads/$BRANCH" && ok "unmerged young branch kept" || bad "unmerged young branch deleted"
+
+echo "Case 11: a branch tip that drifted from the merged PR head is never cleaned"
+build_world
+make_worker feat/drifted worker-h
+write_metadata <<JSON
+{"session":{"id":"worker-h"},"runtime":{"provider_lease":{"file":""}}}
+JSON
+set_merged_pr "0000000000000000000000000000000000000000"
+run_helper --execute
+assert_eq "$HELPER_RC" "2" "head mismatch defers cleanup"
+assert_contains "reason=head_mismatch" "$ERR" "head mismatch deferred reason"
+git -C "$PROJECT" show-ref --verify --quiet "refs/heads/$BRANCH" && ok "drifted branch kept" || bad "drifted branch deleted"
+
+echo "Case 12: a worktree without session METADATA has uncertain identity"
+build_world
+make_worker feat/nometa worker-x
+set_merged_pr "$TIP"
+run_helper --execute
+assert_eq "$HELPER_RC" "2" "missing METADATA defers cleanup"
+assert_contains "reason=session_metadata_missing" "$ERR" "metadata deferred reason"
+[ -d "$WT" ] && ok "worktree kept without METADATA" || bad "worktree removed without METADATA"
+
+echo "Case 13: an alive tmux session without supervised dispatch blocks cleanup"
+build_world
+make_worker feat/livetmux worker-t
+write_metadata <<JSON
+{"session":{"id":"worker-t"},"runtime":{"provider_lease":{"file":""}}}
+JSON
+set_merged_pr "$TIP"
+FAKE_TMUX_ALIVE=1 run_helper --execute
+assert_eq "$HELPER_RC" "2" "alive unaccounted tmux session defers cleanup"
+assert_contains "reason=tmux_session_alive_unaccounted" "$ERR" "tmux deferred reason"
+assert_not_contains "CLEAN_WORKTREE_MODE: execute" "$OUT" "clean-worktree never executed behind tmux gate"
+[ -d "$WT" ] && ok "worktree kept behind tmux gate" || bad "worktree removed behind tmux gate"
+
+echo "Case 14: squash-merged branches escalate from refused -d to evidence-backed -D"
+build_world
+BRANCH=feat/squashed
+SESSION=worker-sq
+git -C "$PROJECT" checkout -q -b "$BRANCH"
+printf 'squash content\n' > "$PROJECT/worker.txt"
+git -C "$PROJECT" add worker.txt
+git -C "$PROJECT" commit -q -m "worker work"
+git -C "$PROJECT" push -q -u origin "$BRANCH"
+TIP=$(git -C "$PROJECT" rev-parse "refs/heads/$BRANCH")
+git -C "$PROJECT" push -q origin --delete "$BRANCH"
+git -C "$PROJECT" fetch -q --prune origin
+git -C "$PROJECT" checkout -q main
+printf 'squash content\n' > "$PROJECT/worker.txt"
+git -C "$PROJECT" add worker.txt
+git -C "$PROJECT" commit -q -m "worker work (#27)"
+git -C "$PROJECT" push -q origin main
+set_merged_pr "$TIP"
+WT=""
+run_helper --execute
+assert_eq "$HELPER_RC" "0" "squash-merged branch cleanup exits 0"
+assert_contains "CLEAN_WORKTREE_BRANCH_FORCE_DELETED" "$OUT" "evidence-backed -D escalation recorded"
+assert_contains "POST_MERGE_CLEANUP_REMOTE_ALREADY_ABSENT: branch=$BRANCH" "$OUT" "absent remote handled idempotently"
+assert_contains "POST_MERGE_CLEANUP_DONE" "$OUT" "squash cleanup completed"
+git -C "$PROJECT" show-ref --verify --quiet "refs/heads/$BRANCH" && bad "squashed branch residue" || ok "squashed branch deleted"
+
+echo "Case 15: gh evidence failures fail closed on both queries"
+build_world
+make_worker feat/ghfail worker-g
+write_metadata <<JSON
+{"session":{"id":"worker-g"},"runtime":{"provider_lease":{"file":""}}}
+JSON
+FAKE_GH_MERGED_FAIL=1 run_helper --execute
+assert_eq "$HELPER_RC" "2" "merged-query failure defers cleanup"
+assert_contains "reason=pr_evidence_unavailable" "$ERR" "merged-query deferred reason"
+set_merged_pr "$TIP"
+FAKE_GH_OPEN_FAIL=1 run_helper --execute
+assert_eq "$HELPER_RC" "2" "open-query failure defers cleanup"
+assert_contains "reason=child_pr_query_unavailable" "$ERR" "open-query deferred reason"
+git -C "$PROJECT" show-ref --verify --quiet "refs/heads/$BRANCH" && ok "branch kept through gh failures" || bad "branch deleted through gh failures"
+
+echo "Case 16: usage errors exit 64"
+build_world
+make_worker feat/usage worker-u
+set_merged_pr "$TIP"
+run_helper --nonsense
+assert_eq "$HELPER_RC" "64" "unknown argument exits 64"
+
+echo ""
+echo "post-merge-cleanup tests: $passed passed, $failed failed"
+[ "$failed" -eq 0 ]


### PR DESCRIPTION
## 摘要

- 新增 fail-closed 的单任务合并后即时清理门禁：`git-workflow` 提供删除资格真值，`multi-agent-orchestration` 负责 terminal/lease/worktree/本地与远端短分支的生命周期执行。
- 新增确定性专项测试，覆盖安全即时清理、open child、长期分支、dirty、active/release-pending、远端失败、dry-run 与零残留验证。

## 测试计划

- `bash skills/multi-agent-orchestration/scripts/test-post-merge-cleanup.sh`：16 场景，87/87 断言通过，多轮复跑。
- `bash skills/multi-agent-orchestration/scripts/test-pm-closeout.sh`：118/118 回归通过，多轮复跑。
- `git diff --check origin/main...HEAD`：通过。
- 真实 GitHub 端到端删除保持 `NOT_VERIFIED`，由独立 reviewer 在隔离 fixture/模拟远端失败基础上复核。

## Agent 归属

- 实现：GLM 5.3 Flash Worker `task_13921534dabc` / `ctx_05b219de806a`。
- PM 仅在 Worker 因 Shell allowlist 漏配完成失败后执行经身份门禁的 safe-push 与 PR 创建；未修改实现内容。

## 关联任务

- Badminton Lab 合并后分支与 Worktree 即时清理门禁。
- Multi-Agent Orchestration Task-103 收口路径。

## 风险与回退

- 只有唯一 `MERGED` PR、精确 head、无 open child、干净 worktree 且 Worker 生命周期已结算时才允许删除；任一事实未知均保留现场并输出 deferred 原因。
- 回退方式为 revert 本 PR；不会恢复此前已经由门禁确认并删除的远端短分支。
