### PR TITLE
fix(multi-agent-orchestration): 加固 reauthorize 与 spawn 既有 Worktree 预门禁

### DIFF
--- a/skills/multi-agent-orchestration/scripts/pm-orchestrate.sh
+++ b/skills/multi-agent-orchestration/scripts/pm-orchestrate.sh
@@ -46,6 +46,11 @@ Commands:
                注册返回 TASK_REUSED 时不再误判为仍 dispatched：先复核状态，确认仍是
                failed/settled 才复位 ready 并只重试一次注册；复核翻回 dispatched（漂移）
                或 unknown/其他状态一律回滚新终端 fail-closed 不复位。
+               (Task-116) 任何 mutation 之前先读权威 Dispatch 状态（worker-show）：仅
+               未 released/acked/settled 的 live 目标可继续；已进入结算链或状态不可证
+               的目标稳定输出 REAUTHORIZE_NOT_LIVE，零副作用（授权文件/launch.sh/
+               终端/METADATA 均不变）。已结算目标的恢复走 release/ack 正常收口或
+               quota-park/明确恢复入口。
   quota-park  Quota-stall recovery handoff (v2.11.0 P0-③)：精确 fence + stop 旧
                supervised Dispatch（worker-stop），完整保留 worktree/session/checkpoint，
                释放 METADATA 记录的 provider lease，之后同 worktree 可用新 session id
@@ -871,6 +876,46 @@ reauthorize_rollback_new_terminal() {
   fi
 }
 
+# Task-116（Badminton Lab 实测事故①）：reauthorize liveness 预门禁。
+# 旧 Dispatch 已 worker_done → release → ack → settled 后，METADATA 残留的 dispatch_id
+# 会让本命令把死目标当 live：先合并授权、重写 launch.sh B64、创建替换终端，直到注册
+# 阶段才发现目标已结算并回滚——授权/终端副作用全部白做。本预门禁在任何 mutation
+# （包括 ensure_coordinator_binding 的 run-use/METADATA 改写）之前读取权威 Dispatch
+# 状态（worker-show）：只有调用可达、Dispatch 记录仍存在、且未进入结算链
+# （terminalResource.releaseState 仍是 not_requested/缺省）的 live 目标才允许继续；
+# released/released_retained/settled、记录缺失、调用失败等其余一切状态一律输出稳定
+# 机器码 REAUTHORIZE_NOT_LIVE 并零副作用退出（fail-closed）。已有 Worktree/Task 的
+# 恢复必须走 reauthorize（仅限 live 目标）/quota-park/明确恢复入口，不在死目标上做副作用。
+reauthorize_liveness_pregate() {
+  local show_json show_rc release_state dispatch_status
+  set +e
+  show_json=$(orca_cli orchestration worker-show --dispatch "$ORCA_DISPATCH_ID" --json 2>&1)
+  show_rc=$?
+  set -e
+  if [ "$show_rc" -ne 0 ]; then
+    echo "REAUTHORIZE_NOT_LIVE: worker-show 不可达（rc=${show_rc}），无法证明 Dispatch 仍 live；未知状态 fail-closed，未做任何变更" >&2
+    exit 2
+  fi
+  if [ -z "$(printf '%s' "$show_json" | jq -r '.result.dispatch.id // empty' 2>/dev/null)" ]; then
+    echo "REAUTHORIZE_NOT_LIVE: worker-show 无 Dispatch 记录（已 GC 或契约不完整），无法证明仍 live；零副作用拒绝" >&2
+    exit 2
+  fi
+  release_state=$(printf '%s' "$show_json" | jq -r '.result.terminalResource.releaseState // .result.terminal_resource.releaseState // empty' 2>/dev/null)
+  dispatch_status=$(printf '%s' "$show_json" | jq -r '.result.dispatch.status // empty' 2>/dev/null)
+  case "$release_state" in
+    ""|null|"not_requested") ;;
+    *)
+      echo "REAUTHORIZE_NOT_LIVE: Dispatch 已进入结算链（releaseState=${release_state}），worker_done 已被 release/ack/settled；请按正常收口处理或走明确恢复入口，reauthorize 零副作用拒绝" >&2
+      exit 2
+      ;;
+  esac
+  if [ "$dispatch_status" = "settled" ]; then
+    echo "REAUTHORIZE_NOT_LIVE: Dispatch status=settled（worker_done 已结算），reauthorize 零副作用拒绝" >&2
+    exit 2
+  fi
+  echo "PM_REAUTHORIZE_LIVENESS_OK: dispatch=$ORCA_DISPATCH_ID releaseState=${release_state:-not_requested} status=${dispatch_status:-unknown}"
+}
+
 cmd_reauthorize() {
   # Task-058: spawn 授权快照的运行时刷新。guard 的 load_authorization() 中
   # WORKER_INSTALL_AUTH_B64（launch.sh 内联、进程环境）绝对优先于授权文件且
@@ -901,6 +946,9 @@ cmd_reauthorize() {
   local launch_sh="$SESSION_CONTEXT/launch.sh"
   [ -f "$auth_file" ] || { echo "ERROR: authorization file not found: $auth_file" >&2; exit 64; }
   [ -f "$launch_sh" ] || { echo "ERROR: launch.sh not found: $launch_sh" >&2; exit 64; }
+  # Task-116：任何 mutation（run-use/METADATA 改写、授权合并、B64 重写、新终端）之前
+  # 先证明目标 Dispatch 仍 live；settled/released/acked/未知一律 REAUTHORIZE_NOT_LIVE。
+  reauthorize_liveness_pregate
   ensure_coordinator_binding || exit 2
 
   # Step 0 (Task-081)：dispatched 等待态探测与消费。仅 dispatched 分支有额外动作；

--- a/skills/multi-agent-orchestration/scripts/spawn-worker-orca.sh
+++ b/skills/multi-agent-orchestration/scripts/spawn-worker-orca.sh
@@ -230,6 +230,72 @@ orca_worktree_create() {
   printf '%s\n' "$worktree_id"
 }
 
+# Task-116（Badminton Lab 实测事故②）：既有 Worktree 预门禁（仅 ORCA auto 模式）。
+# PM 请求一个已存在的精确 worktree 路径/branch 时，Orca worktree create 发现 name/branch
+# 被占会自动改用 -2/-3 后缀新建；旧顺序里 isolation pre-gate 要等 worktree 落盘后才拒绝，
+# 留下必须人工清理的无价值残留。本门禁在任何 provider lease / Orca worktree create /
+# Session Context / terminal / dispatch 副作用之前机械判定，命中即稳定输出
+# EXISTING_WORKTREE_REQUIRES_RECOVERY 并 exit 3（fail-closed）：
+#   ① exact branch 已被同 repo worktree 占用（checked out）；
+#   ② exact branch 本地 ref 已存在（Orca create 将生成 -2 后缀）；
+#   ③ exact --worktree 路径已存在：同仓 worktree/错仓/脏工作区/非 git 目录
+#      （未知状态）一律拒绝。
+# 已有 Worktree 的恢复必须走 reauthorize/quota-park/明确恢复入口；本 skill 不做
+# 自动复用。仅命中 ORCA auto：tmux 路径的既有复用/报错语义保持不变；
+# 路径不存在的新建流程零变化。origin-only 同名 ref 不在本门禁范围（无法证明
+# Orca 一定会后缀化），由 worktree 落盘后的 isolation pre-gate 兜底。
+spawn_worker_existing_worktree_pregate() {
+  [ "$ORCA_MODE" = "auto" ] || return 0
+  [ "$LIGHTWEIGHT_MODE" -eq 0 ] || return 0
+  local gate_branch="$safe_branch" occupied_wt wt_common project_common dirty_count
+  if [ -z "$gate_branch" ]; then
+    echo "EXISTING_WORKTREE_REQUIRES_RECOVERY: worktree 模式下 branch 为空，无法证明新建不与既有 Worktree 冲突（fail-closed）" >&2
+    exit 3
+  fi
+  if git -C "$PROJECT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    occupied_wt=$(git -C "$PROJECT_DIR" worktree list --porcelain 2>/dev/null | awk -v target="refs/heads/$gate_branch" '
+      /^worktree / { wt = substr($0, 10) }
+      /^branch / { if (substr($0, 8) == target) { print wt; exit } }
+    ') || occupied_wt=""
+    if [ -n "$occupied_wt" ]; then
+      echo "EXISTING_WORKTREE_REQUIRES_RECOVERY: branch ${gate_branch} 已被同 repo worktree 占用: ${occupied_wt}；已有 Worktree 的恢复必须走 reauthorize/quota-park/明确恢复入口，spawn 不自动复用（fail-closed）" >&2
+      exit 3
+    fi
+  fi
+  if git -C "$PROJECT_DIR" show-ref --verify --quiet "refs/heads/$gate_branch" 2>/dev/null; then
+    echo "EXISTING_WORKTREE_REQUIRES_RECOVERY: branch ${gate_branch} 已存在于本仓，Orca worktree create 将自动生成 -2 后缀 worktree；请改用新分支或走 reauthorize/quota-park/明确恢复入口（fail-closed）" >&2
+    exit 3
+  fi
+  if [ -e "$WORKTREE" ]; then
+    wt_common=$(git -C "$WORKTREE" rev-parse --git-common-dir 2>/dev/null) || wt_common=""
+    if [ -n "$wt_common" ]; then
+      case "$wt_common" in
+        /*) ;;
+        *) wt_common="$WORKTREE/$wt_common" ;;
+      esac
+      wt_common=$(cd "$wt_common" 2>/dev/null && pwd -P) || wt_common=""
+    fi
+    project_common=$(git -C "$PROJECT_DIR" rev-parse --git-common-dir 2>/dev/null) || project_common=""
+    if [ -n "$project_common" ]; then
+      case "$project_common" in
+        /*) ;;
+        *) project_common="$PROJECT_DIR/$project_common" ;;
+      esac
+      project_common=$(cd "$project_common" 2>/dev/null && pwd -P) || project_common=""
+    fi
+    if [ -n "$wt_common" ] && [ -n "$project_common" ] && [ "$wt_common" = "$project_common" ]; then
+      dirty_count=$(git -C "$WORKTREE" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+      echo "EXISTING_WORKTREE_REQUIRES_RECOVERY: exact worktree 路径已被同 repo worktree 占用: ${WORKTREE}（dirty=${dirty_count}）；已有 Worktree 的恢复必须走 reauthorize/quota-park/明确恢复入口，spawn 不自动复用（fail-closed）" >&2
+    elif [ -n "$wt_common" ]; then
+      echo "EXISTING_WORKTREE_REQUIRES_RECOVERY: exact worktree 路径已存在且属于另一个仓库（错仓）: ${WORKTREE}；拒绝在未知归属路径上做任何 spawn 副作用（fail-closed）" >&2
+    else
+      echo "EXISTING_WORKTREE_REQUIRES_RECOVERY: exact worktree 路径已存在但无法证明是可安全新建的空位（非 git worktree/未知状态）: ${WORKTREE}（fail-closed）" >&2
+    fi
+    exit 3
+  fi
+  echo "SPAWN_WORKER_EXISTING_WORKTREE_PREGATE: branch=${gate_branch} path=${WORKTREE}（未被占用，新建流程放行）"
+}
+
 # ORCA terminal create + tui-idle wait helper。只有非 supervised 模式才发送普通 prompt；
 # supervised 模式由 worker-start 注入唯一的生命周期 preamble + TASK，禁止双重投递。
 # 输入：worktree id、title、worker command。

--- a/skills/multi-agent-orchestration/scripts/spawn-worker.sh
+++ b/skills/multi-agent-orchestration/scripts/spawn-worker.sh
@@ -369,6 +369,45 @@ route_suggest_autofill_provider
 # 的 env 由 PM 的 runtime profile 负责，不重复注入）。
 route_suggest_wrap_command
 
+# shellcheck source=spawn-worker-orca.sh
+source "$SCRIPT_DIR/spawn-worker-orca.sh"
+
+# v2.1（DEC-114）：ORCA 终端模式 auto-detect。必须在 detect_orca_mode / orca_worktree_create /
+# orca_terminal_create_and_send 三个 helper 定义之后调用（bash 函数先定义后调用）。
+# v2.16.0（Task-116）：整块检测提前到 quota preflight / provider lease 之前——既有
+# Worktree 预门禁（EXISTING_WORKTREE_REQUIRES_RECOVERY）必须在任何 provider lease /
+# Orca worktree create / Session Context / terminal / dispatch 副作用之前判定，
+# 而 detect_orca_mode 的 runtime 事实是门禁只命中 ORCA auto 模式的前提。
+# 命中 auto 时：
+#   - ORCA_MODE=auto
+#   - ORCA_WORKTREE_PATH = PROJECT_DIR 的 git toplevel
+#   - ORCA_WORKTREE_ID 待 orca_worktree_create() 填充（worktree 创建阶段）
+#   - ORCA_TERMINAL_HANDLE 待 orca_terminal_create_and_send() 填充（tmux 启动阶段）
+#   - ORCA_APP_VERSION / ORCA_CAPABILITIES_JSON 已从 `orca status --json` 抓取
+detect_orca_mode  # 直接调，设全局 ORCA_MODE + ORCA_APP_VERSION/CAPABILITIES_JSON/WORKTREE_PATH（不用 $() 子 shell）
+if [ "$ORCA_MODE" = "missing_orca" ]; then
+  exit 64
+fi
+if [ "$ORCA_SUPERVISED" -eq 1 ]; then
+  [ -n "$TASK_SPEC" ] || [ -n "$ORCA_TASK_ID" ] || { echo "ERROR: --orca-supervised requires --task-spec or --orca-task-id" >&2; exit 64; }
+  [ -z "$ORCA_TASK_ID" ] || [ -n "$ORCA_RUN_ID" ] || { echo "ERROR: --orca-task-id requires --orca-run-id" >&2; exit 64; }
+  [ -z "$ORCA_TASK_ID" ] || [ -n "$ORCA_COORDINATOR_HANDLE" ] || { echo "ERROR: --orca-task-id requires --orca-coordinator-handle from the Wave receipt" >&2; exit 64; }
+  [ "$ORCA_MODE" = "auto" ] || { echo "ERROR: --orca-supervised requires a current Orca-managed project" >&2; exit 64; }
+  has_orchestration=$(printf '%s' "$ORCA_CAPABILITIES_JSON" | jq -r 'any(. == "orchestration.contract.v1")' 2>/dev/null)
+  [ "$has_orchestration" = "true" ] || { echo "ERROR: Orca runtime lacks orchestration.contract.v1" >&2; exit 64; }
+fi
+if [ "$ORCA_MODE" != "auto" ] && ! command -v tmux >/dev/null 2>&1; then
+  echo "ERROR: tmux is required outside Orca terminal mode" >&2
+  exit 64
+fi
+
+# Task-116（Badminton Lab 实测事故②）：既有 Worktree 预门禁。exact branch/路径已被
+# 同 repo worktree 占用（或本地分支已存在，Orca 将生成 -2 后缀）时，在任何 provider
+# lease / Orca worktree create / Session Context / terminal / dispatch 之前稳定拒绝
+# （exit 3 + EXISTING_WORKTREE_REQUIRES_RECOVERY，零副作用）；路径不存在的新建流程
+# 零变化。仅命中 ORCA auto 模式，tmux 路径语义不变。
+spawn_worker_existing_worktree_pregate
+
 # v2.11.0（P0-①，2026-09 复盘修复）：配额预检门。自动补选与显式 --api-provider
 # 一律在任何 worktree/terminal/lease/dispatch 副作用之前通过 quota_preflight.py；
 # summary 缺失/不可读/过期/低于判停线/provider-lane 不匹配/claude-code 未解析出
@@ -486,34 +525,6 @@ array_to_json() {
     printf '%s\n' "$@" | jq -R . | jq -s .
   fi
 }
-
-# shellcheck source=spawn-worker-orca.sh
-source "$SCRIPT_DIR/spawn-worker-orca.sh"
-
-# v2.1（DEC-114）：ORCA 终端模式 auto-detect。必须在 detect_orca_mode / orca_worktree_create /
-# orca_terminal_create_and_send 三个 helper 定义之后调用（bash 函数先定义后调用）。
-# 命中 auto 时：
-#   - ORCA_MODE=auto
-#   - ORCA_WORKTREE_PATH = PROJECT_DIR 的 git toplevel
-#   - ORCA_WORKTREE_ID 待 orca_worktree_create() 填充（worktree 创建阶段）
-#   - ORCA_TERMINAL_HANDLE 待 orca_terminal_create_and_send() 填充（tmux 启动阶段）
-#   - ORCA_APP_VERSION / ORCA_CAPABILITIES_JSON 已从 `orca status --json` 抓取
-detect_orca_mode  # 直接调，设全局 ORCA_MODE + ORCA_APP_VERSION/CAPABILITIES_JSON/WORKTREE_PATH（不用 $() 子 shell）
-if [ "$ORCA_MODE" = "missing_orca" ]; then
-  exit 64
-fi
-if [ "$ORCA_SUPERVISED" -eq 1 ]; then
-  [ -n "$TASK_SPEC" ] || [ -n "$ORCA_TASK_ID" ] || { echo "ERROR: --orca-supervised requires --task-spec or --orca-task-id" >&2; exit 64; }
-  [ -z "$ORCA_TASK_ID" ] || [ -n "$ORCA_RUN_ID" ] || { echo "ERROR: --orca-task-id requires --orca-run-id" >&2; exit 64; }
-  [ -z "$ORCA_TASK_ID" ] || [ -n "$ORCA_COORDINATOR_HANDLE" ] || { echo "ERROR: --orca-task-id requires --orca-coordinator-handle from the Wave receipt" >&2; exit 64; }
-  [ "$ORCA_MODE" = "auto" ] || { echo "ERROR: --orca-supervised requires a current Orca-managed project" >&2; exit 64; }
-  has_orchestration=$(printf '%s' "$ORCA_CAPABILITIES_JSON" | jq -r 'any(. == "orchestration.contract.v1")' 2>/dev/null)
-  [ "$has_orchestration" = "true" ] || { echo "ERROR: Orca runtime lacks orchestration.contract.v1" >&2; exit 64; }
-fi
-if [ "$ORCA_MODE" != "auto" ] && ! command -v tmux >/dev/null 2>&1; then
-  echo "ERROR: tmux is required outside Orca terminal mode" >&2
-  exit 64
-fi
 
 # v1.18.4：backend 分支化 trust/permission dialog 监控默认值（DEC-112）。
 # 仅在 *_OVERRIDE 标志为 0 时（即用户没显式传 flag）才按 backend 默认。

--- a/skills/multi-agent-orchestration/scripts/test-pm-reauthorize.sh
+++ b/skills/multi-agent-orchestration/scripts/test-pm-reauthorize.sh
@@ -18,14 +18,22 @@
 #   H. register 其他失败：回滚新终端，旧终端保留
 #   I. 旧 runtime 无 task-list：状态探测降级 unknown，行为不比现状差
 #
-# Task-113 增补（failed/settled 结算残留的 TASK_REUSED 有界区分）：
-#   J. failed + 结算（worker_done outcome=failed、Delivery release+ack）后注册返回
-#      TASK_REUSED：复核状态一致 → 复位 ready + 只重试一次 → 恢复，零终端泄漏
-#   J2. settled 状态字串同 J 可恢复
+# Task-113 增补（TASK_REUSED 有界区分的 drift/unknown 防线，注册阶段兜底）：
 #   K. 复位后重试仍 TASK_REUSED：只重试一次，回滚新终端，旧终端保留
 #   L. 预检 failed → 复核翻回 dispatched（漂移=真单活出现）：fail-closed 不复位
 #   M. 预检 unknown + TASK_REUSED：fail-closed 不猜测不复位
-#   N. 结算恢复链重复调用：活终端数不增长
+#
+# Task-116 增补（Badminton Lab 实测事故①：旧 Dispatch 已 worker_done/release/ack/
+# settled 后，METADATA 残留 dispatch_id 让 reauthorize 把死目标当 live，先合并授权、
+# 重写 launch.sh、创建替换终端才回滚。修复：任何 mutation（含 run-use 回绑）前读权威
+# Dispatch 状态，只有仍 live（未 released/acked/settled）的目标可继续，其余稳定输出
+# REAUTHORIZE_NOT_LIVE 并零副作用）：
+#   J.  settled（结算链走完）→ 预门禁拒绝，授权/launch.sh/终端/METADATA 零变化
+#   J2. released → 同 J 拒绝
+#   N.  已结算目标重复调用 → 零副作用、不累积终端
+#   O.  acked（released_retained）→ 同 J 拒绝
+#   O2. worker-show 不可达（状态未知）→ fail-closed 零副作用拒绝
+#   O3. 已结算目标不带 --allow-cmd 的纯快照刷新 → 同样拒绝
 set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -134,6 +142,23 @@ case "$1 $2" in
         ;;
     esac
     ;;
+  "orchestration worker-show")
+    # Task-116 liveness 预门禁数据源：默认 live dispatch（dispatched + 未 release）；
+    # 状态文件把旧 Dispatch 钉进结算链的不同阶段（settled ⊃ released/acked）。
+    if [ -e "$S/worker-show-unavailable" ]; then
+      echo "ERROR: unknown command: worker-show" >&2
+      exit 1
+    fi
+    if [ -e "$S/dispatch-settled" ]; then
+      echo '{"ok":true,"result":{"dispatch":{"id":"ctx-old","status":"settled"},"worker":{"state":"succeeded"},"terminalResource":{"releaseState":"released"}}}'
+    elif [ -e "$S/dispatch-acked" ]; then
+      echo '{"ok":true,"result":{"dispatch":{"id":"ctx-old","status":"completed"},"worker":{"state":"succeeded"},"terminalResource":{"releaseState":"released_retained"}}}'
+    elif [ -e "$S/dispatch-released" ]; then
+      echo '{"ok":true,"result":{"dispatch":{"id":"ctx-old","status":"completed"},"worker":{"state":"stopped"},"terminalResource":{"releaseState":"released"}}}'
+    else
+      echo '{"ok":true,"result":{"dispatch":{"id":"ctx-old","status":"dispatched"},"worker":{"state":"active"},"terminalResource":{"releaseState":"not_requested"}}}'
+    fi
+    ;;
   "orchestration dispatch-show")
     echo '{"ok":true,"result":{"dispatch":{"id":"ctx-new-1"}}}
 '
@@ -227,7 +252,9 @@ make_fixture() {
   rm -f "$SD/terminals.live" "$SD/terminals.closed" "$SD/task-update.count" \
         "$SD/terminal-create.count" "$SD/last-reply-body.txt" "$SD/last-reply-id.txt" \
         "$SD/last-terminal-send.txt" "$SD/terminal-create-fail" "$SD/task-list-unavailable" \
-        "$SD/task-status" "$SD/task-status-next" "$SD/worker-start-result" "$SD/pending-message.json"
+        "$SD/task-status" "$SD/task-status-next" "$SD/worker-start-result" "$SD/pending-message.json" \
+        "$SD/dispatch-settled" "$SD/dispatch-released" "$SD/dispatch-acked" \
+        "$SD/worker-show-unavailable"
   printf 'term-old\n' > "$SD/terminals.live"
 }
 
@@ -363,32 +390,39 @@ check "TASK_REUSED 仍给出 manual-recovery 而非裸错误" grep -q "PM_REAUTH
 check "新终端已回滚" grep -qx "term-new-1" "$SD/terminals.closed"
 assert "旧终端保留且唯一" 'live_is_solely term-old'
 
-echo "Case J (Task-113): failed+settled 结算残留 + TASK_REUSED → 复核一致后复位 ready 重试一次恢复"
+echo "Case J (Task-116): worker_done 结算后（release+ack+settled）→ 预门禁 REAUTHORIZE_NOT_LIVE 零副作用拒绝"
 make_fixture J
 printf 'failed\n' > "$SD/task-status"
 printf 'task_reused_once\n' > "$SD/worker-start-result"
+touch "$SD/dispatch-settled"
+cp "$SC/INSTALL_AUTHORIZATION.json" "$TMP_ROOT/J-auth-before.json"
+cp "$SC/launch.sh" "$TMP_ROOT/J-launch-before.sh"
+cp "$METADATA" "$TMP_ROOT/J-metadata-before.json"
 run_reauth --allow-cmd "cmd-j" --resume-text "结算残留已复位,从断点继续"
-check "退出码 0(旧实现对结算残留必回滚失败)" test "$RC" -eq 0
-check "输出含结算残留复位标记" grep -q "PM_REAUTHORIZE_TASK_RESET" <<<"$OUT"
-check "task-list 恰好两次(预检+复核)" test "$(log_count 'orchestration task-list')" = "2"
-check "task-update 复位恰好一次" test "$(cat "$SD/task-update.count" 2>/dev/null || echo 0)" = "1"
-check "worker-start 恰好两次(拒+重试)" test "$(log_count 'orchestration worker-start')" = "2"
-check "METADATA 改路由新终端" test "$(jq -r '.session.orca.terminal_handle' "$METADATA")" = "term-new-1"
-check "METADATA 改路由新 dispatch" test "$(jq -r '.session.orca.supervised.dispatch_id' "$METADATA")" = "ctx-new-1"
-check "旧终端已关闭" grep -qx "term-old" "$SD/terminals.closed"
-assert "新终端唯一存活(零泄漏)" 'live_is_solely term-new-1'
-check "resume 文本发到新终端" grep -q "结算残留已复位" "$SD/last-terminal-send.txt"
+check "退出码非 0（已结算目标不再经由 reauthorize 复活）" test "$RC" -ne 0
+check "输出含稳定机器码 REAUTHORIZE_NOT_LIVE" grep -q "REAUTHORIZE_NOT_LIVE" <<<"$OUT"
+check_not "零授权合并：--allow-cmd 未写入授权文件" grep -q "cmd-j" "$SC/INSTALL_AUTHORIZATION.json"
+check "launch.sh B64 未被改写" cmp -s "$TMP_ROOT/J-launch-before.sh" "$SC/launch.sh"
+check_not "零新终端创建" test "$(cat "$SD/terminal-create.count" 2>/dev/null || echo 0)" != "0"
+check_not "零 worker-start 调用" grep -q "^orchestration worker-start" "$FAKE_ORCA_LOG"
+check_not "零 task-update 复位" grep -q "^orchestration task-update" "$FAKE_ORCA_LOG"
+check_not "零 reply 消费" grep -q "^orchestration reply " "$FAKE_ORCA_LOG"
+check_not "零 run-use 回绑" grep -q "^orchestration run-use" "$FAKE_ORCA_LOG"
+check "METADATA 未变（仍路由旧终端）" cmp -s "$TMP_ROOT/J-metadata-before.json" "$METADATA"
+assert "旧终端保留且唯一（零终端副作用）" 'live_is_solely term-old'
 
-echo "Case J2 (Task-113): settled 状态字串同 J 可恢复"
+echo "Case J2 (Task-116): released（release 已做、settled 未完成）同 J 拒绝"
 make_fixture J2
-printf 'settled\n' > "$SD/task-status"
+printf 'failed\n' > "$SD/task-status"
 printf 'task_reused_once\n' > "$SD/worker-start-result"
+touch "$SD/dispatch-released"
 run_reauth --allow-cmd "cmd-j2"
-check "退出码 0" test "$RC" -eq 0
-check "task-update 复位恰好一次" test "$(cat "$SD/task-update.count" 2>/dev/null || echo 0)" = "1"
-check "METADATA 改路由新终端" test "$(jq -r '.session.orca.terminal_handle' "$METADATA")" = "term-new-1"
-check "旧终端已关闭" grep -qx "term-old" "$SD/terminals.closed"
-assert "新终端唯一存活" 'live_is_solely term-new-1'
+check "退出码非 0" test "$RC" -ne 0
+check "输出含 REAUTHORIZE_NOT_LIVE" grep -q "REAUTHORIZE_NOT_LIVE" <<<"$OUT"
+check_not "零新终端创建" test "$(cat "$SD/terminal-create.count" 2>/dev/null || echo 0)" != "0"
+check_not "零 worker-start 调用" grep -q "^orchestration worker-start" "$FAKE_ORCA_LOG"
+assert "旧终端保留且唯一" 'live_is_solely term-old'
+check "METADATA 仍路由旧终端" test "$(jq -r '.session.orca.terminal_handle' "$METADATA")" = "term-old"
 
 echo "Case K (Task-113): 复位后重试仍 TASK_REUSED → 只重试一次,回滚新终端 fail-closed"
 make_fixture K
@@ -428,18 +462,56 @@ check "manual-recovery 指引仍在" grep -q "PM_REAUTHORIZE_MANUAL_RECOVERY" <<
 check "新终端已回滚关闭" grep -qx "term-new-1" "$SD/terminals.closed"
 assert "旧终端保留且唯一" 'live_is_solely term-old'
 
-echo "Case N (Task-113): 结算恢复链重复调用不累积终端"
+echo "Case N (Task-116): 已结算目标重复调用 reauthorize 零副作用、不累积终端"
 make_fixture N
 printf 'failed\n' > "$SD/task-status"
 printf 'task_reused_once\n' > "$SD/worker-start-result"
+touch "$SD/dispatch-settled"
 run_reauth --allow-cmd "cmd-n1"
-check "第一次成功" test "$RC" -eq 0
+check "第一次拒绝" test "$RC" -ne 0
 run_reauth --allow-cmd "cmd-n2"
-check "第二次成功" test "$RC" -eq 0
-assert "两次后唯一活终端是最新终端" 'live_is_solely term-new-2'
-check "term-old 已关" grep -qx "term-old" "$SD/terminals.closed"
-check "term-new-1 已关" grep -qx "term-new-1" "$SD/terminals.closed"
-check "METADATA 指向 term-new-2" test "$(jq -r '.session.orca.terminal_handle' "$METADATA")" = "term-new-2"
+check "第二次拒绝" test "$RC" -ne 0
+check "两次调用零新终端创建" test "$(cat "$SD/terminal-create.count" 2>/dev/null || echo 0)" = "0"
+assert "旧终端保留且唯一（活终端数不增长）" 'live_is_solely term-old'
+check_not "零 worker-start 调用" grep -q "^orchestration worker-start" "$FAKE_ORCA_LOG"
+check "METADATA 仍路由旧终端" test "$(jq -r '.session.orca.terminal_handle' "$METADATA")" = "term-old"
+
+echo "Case O (Task-116): acked（released_retained）同属结算链 → 拒绝"
+make_fixture O
+printf 'failed\n' > "$SD/task-status"
+printf 'task_reused_once\n' > "$SD/worker-start-result"
+touch "$SD/dispatch-acked"
+run_reauth --allow-cmd "cmd-o"
+check "退出码非 0" test "$RC" -ne 0
+check "输出含 REAUTHORIZE_NOT_LIVE" grep -q "REAUTHORIZE_NOT_LIVE" <<<"$OUT"
+check_not "零新终端创建" test "$(cat "$SD/terminal-create.count" 2>/dev/null || echo 0)" != "0"
+assert "旧终端保留且唯一" 'live_is_solely term-old'
+
+echo "Case O2 (Task-116): worker-show 不可达（状态未知）→ fail-closed 零副作用拒绝"
+make_fixture O2
+printf 'dispatched\n' > "$SD/task-status"
+printf 'TASK_REUSED\n' > "$SD/worker-start-result"
+touch "$SD/worker-show-unavailable"
+run_reauth --allow-cmd "cmd-o2"
+check "退出码非 0（未知状态不得带副作用推进）" test "$RC" -ne 0
+check "输出含 REAUTHORIZE_NOT_LIVE" grep -q "REAUTHORIZE_NOT_LIVE" <<<"$OUT"
+check_not "零授权合并" grep -q "cmd-o2" "$SC/INSTALL_AUTHORIZATION.json"
+check_not "零新终端创建" test "$(cat "$SD/terminal-create.count" 2>/dev/null || echo 0)" != "0"
+check_not "零 worker-start 调用" grep -q "^orchestration worker-start" "$FAKE_ORCA_LOG"
+assert "旧终端保留且唯一" 'live_is_solely term-old'
+check "METADATA 仍路由旧终端" test "$(jq -r '.session.orca.terminal_handle' "$METADATA")" = "term-old"
+
+echo "Case O3 (Task-116): 已结算目标不带 --allow-cmd 的纯快照刷新请求同样拒绝"
+make_fixture O3
+printf 'failed\n' > "$SD/task-status"
+touch "$SD/dispatch-settled"
+cp "$SC/launch.sh" "$TMP_ROOT/O3-launch-before.sh"
+run_reauth
+check "退出码非 0" test "$RC" -ne 0
+check "输出含 REAUTHORIZE_NOT_LIVE" grep -q "REAUTHORIZE_NOT_LIVE" <<<"$OUT"
+check "launch.sh 未被改写" cmp -s "$TMP_ROOT/O3-launch-before.sh" "$SC/launch.sh"
+check_not "零新终端创建" test "$(cat "$SD/terminal-create.count" 2>/dev/null || echo 0)" != "0"
+assert "旧终端保留且唯一" 'live_is_solely term-old'
 
 echo ""
 echo "Result: $pass pass, $fail fail"

--- a/skills/multi-agent-orchestration/scripts/test-spawn-worker-orca.sh
+++ b/skills/multi-agent-orchestration/scripts/test-spawn-worker-orca.sh
@@ -641,6 +641,7 @@ chmod +x "$E2E_FAKE_BIN/ps"
 
 run_e2e_spawn() {
   local branch="$1" session="$2" out_base="$3"
+  shift 3
   ORCA_CLI_COMMAND="$E2E_ORCA_BIN" \
   E2E_ORCA_STATE="$E2E_STATE" E2E_ORCA_LOG="$E2E_ORCA_LOG" \
   E2E_ORCA_PROJECT="$E2E_PROJECT" E2E_ORCA_WS="$E2E_WS" \
@@ -655,50 +656,101 @@ run_e2e_spawn() {
     --no-trust-auto --no-permission-auto --no-permission-auto-bg --no-external-imports-auto \
     --orca-supervised \
     --task-spec "e2e isolation pre-gate regression spec" \
+    "$@" \
     > "$out_base.out" 2> "$out_base.err"
 }
 
-# 用例 1（复现形态）：branch 已存在，fake Orca 建了 -2 后缀分支 → pre-gate 必须在任何
-# terminal/worker-start/任务注入副作用之前 exit 2。
+# Task-116 既有 Worktree 预门禁断言：命中 exact path/branch 占用时零 mutation 副作用
+# （无 worktree create / terminal / run / task / worker-start，无 Session Context），
+# 稳定输出 EXISTING_WORKTREE_REQUIRES_RECOVERY 且退出码 3。
+assert_existing_worktree_rejection() {
+  local out_base="$1" label="$2"
+  if grep -Fq 'EXISTING_WORKTREE_REQUIRES_RECOVERY' "$out_base.err"; then
+    ok "$label reports the stable existing-worktree machine code"
+  else
+    bad "$label reports the stable existing-worktree machine code"
+  fi
+  if grep -Eq 'worktree create|terminal create|run-create|task-create|worker-start' "$E2E_ORCA_LOG"; then
+    bad "$label performs zero Orca create/terminal/dispatch side effects"
+  else
+    ok "$label performs zero Orca create/terminal/dispatch side effects"
+  fi
+  if [ ! -e "$E2E_PROJECT/.claude/agent-sessions" ]; then
+    ok "$label leaves no Session Context on disk"
+  else
+    bad "$label leaves no Session Context on disk"
+  fi
+}
+
+# 用例 1（Task-116 复现形态）：exact branch 已存在于本仓 → 既有 Worktree 预门禁在任何
+# provider lease / Orca worktree create / terminal / dispatch 之前稳定拒绝（exit 3），
+# Orca 不再生成 -2 后缀 worktree，零残留。
 git -C "$E2E_PROJECT" branch e2e-pregate-miss
-touch "$E2E_STATE/branch-suffix-2"
+rm -f "$E2E_STATE/branch-suffix-2"
 : > "$E2E_ORCA_LOG"
 set +e
 run_e2e_spawn e2e-pregate-miss e2e-pregate-miss "$E2E_ROOT/mismatch"
 e2e_mismatch_rc=$?
 set -e
-if [ "$e2e_mismatch_rc" != "2" ]; then
+if [ "$e2e_mismatch_rc" != "3" ]; then
   sed -n '1,120p' "$E2E_ROOT/mismatch.err" >&2
 fi
-assert_eq "$e2e_mismatch_rc" "2" "-2 suffix branch mismatch exits 2 before any worker side effect"
-if grep -Fq 'SPAWN_WORKER_ISOLATION_PREGATE_FAILED' "$E2E_ROOT/mismatch.err" \
-  && grep -Fq 'actual_branch=e2e-pregate-miss-2' "$E2E_ROOT/mismatch.err"; then
-  ok "-2 suffix mismatch reports the isolation pre-gate failure with both branch names"
+assert_eq "$e2e_mismatch_rc" "3" "existing exact branch exits 3 before any side effect"
+assert_existing_worktree_rejection "$E2E_ROOT/mismatch" "existing exact branch"
+if grep -Fq 'worktree current' "$E2E_ORCA_LOG"; then
+  ok "existing exact branch still used read-only Orca runtime detection"
 else
-  bad "-2 suffix mismatch reports the isolation pre-gate failure with both branch names"
+  bad "existing exact branch still used read-only Orca runtime detection"
+fi
+if [ ! -e "$E2E_WS/e2e-pregate-miss" ] && [ ! -e "$E2E_WS/e2e-pregate-miss-2" ]; then
+  ok "existing exact branch leaves no worktree residue at all"
+else
+  bad "existing exact branch leaves no worktree residue at all"
+fi
+
+# 用例 1b（兜底回归）：branch 名只存在于 origin（本地 ref 不存在）→ 预门禁不误伤
+# 新建流程；若 Orca runtime 漂移仍生成 -2 后缀，late isolation pre-gate 保持
+# exit 2 的兜底语义（零 terminal/任务注入，残留 worktree 保留供 PM 清理）。
+git -C "$E2E_PROJECT" update-ref "refs/remotes/origin/e2e-late-collide" HEAD
+touch "$E2E_STATE/branch-suffix-2"
+: > "$E2E_ORCA_LOG"
+set +e
+run_e2e_spawn e2e-late-collide e2e-late-collide "$E2E_ROOT/late-collide"
+e2e_late_rc=$?
+set -e
+if [ "$e2e_late_rc" != "2" ]; then
+  sed -n '1,120p' "$E2E_ROOT/late-collide.err" >&2
+fi
+assert_eq "$e2e_late_rc" "2" "origin-only name collision falls through to the isolation pre-gate backstop"
+if grep -Fq 'SPAWN_WORKER_ISOLATION_PREGATE_FAILED' "$E2E_ROOT/late-collide.err" \
+  && grep -Fq 'actual_branch=e2e-late-collide-2' "$E2E_ROOT/late-collide.err"; then
+  ok "-2 suffix mismatch still reports the isolation pre-gate failure with both branch names"
+else
+  bad "-2 suffix mismatch still reports the isolation pre-gate failure with both branch names"
 fi
 if grep -Fq 'worktree create' "$E2E_ORCA_LOG" \
   && grep -Fq 'worktree current' "$E2E_ORCA_LOG"; then
-  ok "-2 suffix mismatch still performed the real Orca worktree create"
+  ok "origin-only collision still performed the real Orca worktree create"
 else
-  bad "-2 suffix mismatch still performed the real Orca worktree create"
+  bad "origin-only collision still performed the real Orca worktree create"
 fi
 if grep -Fq 'terminal create' "$E2E_ORCA_LOG" || grep -Fq 'worker-start' "$E2E_ORCA_LOG" \
   || grep -Fq 'task-create' "$E2E_ORCA_LOG" || grep -Fq 'run-create' "$E2E_ORCA_LOG"; then
-  bad "-2 suffix mismatch must not create a terminal, run, task or worker-start"
+  bad "origin-only collision must not create a terminal, run, task or worker-start"
 else
-  ok "-2 suffix mismatch must not create a terminal, run, task or worker-start"
+  ok "origin-only collision must not create a terminal, run, task or worker-start"
 fi
-if [ ! -e "$E2E_PROJECT/.claude/agent-sessions/e2e-pregate-miss" ]; then
-  ok "-2 suffix mismatch leaves no Session Context on disk"
+if [ ! -e "$E2E_PROJECT/.claude/agent-sessions/e2e-late-collide" ]; then
+  ok "origin-only collision leaves no Session Context on disk"
 else
-  bad "-2 suffix mismatch leaves no Session Context on disk"
+  bad "origin-only collision leaves no Session Context on disk"
 fi
-if [ -d "$E2E_WS/e2e-pregate-miss-2" ]; then
-  ok "-2 suffix mismatch retains the created worktree for PM cleanup"
+if [ -d "$E2E_WS/e2e-late-collide-2" ]; then
+  ok "origin-only collision retains the created worktree for PM cleanup"
 else
-  bad "-2 suffix mismatch retains the created worktree for PM cleanup"
+  bad "origin-only collision retains the created worktree for PM cleanup"
 fi
+rm -f "$E2E_STATE/branch-suffix-2"
 
 # 用例 2（成功路径回归保护）：branch 名可用 → pre-gate 放行，supervised 注册与
 # 任务注入照常发生，final gate 通过，exit 0。
@@ -731,6 +783,123 @@ if jq -e '.session.orca.supervised.task_id == "task-pregate" and .session.orca.s
   ok "matching-branch spawn records the supervised dispatch contract in metadata"
 else
   bad "matching-branch spawn records the supervised dispatch contract in metadata"
+fi
+
+# --- Task-116 既有 Worktree 预门禁矩阵 ---
+# exact --worktree 路径 / exact branch 已被同 repo worktree 占用、错仓、脏工作区、
+# 非 git 目录（未知状态）一律在任何 provider lease / Orca worktree create /
+# Session Context / terminal / dispatch 副作用之前稳定拒绝（exit 3 +
+# EXISTING_WORKTREE_REQUIRES_RECOVERY）；恢复必须走 reauthorize/quota-park/明确入口。
+
+# 用例 3：exact branch 已被同 repo worktree 占用（checked out）→ 拒绝，零副作用。
+OCC_BRANCH_WT="$E2E_ROOT/occ-branch-wt"
+git -C "$E2E_PROJECT" worktree add -q -b e2e-occ-branch "$OCC_BRANCH_WT" HEAD
+: > "$E2E_ORCA_LOG"
+set +e
+run_e2e_spawn e2e-occ-branch e2e-occ-branch "$E2E_ROOT/occ-branch"
+occ_branch_rc=$?
+set -e
+if [ "$occ_branch_rc" != "3" ]; then
+  sed -n '1,120p' "$E2E_ROOT/occ-branch.err" >&2
+fi
+assert_eq "$occ_branch_rc" "3" "branch occupied by a same-repo worktree exits 3"
+assert_existing_worktree_rejection "$E2E_ROOT/occ-branch" "occupied branch"
+if grep -Fq "$OCC_BRANCH_WT" "$E2E_ROOT/occ-branch.err"; then
+  ok "occupied branch rejection names the occupying worktree"
+else
+  bad "occupied branch rejection names the occupying worktree"
+fi
+
+# 用例 4：exact --worktree 路径已被同 repo worktree 占用（干净）→ 拒绝。
+OCC_PATH_WT="$E2E_ROOT/occ-path-wt"
+git -C "$E2E_PROJECT" worktree add -q -b e2e-occ-path-branch "$OCC_PATH_WT" HEAD
+: > "$E2E_ORCA_LOG"
+set +e
+run_e2e_spawn e2e-fresh-occ-path e2e-occ-path "$E2E_ROOT/occ-path" --worktree "$OCC_PATH_WT"
+occ_path_rc=$?
+set -e
+if [ "$occ_path_rc" != "3" ]; then
+  sed -n '1,120p' "$E2E_ROOT/occ-path.err" >&2
+fi
+assert_eq "$occ_path_rc" "3" "existing exact worktree path exits 3"
+assert_existing_worktree_rejection "$E2E_ROOT/occ-path" "existing exact path"
+
+# 用例 5：exact --worktree 路径是脏的同 repo worktree → 拒绝并点名 dirty。
+DIRTY_WT="$E2E_ROOT/dirty-wt"
+git -C "$E2E_PROJECT" worktree add -q -b e2e-dirty-branch "$DIRTY_WT" HEAD
+printf 'uncommitted\n' > "$DIRTY_WT/dirty.txt"
+: > "$E2E_ORCA_LOG"
+set +e
+run_e2e_spawn e2e-fresh-dirty e2e-dirty "$E2E_ROOT/dirty" --worktree "$DIRTY_WT"
+dirty_rc=$?
+set -e
+if [ "$dirty_rc" != "3" ]; then
+  sed -n '1,120p' "$E2E_ROOT/dirty.err" >&2
+fi
+assert_eq "$dirty_rc" "3" "dirty existing exact path exits 3"
+assert_existing_worktree_rejection "$E2E_ROOT/dirty" "dirty existing path"
+if grep -Fq 'dirty' "$E2E_ROOT/dirty.err"; then
+  ok "dirty rejection surfaces the dirty signal"
+else
+  bad "dirty rejection surfaces the dirty signal"
+fi
+
+# 用例 6：exact --worktree 路径属于另一个仓库（错仓）→ fail-closed 拒绝。
+OTHER_REPO="$E2E_ROOT/other repo"
+OTHER_WT="$E2E_ROOT/other-wt"
+mkdir -p "$OTHER_REPO"
+git -C "$OTHER_REPO" init -q
+git -C "$OTHER_REPO" config user.email "spawn-orca@test.local"
+git -C "$OTHER_REPO" config user.name "spawn-orca-test"
+git -C "$OTHER_REPO" commit -q --allow-empty -m init
+git -C "$OTHER_REPO" worktree add -q -b other-branch "$OTHER_WT" HEAD
+: > "$E2E_ORCA_LOG"
+set +e
+run_e2e_spawn e2e-fresh-other-repo e2e-other-repo "$E2E_ROOT/other-repo" --worktree "$OTHER_WT"
+other_repo_rc=$?
+set -e
+if [ "$other_repo_rc" != "3" ]; then
+  sed -n '1,120p' "$E2E_ROOT/other-repo.err" >&2
+fi
+assert_eq "$other_repo_rc" "3" "wrong-repo existing exact path exits 3"
+assert_existing_worktree_rejection "$E2E_ROOT/other-repo" "wrong-repo path"
+
+# 用例 7：exact --worktree 路径存在但不是 git worktree（未知状态）→ fail-closed 拒绝。
+PLAIN_DIR="$E2E_ROOT/plain-dir"
+mkdir -p "$PLAIN_DIR"
+: > "$E2E_ORCA_LOG"
+set +e
+run_e2e_spawn e2e-fresh-plain e2e-plain "$E2E_ROOT/plain" --worktree "$PLAIN_DIR"
+plain_rc=$?
+set -e
+if [ "$plain_rc" != "3" ]; then
+  sed -n '1,120p' "$E2E_ROOT/plain.err" >&2
+fi
+assert_eq "$plain_rc" "3" "non-git existing exact path (unknown state) exits 3"
+assert_existing_worktree_rejection "$E2E_ROOT/plain" "unknown-state path"
+
+# 用例 8：路径不存在的新建流程保持不变——fresh branch + fresh --worktree 路径照常
+# 完成 supervised spawn（exit 0），Orca create / terminal / worker-start 照常发生。
+FRESH_WT="$E2E_ROOT/fresh-wt-8"
+if [ -e "$FRESH_WT" ]; then rm -rf "$FRESH_WT"; fi
+: > "$E2E_ORCA_LOG"
+set +e
+run_e2e_spawn e2e-fresh-explicit-path e2e-fresh-explicit "$E2E_ROOT/fresh-explicit" --worktree "$FRESH_WT"
+fresh_explicit_rc=$?
+set -e
+if [ "$fresh_explicit_rc" != "0" ]; then
+  sed -n '1,120p' "$E2E_ROOT/fresh-explicit.err" >&2
+fi
+assert_eq "$fresh_explicit_rc" "0" "fresh branch with non-existing explicit path keeps the green path"
+if grep -Fq 'worktree create' "$E2E_ORCA_LOG" && grep -Fq 'orchestration worker-start' "$E2E_ORCA_LOG"; then
+  ok "fresh explicit-path spawn still creates the worktree and injects the task"
+else
+  bad "fresh explicit-path spawn still creates the worktree and injects the task"
+fi
+if grep -Fq 'EXISTING_WORKTREE_REQUIRES_RECOVERY' "$E2E_ROOT/fresh-explicit.err"; then
+  bad "fresh explicit-path spawn must not report the existing-worktree code"
+else
+  ok "fresh explicit-path spawn must not report the existing-worktree code"
 fi
 
 printf 'spawn-worker Orca helper tests: %s passed, %s failed\n' "$passed" "$failed"


### PR DESCRIPTION
## 变更
- 在 reauthorize 入口前置拒绝已结算、已释放、已确认或未知 Dispatch，保持零副作用
- 在 Orca worktree / provider lease / terminal / dispatch 之前拒绝已占用的同名分支或目标路径
- 补充故障优先与相邻回归测试

## 验证
- test-pm-reauthorize.sh: 113 passed
- test-spawn-worker-orca.sh: 104 passed
- test-dispatch-value-gate.sh: 34 passed
- bash -n: 5 个受影响脚本通过
- flags/metadata/launch/provider-lease 相邻回归通过
- git diff --check 通过

替代发生冲突的旧 PR #131；本 PR 基于最新 main 重新实现，未 cherry-pick 旧提交。