### PR TITLE
fix(multi-agent-orchestration): 对齐 heartbeat 验收背压阈值

### DIFF
--- a/skills/multi-agent-orchestration/scripts/codex-heartbeat-cycle.py
+++ b/skills/multi-agent-orchestration/scripts/codex-heartbeat-cycle.py
@@ -77,8 +77,10 @@ TIMEOUT_BOUNDS = {
     "reconcile_seconds": (1, 300),
     "tick_seconds": (1, 600),
 }
-# 与 dispatch-value-gate.v2 的验收反压阈值一致：待验收 PR > 2 时不允许再 spawn。
-BACKPRESSURE_THRESHOLD = 2
+# 与 dispatch-value-gate.v2 的验收反压阈值一致（MAX_PENDING_ACCEPTANCE_PRS=4，
+# 验收反压口径为 >4）：待验收 PR > 4 时不允许再 spawn。显式声明
+# gates.acceptance_backpressure 的拒绝路径独立于本阈值，始终生效。
+BACKPRESSURE_THRESHOLD = 4
 
 OID_RE = re.compile(r"[0-9a-f]{40}|[0-9a-f]{64}")
 HEX64_RE = re.compile(r"[0-9a-f]{64}")

--- a/skills/multi-agent-orchestration/scripts/test-codex-heartbeat-cycle.py
+++ b/skills/multi-agent-orchestration/scripts/test-codex-heartbeat-cycle.py
@@ -403,9 +403,10 @@ def case_second_heartbeat_after_receipt_ticks_nothing() -> dict[str, Any]:
 
 
 def case_mechanical_backpressure_blocks_spawn() -> dict[str, Any]:
+    # 阈值收敛到 4 后唯一保留的机械阻断档：5 个 open PR 仍必须拒绝 spawn。
     f = Fixture()
     try:
-        items = open_pr_items(3)
+        items = open_pr_items(5)
         f.script([
             {"exit": 0, "stdout": f.status_ok(items=items)},
             {"exit": 0, "stdout": f.reconcile_ready("spawn")},
@@ -418,7 +419,33 @@ def case_mechanical_backpressure_blocks_spawn() -> dict[str, Any]:
         assert "反压" in result["reason"], result["reason"]
         assert len(f.tick_calls()) == 0
         assert len(f.calls) == 3
-        return {"open_prs": 3, "ticks": 0}
+        return {"open_prs": 5, "ticks": 0}
+    finally:
+        f.close()
+
+
+def case_four_open_prs_allow_spawn() -> dict[str, Any]:
+    # dispatch gate 的验收反压已放宽为 >4（MAX_PENDING_ACCEPTANCE_PRS=4），
+    # 心跳机械阈值必须同口径：4 个 open PR 不得再拒绝 spawn。
+    # 旧实现（阈值 2）在此用例上必红——failure-first 回归锚点。
+    f = Fixture()
+    try:
+        items = open_pr_items(4)
+        f.script([
+            {"exit": 0, "stdout": f.status_ok(items=items)},
+            {"exit": 0, "stdout": f.reconcile_ready("spawn")},
+            {"exit": 0, "stdout": f.status_ok(items=items)},
+            {"exit": 0, "stdout": f.tick_receipt()},
+        ])
+        proc = f.run(f.base_request())
+        assert proc.returncode == 0, proc.stderr
+        result = f.result(proc)
+        assert result["decision"] == "dispatch", result["reason"]
+        assert "反压" not in result["reason"], result["reason"]
+        assert result["tick"]["mutation_count"] == 1
+        assert len(f.tick_calls()) == 1
+        assert len(f.calls) == 4
+        return {"open_prs": 4, "ticks": 1}
     finally:
         f.close()
 
@@ -1076,7 +1103,8 @@ CASES: list[tuple[str, Any]] = [
     ("receipt 之后的下一次心跳不再 tick", case_second_heartbeat_after_receipt_ticks_nothing),
     ("声明配额拒绝时拒绝 tick", case_quota_denied_gate_blocks_tick),
     ("声明验收反压时拒绝 spawn tick", case_declared_backpressure_blocks_spawn),
-    ("机械验收反压（3 个 open PR）拒绝 spawn tick", case_mechanical_backpressure_blocks_spawn),
+    ("机械验收反压（5 个 open PR）拒绝 spawn tick", case_mechanical_backpressure_blocks_spawn),
+    ("4 个 open PR 允许 spawn tick（阈值收敛到 4）", case_four_open_prs_allow_spawn),
     ("2 个 open PR 允许 spawn tick", case_two_open_prs_allow_spawn),
     ("provider 重置（retry_later）不 tick", case_provider_reset_ticks_nothing),
     ("reconcile 失败（事实过期）不 tick", case_stale_facts_ticks_nothing),


### PR DESCRIPTION
## 背景

dispatch-value-gate.v2 的验收反压上限已是 `MAX_PENDING_ACCEPTANCE_PRS = 4`（拒绝口径 `pending > 4`），但 `codex-heartbeat-cycle.py` 的 `BACKPRESSURE_THRESHOLD` 仍为 2。4 个待验收 open PR 时，dispatch gate 允许的 spawn 会被心跳 tick 前闸门错误拒绝——两道闸门口径漂移（Task #118）。

## 变更（仅两个授权文件）

- `skills/multi-agent-orchestration/scripts/codex-heartbeat-cycle.py`：`BACKPRESSURE_THRESHOLD` 2 → 4，注释同步为 `>4` 口径（`MAX_PENDING_ACCEPTANCE_PRS=4`）；显式 `gates.acceptance_backpressure=true` 的拒绝路径保持独立、无条件生效；quota_denied / fencing / 租约 / allowlist / 单次 tick 等其余闸门零变化。
- `skills/multi-agent-orchestration/scripts/test-codex-heartbeat-cycle.py`：机械反压阻断档 3 → 5 个 open PR（5 > 4 仍拒绝）；新增「4 个 open PR 允许 spawn tick」用例。

## Failure-first 证据（红 → 绿）

- 红（仅改测试、未改实现，在 origin/main@6a9e1192 上）：`python3 …/test-codex-heartbeat-cycle.py` → 33 通过 / 1 失败，exit 1；失败即新增用例 `not ok 7 - 4 个 open PR 允许 spawn tick（阈值收敛到 4）: AssertionError: 验收反压：待验收 open PR 数 4 超过阈值 2；拒绝 spawn tick`——证明现状错误拒绝 4 个 open PR；同轮「机械验收反压（5 个 open PR）拒绝」用例通过，证明 5 个仍拒绝。
- 绿（阈值改 4 后）：selftest 34/34 全绿，exit 0；`bash …/test-dispatch-value-gate.sh` 34 passed, 0 failed，exit 0；`git diff --check` 干净，exit 0。

## 基线说明

分支基于 origin/main@6a9e119297efcfb523215a21188d28b066afbb0a（任务文字中的 96de72d9 已被 PR #132 快进；两者之间不涉及本 PR 的两个授权文件，已用 `git diff 96de72d9..6a9e1192 -- <两文件>` 核验为空）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
