### PR TITLE
feat(multi-agent-orchestration): worker 内存预算账本与派发排队 [2.21.0]

### DIFF
--- a/skills/multi-agent-orchestration/CHANGELOG.md
+++ b/skills/multi-agent-orchestration/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [2.21.0] - 2026-09-06
+
+### 新增
+
+- 新增物理内存预算预检门 `scripts/mem_budget_probe.py`：读 hw.memsize 与 vm_stat / memory_pressure / vm.swapusage 现场快照，输出 `memory-budget.summary.v1` JSON（可用安全内存、swap 压力信号、按 per-worker 预算折算的可派发额度）；读取失败 exit 1 且不输出额度（fail-closed，绝不编造）。
+- per-worker 预算默认 3 GiB（agent 本体约 1.2 GiB + 测试/构建余量约 2 GiB，与 v2.20.0 堆顶量级对齐）；`SPAWN_WORKER_MEM_BUDGET_BYTES` 可调（非法值 fail-closed），`=0` 显式关闭整道门。压力分级收紧：warn 把可承诺额度折半、critical 额度归零。
+- `spawn-worker.sh` 在任何 worktree/terminal/lease/dispatch 副作用之前接线内存门：额度不足以专用退出码 4 拒绝并输出 可用/预算/缺口 诊断与 `SPAWN_WORKER_MEM_BUDGET_DENIED` 稳定标记；放行输出 `SPAWN_WORKER_MEM_BUDGET: available=… budget=… slots=…` 账本行；probe 读失败同样 fail-closed 拒绝（坏门永远不放行）。
+- SKILL §5 新增排队规则：额度不足不 spawn、本轮记 `PARKED_FOR_MEMORY`、下一轮巡检重试，同一任务连续 3 轮不足泊车并向用户报告（附 probe 输出）；OOM 退避重拉前必须重跑 probe（每次 spawn 现场探测、不缓存）。
+- SKILL §6 收口清单新增第 6 条：`STATUS=done` 但进程仍存活的 worker（含跨会话遗留）当轮即触发收口或上报，滞留进程持续挤占物理内存派发额度。
+- 新增 `references/22-mem-budget-lane.md`（数据源、预算推导、排队状态机、与 OOM 退避交互、维护矩阵）；维护矩阵 `references/19-maintainer-validation.md` 收录 `test-mem-budget-probe.py`。
+
+### 非目标（边界）
+
+- 不建跨项目全局 worker 注册表/文件锁：现场物理探测天然覆盖跨项目占用。probe 只读、只做派发门槛，不做自动杀进程、自动降级、swap 清理等任何回收动作。quota lane 既有语义不变。
+
+### 验证
+
+- 新增 `scripts/test-mem-budget-probe.py` 52/52 通过：vm_stat（16k/4k page size、行集差异、缺关键行/表头）、memory_pressure（关键词句式、百分比句式、垃圾输入）、vm.swapusage（M/G 后缀、零 swap）解析；swap 高压 warn 折半、critical 归零；全读失败 exit 1 且 payload 无额度字段；`--json` schema 字段稳定（key set 逐字段钉住）；预算 env 覆盖与 `=0` 直通；真实机器 smoke 现场读源。E2E（fake Orca CLI，与真实 runtime 隔离）：低内存 fixture 专用退出码 4 + 诊断 + 零 worktree/terminal 副作用 + 无 Session Context 残留；健康 fixture 放行并输出账本行；`=0` 低内存直通。
+- 既有矩阵回归：`test-spawn-worker-orca.sh` 104/104、`test-spawn-worker-flags.sh` 31/31、`test-spawn-worker-deps.sh` 18/18、`test-spawn-worker-verification.sh` 13/13、`bash -n scripts/spawn-worker.sh` 通过。
+
 ## [2.20.0] - 2026-09-05
 
 ### 新增

--- a/skills/multi-agent-orchestration/SKILL.md
+++ b/skills/multi-agent-orchestration/SKILL.md
@@ -3,7 +3,7 @@ name: multi-agent-orchestration
 description: 编排两个以上边界独立的本地 worker，使用 Orca Run/Task/Dispatch、独立 worktree/session 或 tmux 回退，由 PM 负责拆解、派发、巡检、429 停滞恢复、独立验收、PR 收口与临时资源清理；也用于用户明确要求“并行推进”“多个 worker”“PM 总控”“Wave Autopilot”或防止 PM 直接实现逃逸。不要用于单个短任务、纯状态同步，或仅需 Git 分支、提交、PR、merge 规则的工作。
 license: MIT
 metadata:
-  version: "2.20.0"
+  version: "2.21.0"
   homepage: https://github.com/cat-xierluo/legal-skills
   author: 杨卫薪律师（微信ywxlaw）
 ---
@@ -140,7 +140,9 @@ Wave Autopilot 只有用户明确授权并在项目任务源固定策略后才�
 
 跨项目检查 Orca Worker 是否因 429/usage limit 停在 idle 时，运行 `scripts/orca_rate_limit_recovery.py --manifest <私有清单>`；默认只读，只有显式 `--execute` 才对高置信 `RATE_LIMIT_IDLE` 通过 terminal 输入通道发送一次固定“继续”。tmux、单关键词/陈旧 tail、未分组身份和状态不确定一律不处置；`WAKE_ACCEPTED` 不等于额度恢复或业务继续。完整 manifest、状态机、错峰、幂等、TOCTOU 与退出码读取 `references/20-orca-rate-limit-recovery.md`。
 
-**Worker node OOM 识别与退避**（2026-09-05 事故：多 worker 长输出使会话内 node 进程 V8 堆耗尽 `FatalProcessOutOfMemory → SIGABRT`，PM 周期重拉形成崩溃循环并一度触发整机强制重启）。`spawn-worker.sh` v2.20.0 起默认给 worker 会话注入 `NODE_OPTIONS=--max-old-space-size=2048`（`SPAWN_WORKER_NODE_MAX_OLD_SPACE_MB=0` 可关），worker 到限自身退出而非拖垮系统。PM 巡检发现 worker node OOM（退出码 134 / SIGABRT / 日志含 `FatalProcessOutOfMemory` / 机器 `~/Library/Logs/DiagnosticReports/node-*.ips` 新增且时间吻合）时：同任务不得立即重拉，至少等下一轮巡检并全局并发 -1；同一任务连续 2 次 OOM 后停止重拉、泊车并向用户报告——这通常意味着任务本身产生超长输出（全量日志聚合、超大测试跑），需任务侧降输出或拆分，而不是更用力地重试。
+**Worker node OOM 识别与退避**（2026-09-05 事故：多 worker 长输出使会话内 node 进程 V8 堆耗尽 `FatalProcessOutOfMemory → SIGABRT`，PM 周期重拉形成崩溃循环并一度触发整机强制重启）。`spawn-worker.sh` v2.20.0 起默认给 worker 会话注入 `NODE_OPTIONS=--max-old-space-size=2048`（`SPAWN_WORKER_NODE_MAX_OLD_SPACE_MB=0` 可关），worker 到限自身退出而非拖垮系统。PM 巡检发现 worker node OOM（退出码 134 / SIGABRT / 日志含 `FatalProcessOutOfMemory` / 机器 `~/Library/Logs/DiagnosticReports/node-*.ips` 新增且时间吻合）时：同任务不得立即重拉，至少等下一轮巡检并全局并发 -1，且重拉前必须重跑内存预算预检（probe 每次 spawn 都现场探测、不缓存；额度不足按 `PARKED_FOR_MEMORY` 排队，不得绕过）；同一任务连续 2 次 OOM 后停止重拉、泊车并向用户报告——这通常意味着任务本身产生超长输出（全量日志聚合、超大测试跑），需任务侧降输出或拆分，而不是更用力地重试。
+
+**物理内存预算排队（mem budget lane）**：`spawn-worker.sh` 在任何 worktree/terminal/lease/dispatch 副作用之前运行 `scripts/mem_budget_probe.py`，按 per-worker 预算（默认 3 GiB；`SPAWN_WORKER_MEM_BUDGET_BYTES` 可调，`=0` 显式关闭整道门）把现场可用物理内存折算成可派发额度。额度不足或探测不可读时 spawn 以专用退出码 4 拒绝，输出 `SPAWN_WORKER_MEM_BUDGET_DENIED` 与 可用/预算/缺口 诊断；放行则在 PM 日志留下 `SPAWN_WORKER_MEM_BUDGET: available=… budget=… slots=…` 账本行。PM 收到该拒绝不得忙等、不得改走手动 spawn：本轮巡检把任务记 `PARKED_FOR_MEMORY` 并留存 probe 输出，下一轮巡检重试；同一任务连续 3 轮额度不足则正式泊车并向用户报告（附 probe JSON）。单进程堆顶（v2.20.0）管单个 worker 的失血点，本门管总量叠加承诺，也覆盖无堆顶可依赖的非 node runtime。数据源、预算推导、压力收紧与排队状态机读取 `references/22-mem-budget-lane.md`。
 
 ## 6. 验收、Git 交付与资源收口
 
@@ -151,6 +153,7 @@ PM 依次完成：
 3. supervised worker 先 reuse/release/retain，再 ack；仍存活但漏发完成时先结构化提醒，确认已死才使用 `settle`。
 4. 用户或项目已授权 Git 外部写入时，使用 `pm-closeout.sh` 的 PR-first 流程。PR 唯一性、冻结 head/diff/check/review、两阶段 mutation receipt、Monorepo integration path 与结果不确定恢复统一以 `references/14-pm-orchestrate.md` 为准。
 5. 交付确认后立即取得资源终态；不得把清理留给 PM 记忆。
+6. `STATUS=done`（或 PR 已合并）但进程仍存活的 worker——含跨会话遗留——当轮巡检即触发收口或上报：按 owner 通道 closeout / 释放 terminal / 结算 lifecycle，无法处置时向用户报告具体滞留对象。滞留进程持续挤占物理内存派发额度（`references/22-mem-budget-lane.md`），不收口就直接压缩下一波可派发 worker 数。
 
 ```bash
 bash scripts/pm-cleanup-worker.sh \
@@ -195,6 +198,7 @@ bash scripts/check-dependencies.sh --backend claude-code --backend codex --check
 | 派发、交付、review 与修复合同 | `references/18-dispatch-acceptance-contracts.md` |
 | Orca Worker 429 批量巡检与错峰唤醒 | `references/20-orca-rate-limit-recovery.md` |
 | zcode 额度 lane 的 summary 生产链路 | `references/21-zcode-quota-producer.md` |
+| 物理内存预算 lane 与派发排队 | `references/22-mem-budget-lane.md` |
 | 修改本 Skill 后的验证 | `references/19-maintainer-validation.md` |
 
 不要一次加载全部 references；只读取当前阶段与 backend 所需的文件。

--- a/skills/multi-agent-orchestration/references/19-maintainer-validation.md
+++ b/skills/multi-agent-orchestration/references/19-maintainer-validation.md
@@ -26,6 +26,7 @@ bash scripts/test-spawn-worker-flags.sh
 bash scripts/test-spawn-worker-orca.sh
 bash scripts/test-pm-quota-stall.sh
 python3 scripts/test-quota-preflight.py
+python3 scripts/test-mem-budget-probe.py
 python3 scripts/test-quota-summary-zcode.py
 bash scripts/test-pm-orchestrate-handoff.sh
 bash scripts/test-night-watch.sh

--- a/skills/multi-agent-orchestration/references/22-mem-budget-lane.md
+++ b/skills/multi-agent-orchestration/references/22-mem-budget-lane.md
@@ -1,0 +1,81 @@
+# Reference 22 — 物理内存预算 lane 与派发排队
+
+> spawn 前物理内存维度的预检门。quota lane 管 API 配额维度，本 lane 管物理内存维度。日常派发只需 SKILL §5 的排队规则；调预算、排障 probe 输出或改判定逻辑时读本文件。
+
+## 1. 定位与边界
+
+- 只读探测 + 派发门槛：`mem_budget_probe.py` 读系统快照、折算额度、输出 JSON；不做任何回收动作（不杀进程、不自动降级其他应用、不清 swap）。
+- 不建跨项目全局 worker 注册表/文件锁：每次 spawn 现场探测物理内存，其他项目/会话的占用天然反映在可用额度里，无需对账。
+- 与 v2.20.0 单进程堆顶互补：堆顶管"单个 worker 的失血点"（node 到限自身退出），本门管"总量叠加承诺"。非 node runtime（python 等）无堆顶可依赖，总量门是唯一防线。
+- 已交付但进程滞留的 worker 持续消耗额度，收口纪律见 SKILL §6 收口清单第 6 条。
+
+## 2. 数据源与读取
+
+| 源 | 命令（绝对路径） | 用途 | 失败时 |
+|---|---|---|---|
+| hw.memsize | `/usr/sbin/sysctl -n hw.memsize` | 物理总量，保留比例基数 | exit 1（无总量不可判） |
+| vm_stat | `/usr/bin/vm_stat` | 可用页 × page size（可用性基准优先源） | 降级用 memory_pressure 百分比 |
+| memory_pressure | `/usr/bin/memory_pressure`（无参数只读形态） | 官方压力分级 + 可用百分比 | 该源无信号，不参与收紧 |
+| vm.swapusage | `/usr/sbin/sysctl -n vm.swapusage` | swap used/total 比例（压力信号） | 无 swap 信号 |
+
+- 任一源失败只降级该源信号；物理总量与可用性基准（vm_stat 或 memory_pressure 百分比）都确立不了 → exit 1 且输出不含任何额度字段（fail-closed，绝不编造）。
+- macOS 之外的系统（源路径不存在）同样表现为读取失败 → fail-closed。
+- 测试/离线诊断注入：`--fixture-dir`（或 `MEM_BUDGET_FIXTURE_DIR`）目录下 `hw_memsize.txt` / `vm_stat.txt` / `memory_pressure.txt` / `vm_swapusage.txt`，文件缺席 = 该源读取失败，与真实失败同语义。
+
+## 3. 预算推导与压力收紧
+
+```text
+available_bytes  = (Pages free + speculative + inactive) × page_size   # vm_stat 优先
+                   或 total_bytes × available_percent / 100             # memory_pressure 兜底
+                   （钳位到 [0, total_bytes]）
+reserve_bytes    = max(2 GiB, 10% × total_bytes)   # 系统底仓，不派给 worker
+safe_available   = max(0, available_bytes − reserve_bytes)
+tighten          = normal 1.0 | warn 0.5 | critical 0.0
+slots            = floor(safe_available × tighten / budget_bytes)
+```
+
+- per-worker 预算默认 3 GiB：agent 本体（约 1.2 GiB）+ 测试/构建余量（约 2 GiB），与 v2.20.0 `--max-old-space-size=2048` 堆顶量级对齐。`SPAWN_WORKER_MEM_BUDGET_BYTES` 调整（十进制字节数；`--budget` 可临时覆盖，优先级 flag > env > 默认），非法值 exit 1；`=0` 显式关闭整道门（探测数据照常输出，slots 为 null）。
+- 压力分级取各信号最坏值：memory_pressure 关键词（`critical` / `increasing pressure` / `sufficient space`；无关键词但有官方可用百分比时按 ≤5% critical、≤15% warn 推导）与 swap used 比例（≥0.95 critical、≥0.75 warn）。warn 把可承诺额度折半，critical 直接 slots=0。
+- vm_stat 的 Swapins/Swapouts 是开机累计计数、不是瞬时压力，不参与判定。
+- available 计入 inactive 页：可回收但可能触发换出 I/O；保留底仓 + 压力收紧覆盖尾部风险，换取正常负载下的合理吞吐。
+
+## 4. spawn 接线与退出码
+
+| 场景 | probe rc | spawn 行为 |
+|---|---|---|
+| ok（slots ≥ 1） | 0 | 放行；PM 日志 `SPAWN_WORKER_MEM_BUDGET: available=<safe_available> budget=<budget> slots=<n> pressure=<level>` |
+| disabled（预算 =0） | 0 | 放行；日志 `SPAWN_WORKER_MEM_BUDGET: disabled (SPAWN_WORKER_MEM_BUDGET_BYTES=0)` |
+| denied（slots = 0） | 3 | exit 4 + `SPAWN_WORKER_MEM_BUDGET_DENIED` + 可用/预算/缺口诊断 |
+| unprobeable / config_invalid / probe 崩溃 | 1 / 其他 | exit 4 + `SPAWN_WORKER_MEM_BUDGET_PROBE_FAILED`（坏门永远不放行） |
+
+- 门的位置：既有 worktree 预门禁与 quota preflight 之后、provider lease / Orca worktree create / Session Context / terminal / dispatch 之前——与 quota 门同一条"任何副作用之前"边界。
+- exit 4 是本门专用退出码（区别于 3 = quota / 既有 worktree 预门禁、2 = isolation、64 = 参数与配置）。
+- 每次 spawn 现场探测、不缓存：多项目并发时放行额度由物理事实自然收敛，无需注册表；同一任务 OOM 退避后的重拉也天然重跑 probe。
+
+## 5. 排队状态机（PM 巡检）
+
+```text
+待派发 ──spawn exit 4──▶ PARKED_FOR_MEMORY（本轮记 probe 输出）
+   ▲                          │
+   └──────下一轮巡检重试───────┤
+                              └──连续 3 轮不足──▶ 泊车 + 向用户报告（附 probe JSON）
+额度恢复（worker 收口 / 负载回落）后，下一轮巡检自然放行
+```
+
+- 拒绝不是丢弃：任务保持待派发态，PM 按巡检节奏重试；禁止忙等，禁止绕过门手动 spawn。
+- 不足轮次按任务计数；连续 3 轮不足 → 正式泊车并向用户报告。常见根因是机器整体过载或预算与机型不匹配（调整 `SPAWN_WORKER_MEM_BUDGET_BYTES` 需用户确认，不让 PM 自行放宽）。
+
+## 6. 与 OOM 退避的交互（v2.20.0）
+
+- worker node OOM（SKILL §5 判定）后同任务不得立即重拉；重拉 spawn 会重新现场跑 probe——OOM 场景常伴随高内存占用，额度不足时任务自然排队，退避规则之外不需要再叠加独立检查。
+- OOM 退避的"全局并发 -1"与本门 slots 账本互补：退避管该任务的失败模式，账本管物理承诺总量。
+- 滞留的已交付 worker（STATUS=done 进程仍活）按 SKILL §6 当轮收口——它们不退出，额度就回不来。
+
+## 7. 维护矩阵
+
+| 变更 | 必跑 |
+|---|---|
+| probe 判定 / 解析 / schema | `python3 scripts/test-mem-budget-probe.py`；动了解析先在测试里钉住新形态再改 parser |
+| spawn 门位置 / 退出码 / 输出行 | 同上，另 `bash -n scripts/spawn-worker.sh`、`bash scripts/test-spawn-worker-orca.sh`（E2E 成功路径会过真实门） |
+| 预算默认值 / 保留公式 / 收紧档位 | 更新本文件 §3 与 SKILL §5 段落；测试 fixture 期望值同步（fixture 数值即推导文档） |
+| macOS 源输出形态变化 | 在 test-mem-budget-probe.py 增补该形态用例后复跑全套 |

--- a/skills/multi-agent-orchestration/scripts/mem_budget_probe.py
+++ b/skills/multi-agent-orchestration/scripts/mem_budget_probe.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""物理内存预算探测（memory budget probe，fail-closed）。
+
+spawn 前的物理内存维度预检：读 hw.memsize 与 vm_stat / memory_pressure /
+vm.swapusage 的现场快照，折算「当前还能安全承诺几个 worker」，输出
+memory-budget.summary.v1 JSON。quota preflight 管 API 配额维度，本 probe 管
+物理内存维度；两者都在任何 provider lease / worktree create / terminal /
+dispatch 副作用之前运行（spawn-worker.sh mem_budget_gate_run）。
+
+预算模型（references/22-mem-budget-lane.md 为权威推导）：
+
+  available_bytes   ≈ (Pages free + speculative + inactive) × page size
+                      （可回收而无须新换出的近似；memory_pressure 百分比兜底）
+  reserve_bytes     = max(2 GiB, 10% × hw.memsize)（系统/内核余量，不派给 worker）
+  safe_available    = max(0, available - reserve)
+  pressure level    = worst(memory_pressure 关键词, vm.swapusage used/total)
+                      normal=1.0 / warn=0.5（折半收紧）/ critical=0（slots=0）
+  slots             = floor(safe_available × tighten / budget_bytes)
+
+fail-closed 语义：
+  - hw.memsize 缺失，或 vm_stat 与 memory_pressure 均不可用（无法确立可用性
+    基准）→ exit 1，输出不含任何额度字段（绝不编造）。
+  - SPAWN_WORKER_MEM_BUDGET_BYTES 非法（非十进制非负整数）→ exit 1。
+  - 额度不足（slots == 0）→ exit 3，status=denied，reason 含可用/预算/缺口。
+  - =0 显式关闭整道门 → status=disabled，exit 0（与 NODE_OPTIONS 堆顶的
+    opt-out 风格一致）。
+
+数据源读取默认走绝对路径（macOS）；任一读取失败只降级该源信号，可用性基准
+仍按上述 fail-closed 规则判定。测试/离线诊断用 --fixture-dir（或
+MEM_BUDGET_FIXTURE_DIR）注入快照文件，文件缺席 = 该源读取失败。
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from typing import Any, Callable
+
+EXIT_OK = 0
+EXIT_FAIL_CLOSED = 1
+EXIT_DENIED = 3
+
+SCHEMA = "memory-budget.summary.v1"
+
+# per-worker 默认预算 3 GiB：agent 本体（约 1.2 GiB）+ 测试/构建余量（约 2 GiB），
+# 与 v2.20.0 NODE_OPTIONS=--max-old-space-size=2048 堆顶量级对齐。
+DEFAULT_BUDGET_BYTES = 3 * 1024 ** 3
+# 系统保留：不派给 worker 的底仓，防 spawn 后内核/缓存无路可走。
+RESERVE_FLOOR_BYTES = 2 * 1024 ** 3
+RESERVE_RATIO = 0.10
+
+GIB = float(1024 ** 3)
+
+SYSCTL = "/usr/sbin/sysctl"
+VM_STAT = "/usr/bin/vm_stat"
+MEMORY_PRESSURE = "/usr/bin/memory_pressure"
+SOURCE_TIMEOUT_SECONDS = 10
+
+FIXTURE_FILES = {
+    "hw_memsize": "hw_memsize.txt",
+    "vm_swapusage": "vm_swapusage.txt",
+    "vm_stat": "vm_stat.txt",
+    "memory_pressure": "memory_pressure.txt",
+}
+
+BUDGET_ENV = "SPAWN_WORKER_MEM_BUDGET_BYTES"
+FIXTURE_ENV = "MEM_BUDGET_FIXTURE_DIR"
+
+SWAP_WARN_RATIO = 0.75
+SWAP_CRITICAL_RATIO = 0.95
+PRESSURE_WARN_AVAILABLE_PERCENT = 15.0
+PRESSURE_CRITICAL_AVAILABLE_PERCENT = 5.0
+
+
+def _gib(value: int) -> str:
+    return f"{value / GIB:.2f}GiB"
+
+
+def parse_hw_memsize(text: str) -> int | None:
+    """`sysctl -n hw.memsize` → 物理内存字节数。"""
+    if not text:
+        return None
+    match = re.search(r"(\d+)", text)
+    if not match:
+        return None
+    total = int(match.group(1))
+    return total if total > 0 else None
+
+
+_SIZE_SUFFIXES = {
+    "": 1, "B": 1,
+    "K": 1024, "KB": 1024, "KIB": 1024,
+    "M": 1024 ** 2, "MB": 1024 ** 2, "MIB": 1024 ** 2,
+    "G": 1024 ** 3, "GB": 1024 ** 3, "GIB": 1024 ** 3,
+    "T": 1024 ** 4, "TB": 1024 ** 4, "TIB": 1024 ** 4,
+}
+
+
+def _parse_size(token: str) -> int | None:
+    match = re.fullmatch(r"([\d.]+)\s*([A-Za-z]*)", token.strip())
+    if not match:
+        return None
+    multiplier = _SIZE_SUFFIXES.get(match.group(2).upper())
+    if multiplier is None:
+        return None
+    try:
+        value = int(float(match.group(1)) * multiplier)
+    except (ValueError, OverflowError):
+        return None
+    return value if value >= 0 else None
+
+
+def parse_swap_usage(text: str) -> dict[str, Any] | None:
+    """`sysctl -n vm.swapusage` → {"total_bytes","used_bytes","free_bytes","used_ratio"}。
+
+    形态：`total = 2048.00M  used = 512.00M  free = 1536.00M`。
+    """
+
+    def grab(name: str) -> int | None:
+        match = re.search(rf"\b{name}\s*=\s*([\d.]+\s*[A-Za-z]*)", text)
+        return _parse_size(match.group(1)) if match else None
+
+    if not text:
+        return None
+    total = grab("total")
+    used = grab("used")
+    free = grab("free")
+    if total is None or used is None:
+        return None
+    if total == 0:
+        # 未配置 swap：无换出空间，也无换出压力信号。
+        return {"total_bytes": 0, "used_bytes": 0, "free_bytes": 0, "used_ratio": 0.0,
+                "no_swap": True}
+    if free is None:
+        free = max(0, total - used)
+    used = min(used, total)
+    return {"total_bytes": total, "used_bytes": used, "free_bytes": free,
+            "used_ratio": used / total, "no_swap": False}
+
+
+def parse_vm_stat(text: str) -> dict[str, Any] | None:
+    """`vm_stat` → {"page_size","available_bytes","pages"}。
+
+    需要表头 page size 与 Pages free（speculative / inactive 缺席按 0 容忍，
+    兼容不同 macOS 版本的行集差异）。解析不出可用性基准 → None。
+    """
+    if not text:
+        return None
+    header = re.search(r"page size of (\d+) bytes", text)
+    if not header:
+        return None
+    page_size = int(header.group(1))
+    if page_size <= 0:
+        return None
+    pages: dict[str, int] = {}
+    for line in text.splitlines():
+        match = re.match(r"^Pages?\s+([^:]+?)\s*:\s*([\d,]+)\s*\.?\s*$", line)
+        if match:
+            pages[match.group(1).strip().lower()] = int(match.group(2).replace(",", ""))
+    free = pages.get("free")
+    if free is None:
+        return None
+    available_pages = free + pages.get("speculative", 0) + pages.get("inactive", 0)
+    return {
+        "page_size": page_size,
+        "available_bytes": available_pages * page_size,
+        "pages": pages,
+    }
+
+
+def parse_memory_pressure(text: str) -> dict[str, Any] | None:
+    """`memory_pressure`（无参数只读形态）→ level 与百分比。
+
+    兼容两类输出形态：关键词句式（"The system has sufficient space." /
+    "is under increasing pressure" / "critical memory situation"）与
+    百分比句式（"X% of memory in use by apps, Y% available"）。
+    关键词是操作系统自己的分级，优先于百分比推导；两者都没有 → None。
+    """
+    if not text:
+        return None
+    lowered = text.lower()
+    level: str | None = None
+    if "critical" in lowered:
+        level = "critical"
+    elif "increasing pressure" in lowered or re.search(r"\bwarn(ing)?\b", lowered):
+        level = "warn"
+    elif "sufficient space" in lowered or re.search(r"pressure[^:\n]{0,24}:\s*normal", lowered):
+        level = "normal"
+    used_percent: float | None = None
+    available_percent: float | None = None
+    match = re.search(r"(\d+(?:\.\d+)?)\s*%\s*of memory\s+(?:in use|used)", lowered)
+    if match:
+        used_percent = float(match.group(1))
+    match = re.search(r"(\d+(?:\.\d+)?)\s*%\s*available", lowered)
+    if match:
+        available_percent = float(match.group(1))
+    if level is None and available_percent is not None:
+        # 无关键词但有官方可用百分比：按阈值推导分级。
+        if available_percent <= PRESSURE_CRITICAL_AVAILABLE_PERCENT:
+            level = "critical"
+        elif available_percent <= PRESSURE_WARN_AVAILABLE_PERCENT:
+            level = "warn"
+        else:
+            level = "normal"
+    if level is None:
+        return None
+    return {"level": level, "used_percent": used_percent,
+            "available_percent": available_percent}
+
+
+_LEVEL_ORDER = {"normal": 0, "warn": 1, "critical": 2}
+_TIGHTEN_FACTOR = {"normal": 1.0, "warn": 0.5, "critical": 0.0}
+
+
+def aggregate_pressure(memory_pressure: dict[str, Any] | None,
+                       swap: dict[str, Any] | None) -> dict[str, Any]:
+    """汇成单一 level + 收紧因子 + 命中信号列表；无任何信号时按 normal 不收紧。"""
+    signals: list[str] = []
+    level = "normal"
+    if memory_pressure is not None:
+        mp_level = memory_pressure["level"]
+        if _LEVEL_ORDER[mp_level] > _LEVEL_ORDER[level]:
+            level = mp_level
+        if mp_level != "normal":
+            signals.append(f"memory_pressure:{mp_level}")
+    if swap is not None and not swap.get("no_swap"):
+        ratio = float(swap["used_ratio"])
+        if ratio >= SWAP_CRITICAL_RATIO:
+            if _LEVEL_ORDER["critical"] > _LEVEL_ORDER[level]:
+                level = "critical"
+            signals.append(f"swap_used_ratio={ratio:.2f}>={SWAP_CRITICAL_RATIO}")
+        elif ratio >= SWAP_WARN_RATIO:
+            if _LEVEL_ORDER["warn"] > _LEVEL_ORDER[level]:
+                level = "warn"
+            signals.append(f"swap_used_ratio={ratio:.2f}>={SWAP_WARN_RATIO}")
+    return {"level": level, "tighten_factor": _TIGHTEN_FACTOR[level], "signals": signals}
+
+
+def resolve_budget(flag_value: str | None, env: dict[str, str]) -> tuple[int | None, str | None]:
+    """--budget > SPAWN_WORKER_MEM_BUDGET_BYTES > 默认 3 GiB；非法值 fail-closed。"""
+    raw: str | None = None
+    source = "default"
+    if flag_value is not None:
+        raw, source = flag_value, "flag"
+    elif env.get(BUDGET_ENV, "").strip() != "":
+        raw, source = env.get(BUDGET_ENV), "env"
+    if raw is None:
+        return DEFAULT_BUDGET_BYTES, source
+    token = raw.strip()
+    if not re.fullmatch(r"\d+", token):
+        return None, source
+    return int(token), source
+
+
+def collect_real() -> dict[str, str | None]:
+    def run(argv: list[str]) -> str | None:
+        try:
+            proc = subprocess.run(argv, capture_output=True, text=True,
+                                  timeout=SOURCE_TIMEOUT_SECONDS)
+        except (OSError, subprocess.TimeoutExpired):
+            return None
+        if proc.returncode != 0:
+            return None
+        return proc.stdout or None
+
+    return {
+        "hw_memsize": run([SYSCTL, "-n", "hw.memsize"]),
+        "vm_swapusage": run([SYSCTL, "-n", "vm.swapusage"]),
+        "vm_stat": run([VM_STAT]),
+        "memory_pressure": run([MEMORY_PRESSURE]),
+    }
+
+
+def collect_fixture(fixture_dir: str) -> dict[str, str | None]:
+    """快照文件缺席 = 该源读取失败（与真实读取失败同语义）。"""
+    snapshots: dict[str, str | None] = {}
+    for name, filename in FIXTURE_FILES.items():
+        path = os.path.join(fixture_dir, filename)
+        try:
+            with open(path, encoding="utf-8") as stream:
+                snapshots[name] = stream.read()
+        except OSError:
+            snapshots[name] = None
+    return snapshots
+
+
+def evaluate(snapshots: dict[str, str | None], budget_bytes: int,
+             budget_source: str) -> dict[str, Any]:
+    """纯决策核心：快照 + 预算 → memory-budget.summary.v1 payload。"""
+    sources: dict[str, str] = {}
+    for name in ("hw_memsize", "vm_stat", "memory_pressure", "vm_swapusage"):
+        sources[name] = "ok" if snapshots.get(name) else "failed"
+
+    total_bytes = parse_hw_memsize(snapshots.get("hw_memsize") or "")
+    vm_stat = parse_vm_stat(snapshots.get("vm_stat") or "")
+    memory_pressure = parse_memory_pressure(snapshots.get("memory_pressure") or "")
+    swap = parse_swap_usage(snapshots.get("vm_swapusage") or "")
+
+    payload: dict[str, Any] = {
+        "schema": SCHEMA,
+        "budget_bytes": budget_bytes,
+        "budget_source": budget_source,
+        "sources": sources,
+    }
+
+    if total_bytes is None:
+        payload["status"] = "unprobeable"
+        payload["reason"] = "hw.memsize 不可读：无法确立物理内存总量（fail-closed，不输出额度）"
+        return payload
+
+    # 可用性基准：vm_stat 页账本优先，memory_pressure 官方百分比兜底；两者皆失 → fail-closed。
+    if vm_stat is not None:
+        available_bytes = min(vm_stat["available_bytes"], total_bytes)
+        availability_basis = "vm_stat"
+        page_size: int | None = vm_stat["page_size"]
+    elif memory_pressure is not None and memory_pressure["available_percent"] is not None:
+        available_bytes = int(total_bytes * memory_pressure["available_percent"] / 100.0)
+        availability_basis = "memory_pressure_percent"
+        page_size = None
+    else:
+        payload["status"] = "unprobeable"
+        payload["total_bytes"] = total_bytes
+        payload["reason"] = ("vm_stat 与 memory_pressure 均不可用：无法确立可用内存基准"
+                            "（fail-closed，不输出额度）")
+        return payload
+
+    reserve_bytes = max(RESERVE_FLOOR_BYTES, int(total_bytes * RESERVE_RATIO))
+    safe_available = max(0, available_bytes - reserve_bytes)
+    pressure = aggregate_pressure(memory_pressure, swap)
+
+    payload.update({
+        "total_bytes": total_bytes,
+        "page_size": page_size,
+        "availability_basis": availability_basis,
+        "available_bytes": available_bytes,
+        "reserve_bytes": reserve_bytes,
+        "safe_available_bytes": safe_available,
+        "pressure": pressure,
+    })
+    if swap is not None:
+        payload["swap"] = {key: swap[key] for key in
+                           ("total_bytes", "used_bytes", "free_bytes", "used_ratio")}
+
+    if budget_bytes == 0:
+        payload["status"] = "disabled"
+        payload["slots"] = None
+        payload["reason"] = f"{BUDGET_ENV}=0 显式关闭内存预算门（opt-out，探测数据照常输出）"
+        return payload
+
+    effective = int(safe_available * pressure["tighten_factor"])
+    slots = effective // budget_bytes
+    payload["slots"] = slots
+    payload["effective_available_bytes"] = effective
+    if pressure["level"] == "critical":
+        payload["status"] = "denied"
+        payload["reason"] = (f"内存压力 critical（{', '.join(pressure['signals']) or 'level=critical'}）"
+                            f"→ slots=0；safe_available={_gib(safe_available)} "
+                            f"budget={_gib(budget_bytes)}")
+    elif slots < 1:
+        deficit = budget_bytes - effective
+        payload["status"] = "denied"
+        payload["reason"] = (f"safe_available={_gib(safe_available)}"
+                            f"×tighten({pressure['tighten_factor']})={_gib(effective)} "
+                            f"< budget={_gib(budget_bytes)}（缺口 {_gib(deficit)}，"
+                            f"pressure={pressure['level']}）")
+    else:
+        payload["status"] = "ok"
+        payload["reason"] = (f"safe_available={_gib(safe_available)} "
+                            f"budget={_gib(budget_bytes)} → slots={slots}"
+                            f"（pressure={pressure['level']}）")
+    return payload
+
+
+def human_summary(payload: dict[str, Any]) -> str:
+    if payload.get("status") == "unprobeable":
+        return f"MEM_BUDGET_PROBE: status=unprobeable reason={payload.get('reason', '')}"
+    pressure = payload.get("pressure", {})
+    return (f"MEM_BUDGET_PROBE: status={payload.get('status')} "
+            f"total={_gib(payload['total_bytes'])} "
+            f"available={_gib(payload['available_bytes'])} "
+            f"reserve={_gib(payload['reserve_bytes'])} "
+            f"safe={_gib(payload['safe_available_bytes'])} "
+            f"budget={_gib(payload['budget_bytes'])} "
+            f"slots={payload.get('slots')} pressure={pressure.get('level')}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="物理内存预算探测：输出 memory-budget.summary.v1（fail-closed）")
+    parser.add_argument("--json", action="store_true", help="输出单行 JSON（机器合同）")
+    parser.add_argument("--budget", default=None,
+                        help="per-worker 预算字节数（覆盖 %s；0=关闭）" % BUDGET_ENV)
+    parser.add_argument("--fixture-dir", default=None,
+                        help=("测试/离线诊断快照目录（%s 同名）；文件缺席=该源读取失败"
+                              % FIXTURE_ENV))
+    args = parser.parse_args(argv)
+
+    budget_bytes, budget_source = resolve_budget(args.budget, dict(os.environ))
+    if budget_bytes is None:
+        payload = {
+            "schema": SCHEMA,
+            "status": "config_invalid",
+            "budget_source": budget_source,
+            "reason": (f"{BUDGET_ENV}/{args.budget!r} 不是合法的非负整数字节数"
+                       "（fail-closed，不输出额度）"),
+        }
+        json.dump(payload, sys.stdout, ensure_ascii=False)
+        sys.stdout.write("\n")
+        return EXIT_FAIL_CLOSED
+
+    fixture_dir = args.fixture_dir or os.environ.get(FIXTURE_ENV, "").strip() or None
+    if fixture_dir is not None:
+        snapshots = collect_fixture(fixture_dir)
+    else:
+        snapshots = collect_real()
+
+    payload = evaluate(snapshots, budget_bytes, budget_source)
+    if args.json:
+        json.dump(payload, sys.stdout, ensure_ascii=False)
+        sys.stdout.write("\n")
+    else:
+        print(human_summary(payload))
+        if payload.get("status") == "denied":
+            print(f"MEM_BUDGET_PROBE_REASON: {payload['reason']}")
+    status = payload.get("status")
+    if status == "denied":
+        return EXIT_DENIED
+    if status in {"unprobeable", "config_invalid"}:
+        return EXIT_FAIL_CLOSED
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/multi-agent-orchestration/scripts/spawn-worker.sh
+++ b/skills/multi-agent-orchestration/scripts/spawn-worker.sh
@@ -462,6 +462,46 @@ quota_preflight_run() {
 }
 quota_preflight_run
 
+# v2.21.0（2026-09-06）：物理内存预算预检门（mem budget lane）。quota preflight 管
+# API 配额维度，本门管物理内存维度：现场探测 hw.memsize / vm_stat / memory_pressure /
+# vm.swapusage，按 per-worker 预算（默认 3GiB，SPAWN_WORKER_MEM_BUDGET_BYTES 可调）折算
+# 还能安全承诺几个 worker。额度为 0 → exit 4（专用退出码）+ SPAWN_WORKER_MEM_BUDGET_DENIED，
+# PM 不 spawn、按 §5 排队规则记 PARKED_FOR_MEMORY 下一轮巡检重试；probe 读失败同样
+# fail-closed 拒绝（坏门永远不放行）。SPAWN_WORKER_MEM_BUDGET_BYTES=0 显式关闭整道门
+# （与 NODE_OPTIONS 堆顶的 opt-out 风格一致）。每次 spawn 都现场探测、不缓存——同一任务
+# OOM 退避后 PM 重拉天然重跑 probe（§5）。数据源与推导权威：references/22-mem-budget-lane.md。
+mem_budget_gate_run() {
+  local probe_out probe_rc probe_status probe_reason
+  set +e
+  probe_out=$(python3 "$SCRIPT_DIR/mem_budget_probe.py" --json)
+  probe_rc=$?
+  set -e
+  probe_status=$(printf '%s' "$probe_out" | jq -r '.status // "unprobeable"' 2>/dev/null) || probe_status="unprobeable"
+  if [ "$probe_rc" -eq 0 ] && [ "$probe_status" = "ok" ]; then
+    printf 'SPAWN_WORKER_MEM_BUDGET: available=%s budget=%s slots=%s pressure=%s\n' \
+      "$(printf '%s' "$probe_out" | jq -r '.safe_available_bytes')" \
+      "$(printf '%s' "$probe_out" | jq -r '.budget_bytes')" \
+      "$(printf '%s' "$probe_out" | jq -r '.slots')" \
+      "$(printf '%s' "$probe_out" | jq -r '.pressure.level')"
+    return 0
+  fi
+  if [ "$probe_rc" -eq 0 ] && [ "$probe_status" = "disabled" ]; then
+    echo "SPAWN_WORKER_MEM_BUDGET: disabled (SPAWN_WORKER_MEM_BUDGET_BYTES=0)"
+    return 0
+  fi
+  probe_reason=$(printf '%s' "$probe_out" | jq -r '.reason // "probe produced no reason"' 2>/dev/null) || probe_reason="probe produced no reason"
+  if [ "$probe_status" = "denied" ]; then
+    printf 'ERROR: memory budget gate denied before any worktree/terminal/lease/dispatch side effect: %s\n' "$probe_reason" >&2
+    echo "SPAWN_WORKER_MEM_BUDGET_DENIED: 本轮不 spawn，任务记 PARKED_FOR_MEMORY 下一轮巡检重试（SKILL §5 排队规则）" >&2
+  else
+    printf 'ERROR: memory budget probe failed (rc=%s status=%s): %s; a broken gate can never pass (fail-closed)\n' \
+      "$probe_rc" "$probe_status" "$probe_reason" >&2
+    echo "SPAWN_WORKER_MEM_BUDGET_PROBE_FAILED: 内存现场不可探测，本轮不 spawn（fail-closed）" >&2
+  fi
+  exit 4
+}
+mem_budget_gate_run
+
 # shellcheck source=spawn-worker-provider-lease.sh
 source "$SCRIPT_DIR/spawn-worker-provider-lease.sh"
 

--- a/skills/multi-agent-orchestration/scripts/test-mem-budget-probe.py
+++ b/skills/multi-agent-orchestration/scripts/test-mem-budget-probe.py
@@ -1,0 +1,534 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""test-mem-budget-probe.py — 物理内存预算 lane（v2.21.0）fail-closed 语义测试。
+
+覆盖（任务合同 TASK-2026-09-06-MEM-BUDGET）：
+  - vm_stat / memory_pressure / vm.swapusage 各输出形态解析；
+  - swap 高压时额度折算收紧（warn 折半、critical 归零）；
+  - 读取全失败 exit 1 且不输出额度（fail-closed，绝不编造）；
+  - --json 输出 memory-budget.summary.v1 schema 字段稳定；
+  - 低内存 fixture 下 spawn-worker.sh 预检拒绝：专用 exit code 4 + 可诊断原因
+    （当前可用 / 预算 / 缺口），且发生在任何 worktree / terminal 副作用之前；
+  - 正常放行输出 SPAWN_WORKER_MEM_BUDGET: available=X budget=Y slots=N；
+  - SPAWN_WORKER_MEM_BUDGET_BYTES=0 显式直通（关门 opt-out）。
+
+E2E 用例复用 test-spawn-worker-orca.sh 的 fake Orca CLI 模式（临时 git 仓 +
+fake orca/fake ps），与真实 Orca runtime 完全隔离。
+"""
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PROBE = os.path.join(SCRIPT_DIR, "mem_budget_probe.py")
+SPAWN_WORKER = os.path.join(SCRIPT_DIR, "spawn-worker.sh")
+
+sys.path.insert(0, SCRIPT_DIR)
+import mem_budget_probe as mbp  # noqa: E402
+
+passed = 0
+failed = 0
+
+
+def ok(label):
+    global passed
+    passed += 1
+    print(f"PASS: {label}")
+
+
+def bad(label, detail=""):
+    global failed
+    failed += 1
+    print(f"FAIL: {label} {detail}", file=sys.stderr)
+
+
+def check(label, condition, detail=""):
+    if condition:
+        ok(label)
+    else:
+        bad(label, detail)
+
+
+def probe_env(**overrides):
+    env = dict(os.environ)
+    env.pop("MEM_BUDGET_FIXTURE_DIR", None)
+    env.pop("SPAWN_WORKER_MEM_BUDGET_BYTES", None)
+    env.update(overrides)
+    return env
+
+
+def run_probe(args=(), env=None, timeout=30):
+    proc = subprocess.run([sys.executable, PROBE, "--json", *args],
+                          capture_output=True, text=True, env=env or probe_env(),
+                          timeout=timeout)
+    payload = None
+    try:
+        payload = json.loads(proc.stdout)
+    except (ValueError, TypeError):
+        pass
+    return proc.returncode, payload
+
+
+GIB = 1024 ** 3
+TOTAL_32G = 32 * GIB
+BUDGET_DEFAULT = 3 * GIB
+
+
+def vm_stat_text(page_size, free, speculative, inactive, extra_lines=""):
+    lines = [
+        "Mach Virtual Memory Statistics: (page size of %d bytes)" % page_size,
+        "Pages free:                               %d." % free,
+        "Pages speculative:                        %d." % speculative,
+        "Pages inactive:                           %d." % inactive,
+    ]
+    return "\n".join(lines + ([extra_lines] if extra_lines else [])) + "\n"
+
+
+def write_fixture(directory, **files):
+    os.makedirs(directory, exist_ok=True)
+    for name, content in files.items():
+        with open(os.path.join(directory, mbp.FIXTURE_FILES[name]), "w",
+                  encoding="utf-8") as stream:
+            stream.write(content)
+
+
+# ---- 单元：vm_stat 解析（含 16384/4096 两代 page size 与行集差异） ----
+parsed = mbp.parse_vm_stat(vm_stat_text(16384, 600000, 300000, 148576))
+check("vm_stat parses 16k-page form into page size and available bytes",
+      parsed and parsed["page_size"] == 16384
+      and parsed["available_bytes"] == 1048576 * 16384,
+      f"(got={parsed})")
+
+parsed = mbp.parse_vm_stat(vm_stat_text(4096, 500000, 0, 300000))
+check("vm_stat parses legacy 4k-page form",
+      parsed and parsed["page_size"] == 4096
+      and parsed["available_bytes"] == 800000 * 4096,
+      f"(got={parsed})")
+
+parsed = mbp.parse_vm_stat(
+    "Mach Virtual Memory Statistics: (page size of 16384 bytes)\n"
+    "Pages free:                               100.\n")
+check("vm_stat tolerates missing speculative/inactive lines",
+      parsed and parsed["available_bytes"] == 100 * 16384, f"(got={parsed})")
+
+check("vm_stat without the page-size header is unusable",
+      mbp.parse_vm_stat("Pages free:  100.\n") is None)
+check("vm_stat without Pages free is unusable",
+      mbp.parse_vm_stat(
+          "Mach Virtual Memory Statistics: (page size of 16384 bytes)\n"
+          "Pages wired down: 100.\n") is None)
+check("vm_stat garbage is unusable", mbp.parse_vm_stat("total nonsense") is None)
+
+# ---- 单元：memory_pressure 解析（关键词句式 / 百分比句式 / 垃圾） ----
+mp = mbp.parse_memory_pressure(
+    "The system has sufficient space. (21% of memory in use by apps, 62% available)\n")
+check("memory_pressure parses the sufficient-space keyword form",
+      mp and mp["level"] == "normal" and mp["available_percent"] == 62.0
+      and mp["used_percent"] == 21.0, f"(got={mp})")
+
+mp = mbp.parse_memory_pressure(
+    "The system is under increasing pressure. (70% of memory in use, 12% available)\n")
+check("memory_pressure parses the increasing-pressure keyword as warn",
+      mp and mp["level"] == "warn" and mp["available_percent"] == 12.0,
+      f"(got={mp})")
+
+mp = mbp.parse_memory_pressure("The system is in a critical memory situation.\n")
+check("memory_pressure parses the critical keyword without percentages",
+      mp and mp["level"] == "critical" and mp["available_percent"] is None,
+      f"(got={mp})")
+
+mp = mbp.parse_memory_pressure("Memory status: (5% of memory in use, 4% available)\n")
+check("memory_pressure derives critical from a bare low-available percentage",
+      mp and mp["level"] == "critical", f"(got={mp})")
+
+mp = mbp.parse_memory_pressure("Memory status: (50% of memory in use, 60% available)\n")
+check("memory_pressure derives normal from a bare healthy percentage",
+      mp and mp["level"] == "normal", f"(got={mp})")
+
+check("memory_pressure garbage is unusable",
+      mbp.parse_memory_pressure("nothing recognizable here") is None)
+
+# ---- 单元：vm.swapusage 解析 ----
+swap = mbp.parse_swap_usage("total = 2048.00M  used = 512.00M  free = 1536.00M\n")
+check("swapusage parses M-suffix values into bytes and a ratio",
+      swap and swap["total_bytes"] == 2048 * 1024 * 1024
+      and swap["used_bytes"] == 512 * 1024 * 1024
+      and abs(swap["used_ratio"] - 0.25) < 1e-9, f"(got={swap})")
+
+swap = mbp.parse_swap_usage("total = 2.00G  used = 1.50G  free = 0.50G\n")
+check("swapusage parses G-suffix values",
+      swap and swap["used_bytes"] == int(1.5 * GIB)
+      and abs(swap["used_ratio"] - 0.75) < 1e-9, f"(got={swap})")
+
+swap = mbp.parse_swap_usage("total = 0B  used = 0B  free = 0B\n")
+check("swapusage with no configured swap reports zero pressure",
+      swap and swap.get("no_swap") is True and swap["used_ratio"] == 0.0,
+      f"(got={swap})")
+
+check("swapusage garbage is unusable", mbp.parse_swap_usage("free lunch") is None)
+
+# ---- 单元：压力聚合（swap 高压收紧档位） ----
+agg = mbp.aggregate_pressure(None, None)
+check("no pressure signals aggregate to normal without tightening",
+      agg["level"] == "normal" and agg["tighten_factor"] == 1.0, f"(got={agg})")
+
+agg = mbp.aggregate_pressure(None, {"used_ratio": 0.80, "no_swap": False})
+check("swap used ratio >= 0.75 aggregates to warn (factor 0.5)",
+      agg["level"] == "warn" and agg["tighten_factor"] == 0.5, f"(got={agg})")
+
+agg = mbp.aggregate_pressure(None, {"used_ratio": 0.96, "no_swap": False})
+check("swap used ratio >= 0.95 aggregates to critical (factor 0)",
+      agg["level"] == "critical" and agg["tighten_factor"] == 0.0, f"(got={agg})")
+
+agg = mbp.aggregate_pressure({"level": "critical", "used_percent": None,
+                              "available_percent": None},
+                             {"used_ratio": 0.10, "no_swap": False})
+check("memory_pressure critical wins over a mild swap ratio",
+      agg["level"] == "critical" and agg["tighten_factor"] == 0.0, f"(got={agg})")
+
+# ---- 单元：预算解析（env / flag / 默认 / 非法 fail-closed） ----
+budget, source = mbp.resolve_budget(None, {})
+check("budget falls back to the 3 GiB default",
+      budget == BUDGET_DEFAULT and source == "default", f"(got={budget},{source})")
+
+budget, source = mbp.resolve_budget(None, {"SPAWN_WORKER_MEM_BUDGET_BYTES": "1073741824"})
+check("budget reads SPAWN_WORKER_MEM_BUDGET_BYTES from env",
+      budget == GIB and source == "env", f"(got={budget},{source})")
+
+budget, source = mbp.resolve_budget("3221225472", {"SPAWN_WORKER_MEM_BUDGET_BYTES": "1"})
+check("--budget flag overrides the env value",
+      budget == BUDGET_DEFAULT and source == "flag", f"(got={budget},{source})")
+
+check("non-integer budget fails closed", mbp.resolve_budget("abc", {}) == (None, "flag"))
+check("negative-shaped budget fails closed",
+      mbp.resolve_budget(None, {"SPAWN_WORKER_MEM_BUDGET_BYTES": "-5"})[0] is None)
+
+# ---- 集成：fixture 快照驱动 probe 子进程 ----
+HEALTHY_MP = "The system has sufficient space. (21% of memory in use by apps, 62% available)\n"
+HEALTHY_SWAP = "total = 2048.00M  used = 100.00M  free = 1948.00M\n"
+HEALTHY_VM = vm_stat_text(16384, 600000, 300000, 148576)  # 16 GiB 可回收
+LOWMEM_VM = vm_stat_text(16384, 200000, 70000, 57680)     # 5 GiB 可回收
+
+FIXTURES = tempfile.mkdtemp(prefix="membudget-fixtures-")
+
+
+def fixture(name, **files):
+    path = os.path.join(FIXTURES, name)
+    write_fixture(path, **files)
+    return path
+
+
+healthy_fx = fixture("healthy", hw_memsize="34359738368\n", vm_stat=HEALTHY_VM,
+                     memory_pressure=HEALTHY_MP, vm_swapusage=HEALTHY_SWAP)
+lowmem_fx = fixture("lowmem", hw_memsize="34359738368\n", vm_stat=LOWMEM_VM,
+                    memory_pressure=HEALTHY_MP, vm_swapusage=HEALTHY_SWAP)
+swaphigh_fx = fixture("swaphigh", hw_memsize="34359738368\n", vm_stat=HEALTHY_VM,
+                      memory_pressure=HEALTHY_MP,
+                      vm_swapusage="total = 8192.00M  used = 7000.00M  free = 1192.00M\n")
+crit_fx = fixture("critical", hw_memsize="34359738368\n", vm_stat=HEALTHY_VM,
+                  memory_pressure="The system is in a critical memory situation.\n",
+                  vm_swapusage=HEALTHY_SWAP)
+empty_fx = fixture("empty")
+nohw_fx = fixture("nohw", vm_stat=HEALTHY_VM, memory_pressure=HEALTHY_MP)
+garbage_fx = fixture("garbage", hw_memsize="34359738368\n", vm_stat="pages everywhere",
+                     memory_pressure="no keywords no percentages")
+pctonly_fx = fixture("pctonly", hw_memsize="34359738368\n", memory_pressure=HEALTHY_MP)
+clamp_fx = fixture("clamp", hw_memsize="34359738368\n",
+                   vm_stat=vm_stat_text(16384, 10 ** 7, 10 ** 6, 10 ** 6),
+                   memory_pressure=HEALTHY_MP, vm_swapusage=HEALTHY_SWAP)
+
+# 正常放行：健康快照 + 默认预算 → slots >= 1，schema 字段稳定。
+code, out = run_probe(["--fixture-dir", healthy_fx])
+OK_KEYS = {"schema", "status", "reason", "sources", "budget_bytes", "budget_source",
+           "total_bytes", "page_size", "availability_basis", "available_bytes",
+           "reserve_bytes", "safe_available_bytes", "pressure", "swap", "slots",
+           "effective_available_bytes"}
+check("healthy fixture allows spawn with slots >= 1",
+      code == 0 and out and out["status"] == "ok" and out["slots"] >= 1,
+      f"(code={code} out={out})")
+check("healthy fixture emits the stable memory-budget.summary.v1 key set",
+      out and set(out.keys()) == OK_KEYS, f"(keys={sorted(out.keys()) if out else None})")
+check("schema field values keep byte-level types and units",
+      out and out["schema"] == "memory-budget.summary.v1"
+      and out["total_bytes"] == TOTAL_32G and out["page_size"] == 16384
+      and out["availability_basis"] == "vm_stat"
+      and isinstance(out["slots"], int)
+      and set(out["pressure"].keys()) == {"level", "tighten_factor", "signals"}
+      and set(out["swap"].keys()) == {"total_bytes", "used_bytes", "free_bytes",
+                                      "used_ratio"},
+      f"(out={out})")
+check("healthy fixture computes reserve as max(2GiB, 10% total)",
+      out and out["reserve_bytes"] == int(TOTAL_32G * 0.10)
+      and out["safe_available_bytes"] == 16 * GIB - int(TOTAL_32G * 0.10),
+      f"(out={out})")
+healthy_slots = out["slots"] if out else None
+
+# swap 高压：同一可用性下额度折算收紧（warn 折半 → slots 减半档）。
+code, swap_out = run_probe(["--fixture-dir", swaphigh_fx])
+check("swap high pressure tightens the slot ledger (warn halves capacity)",
+      code == 0 and swap_out and swap_out["pressure"]["level"] == "warn"
+      and swap_out["pressure"]["tighten_factor"] == 0.5
+      and swap_out["slots"] < healthy_slots
+      and swap_out["slots"] == (16 * GIB - int(TOTAL_32G * 0.10)) // 2 // BUDGET_DEFAULT,
+      f"(code={code} out={swap_out})")
+
+# 压力 critical：slots 直接归零，deny。
+code, crit_out = run_probe(["--fixture-dir", crit_fx])
+check("critical pressure zeroes slots and denies",
+      code == 3 and crit_out and crit_out["status"] == "denied"
+      and crit_out["slots"] == 0, f"(code={code} out={crit_out})")
+
+# 低内存：deny + 诊断含 可用/预算/缺口。
+code, low_out = run_probe(["--fixture-dir", lowmem_fx])
+check("low-memory fixture denies with exit 3",
+      code == 3 and low_out and low_out["status"] == "denied"
+      and low_out["slots"] == 0, f"(code={code} out={low_out})")
+reason = low_out["reason"] if low_out else ""
+check("denial reason carries available/budget/deficit diagnostics",
+      "safe_available=" in reason and "budget=" in reason and "缺口" in reason,
+      f"(reason={reason!r})")
+
+# 读取全失败：exit 1，payload 无任何额度字段。
+code, empty_out = run_probe(["--fixture-dir", empty_fx])
+check("all sources missing exits 1 with no quota fields",
+      code == 1 and empty_out and empty_out["status"] == "unprobeable"
+      and "slots" not in empty_out and "available_bytes" not in empty_out
+      and "safe_available_bytes" not in empty_out,
+      f"(code={code} out={empty_out})")
+
+code, nohw_out = run_probe(["--fixture-dir", nohw_fx])
+check("missing hw.memsize alone is unprobeable (never invent totals)",
+      code == 1 and nohw_out and nohw_out["status"] == "unprobeable"
+      and "total_bytes" not in nohw_out and "slots" not in nohw_out,
+      f"(code={code} out={nohw_out})")
+
+code, garbage_out = run_probe(["--fixture-dir", garbage_fx])
+check("unreadable vm_stat/memory_pressure snapshots fail closed",
+      code == 1 and garbage_out and garbage_out["status"] == "unprobeable",
+      f"(code={code} out={garbage_out})")
+
+# memory_pressure 百分比兜底基准（vm_stat 缺席）。
+code, pct_out = run_probe(["--fixture-dir", pctonly_fx])
+check("memory_pressure percentage is a valid availability fallback basis",
+      code == 0 and pct_out and pct_out["availability_basis"] == "memory_pressure_percent"
+      and pct_out["page_size"] is None
+      and pct_out["available_bytes"] == int(TOTAL_32G * 0.62),
+      f"(code={code} out={pct_out})")
+
+# 可用性钳位：vm_stat 荒高值不超过物理总量（钳到 32GiB 后仍足额放行）。
+code, clamp_out = run_probe(["--fixture-dir", clamp_fx])
+check("availability is clamped to the physical total",
+      code == 0 and clamp_out and clamp_out["available_bytes"] == TOTAL_32G,
+      f"(code={code} out={clamp_out})")
+
+# env 覆盖：预算 1GiB 时低内存档变为可派发 1 slot。
+code, over_out = run_probe(["--fixture-dir", lowmem_fx],
+                           env=probe_env(SPAWN_WORKER_MEM_BUDGET_BYTES=str(GIB)))
+check("smaller env budget reopens the low-memory fixture for one slot",
+      code == 0 and over_out and over_out["budget_bytes"] == GIB
+      and over_out["slots"] == 1, f"(code={code} out={over_out})")
+
+# 预算 =0：显式直通，slots=null。
+code, off_out = run_probe(["--fixture-dir", lowmem_fx],
+                          env=probe_env(SPAWN_WORKER_MEM_BUDGET_BYTES="0"))
+check("SPAWN_WORKER_MEM_BUDGET_BYTES=0 disables the gate (opt-out passthrough)",
+      code == 0 and off_out and off_out["status"] == "disabled"
+      and off_out["slots"] is None
+      and "effective_available_bytes" not in off_out
+      and "SPAWN_WORKER_MEM_BUDGET_BYTES=0" in off_out["reason"],
+      f"(code={code} out={off_out})")
+
+# 非法预算：fail-closed exit 1。
+code, bad_out = run_probe([], env=probe_env(SPAWN_WORKER_MEM_BUDGET_BYTES="3GB"))
+check("invalid env budget fails closed with config_invalid",
+      code == 1 and bad_out and bad_out["status"] == "config_invalid"
+      and "slots" not in bad_out, f"(code={code} out={bad_out})")
+
+# 真实机器 smoke：无 fixture 时现场读源，本机必须可探测且 schema 一致。
+code, real_out = run_probe([])
+check("real-machine smoke probe stays probeable with a stable schema",
+      code in (0, 3) and real_out
+      and real_out.get("status") in ("ok", "denied")
+      and real_out.get("schema") == "memory-budget.summary.v1"
+      and isinstance(real_out.get("slots"), int),
+      f"(code={code} out={real_out})")
+if real_out and real_out.get("status") == "ok":
+    print(f"  real-machine ledger: {real_out['reason']}")
+
+# ---- E2E：spawn-worker.sh 内存门（fake Orca CLI，与真实 runtime 隔离） ----
+# macOS 的 /var/folders 临时目录是 symlink；spawn-worker.sh 会把 --project 用
+# pwd -P 物理化，fake orca 返回的路径必须同样是物理路径才能命中 auto 模式。
+E2E_ROOT = os.path.realpath(tempfile.mkdtemp(prefix="membudget-e2e-"))
+E2E_PROJECT = os.path.join(E2E_ROOT, "business repo")
+E2E_WS = os.path.join(E2E_ROOT, "orca workspaces")
+E2E_ORCA_BIN = os.path.join(E2E_ROOT, "fake-orca")
+E2E_ORCA_LOG = os.path.join(E2E_ROOT, "orca-calls.log")
+E2E_STATE = os.path.join(E2E_ROOT, "state")
+E2E_FAKE_BIN = os.path.join(E2E_ROOT, "bin")
+E2E_PERSONAL_CONFIG = os.path.join(E2E_ROOT, "personal-quota-disabled.json")
+for directory in (E2E_PROJECT, E2E_WS, E2E_STATE, E2E_FAKE_BIN):
+    os.makedirs(directory, exist_ok=True)
+
+
+def git(project, *args):
+    subprocess.run(["git", "-C", project, *args], check=True, capture_output=True,
+                   text=True)
+
+
+git(E2E_PROJECT, "init", "-q")
+git(E2E_PROJECT, "config", "user.email", "mem-budget@test.local")
+git(E2E_PROJECT, "config", "user.name", "mem-budget-test")
+git(E2E_PROJECT, "commit", "-q", "--allow-empty", "-m", "init")
+with open(E2E_PERSONAL_CONFIG, "w", encoding="utf-8") as stream:
+    stream.write('{"quota_aware_routing":{"enabled":false}}\n')
+
+with open(E2E_ORCA_BIN, "w", encoding="utf-8") as stream:
+    stream.write("""#!/usr/bin/env bash
+# fake Orca CLI：测试状态文件驱动；每次调用原文追加进日志（源自 test-spawn-worker-orca.sh）。
+state="${E2E_ORCA_STATE:?}"
+log="${E2E_ORCA_LOG:?}"
+printf '%s\\n' "$*" >> "$log"
+resp_worktree() {
+  jq -cn --arg id "repo-1::$1" --arg path "$1" '{result:{worktree:{id:$id,path:$path}}}'
+}
+case "$1 $2" in
+  "worktree current")
+    resp_worktree "$E2E_ORCA_PROJECT" ;;
+  "status --json")
+    printf '%s\\n' '{"result":{"runtime":{"appVersion":"1.4.9","capabilities":["terminal.multiplex.v1","orchestration.contract.v1"]}}}' ;;
+  "worktree create")
+    name=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --name) name="$2" ;;
+      esac
+      shift
+    done
+    wt_path="$E2E_ORCA_WS/$name"
+    git -C "$E2E_ORCA_PROJECT" worktree add -q -b "$name" "$wt_path" HEAD >/dev/null 2>&1 || exit 1
+    resp_worktree "$wt_path" ;;
+  "worktree show")
+    wt=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        id:*|path:*) wt="${1#id:}"; wt="${wt#path:}" ;;
+      esac
+      shift
+    done
+    case "$wt" in *::*) wt="${wt#*::}" ;; esac
+    resp_worktree "$wt" ;;
+  "terminal create")
+    printf '%s\\n' '{"result":{"terminal":{"handle":"term-membudget"}}}' ;;
+  "terminal wait")
+    printf '%s\\n' '{"result":{"ok":true}}' ;;
+  "orchestration run-create")
+    printf '%s\\n' '{"result":{"run":{"id":"run-membudget","coordinator_handle":"term-pm-membudget"}}}' ;;
+  "orchestration task-create")
+    printf '%s\\n' '{"result":{"task":{"id":"task-membudget"}}}' ;;
+  "orchestration worker-start")
+    printf '%s\\n' '{"result":{"worker":{"dispatch":{"id":"ctx-membudget"}}}}' ;;
+  "orchestration dispatch-show")
+    printf '%s\\n' '{"result":{"dispatch":{"id":"ctx-membudget"}}}' ;;
+  *) exit 1 ;;
+esac
+""")
+os.chmod(E2E_ORCA_BIN, 0o755)
+
+with open(os.path.join(E2E_FAKE_BIN, "ps"), "w", encoding="utf-8") as stream:
+    stream.write("""#!/usr/bin/env bash
+# 隔离测试进程树：给 harness 祖先链检测一个确定的单层 codex 链。
+case "$*" in
+  *"-o ppid="*) printf '%s\\n' '1' ;;
+  *"-o comm="*) printf '%s\\n' '/usr/local/bin/codex' ;;
+  *"-o args="*) printf '%s\\n' 'codex' ;;
+  *) exit 1 ;;
+esac
+""")
+os.chmod(os.path.join(E2E_FAKE_BIN, "ps"), 0o755)
+
+
+def run_spawn(branch, fixture_dir, budget=None, timeout=300):
+    env = probe_env(
+        ORCA_CLI_COMMAND=E2E_ORCA_BIN,
+        E2E_ORCA_STATE=E2E_STATE, E2E_ORCA_LOG=E2E_ORCA_LOG,
+        E2E_ORCA_PROJECT=E2E_PROJECT, E2E_ORCA_WS=E2E_WS,
+        MULTI_AGENT_ORCHESTRATION_PERSONAL_CONFIG=E2E_PERSONAL_CONFIG,
+        MEM_BUDGET_FIXTURE_DIR=fixture_dir,
+        PATH=E2E_FAKE_BIN + os.pathsep + os.environ.get("PATH", ""),
+    )
+    if budget is not None:
+        env["SPAWN_WORKER_MEM_BUDGET_BYTES"] = budget
+    proc = subprocess.run(
+        ["bash", SPAWN_WORKER,
+         "--project", E2E_PROJECT, "--branch", branch, "--session", branch,
+         "--worker-backend", "codebuddy",
+         "--command", "codebuddy --permission-mode acceptEdits",
+         "--no-trust-auto", "--no-permission-auto", "--no-permission-auto-bg",
+         "--no-external-imports-auto", "--orca-supervised",
+         "--task-spec", "mem budget gate e2e spec"],
+        capture_output=True, text=True, env=env, timeout=timeout)
+    return proc
+
+
+def orca_log_text():
+    try:
+        with open(E2E_ORCA_LOG, encoding="utf-8") as stream:
+            return stream.read()
+    except OSError:
+        return ""
+
+
+# E2E 用例 1：低内存 fixture → 专用 exit 4 + 诊断 + 零 worktree/terminal 副作用。
+open(E2E_ORCA_LOG, "w").close()
+proc = run_spawn("membudget-deny", lowmem_fx)
+mutation_calls = [line for line in orca_log_text().splitlines()
+                  if re.search(r"worktree create|terminal create|run-create|"
+                               r"task-create|worker-start", line)]
+check("low-memory spawn is rejected with the dedicated exit code 4",
+      proc.returncode == 4,
+      f"(rc={proc.returncode} stderr={proc.stderr[-600:]})")
+check("low-memory rejection prints the stable machine marker",
+      "SPAWN_WORKER_MEM_BUDGET_DENIED" in proc.stderr
+      and "PARKED_FOR_MEMORY" in proc.stderr,
+      f"(stderr={proc.stderr[-600:]})")
+check("low-memory rejection carries available/budget/deficit diagnostics",
+      "safe_available=" in proc.stderr and "budget=" in proc.stderr
+      and "缺口" in proc.stderr, f"(stderr={proc.stderr[-600:]})")
+check("low-memory rejection happens before any worktree/terminal side effect",
+      mutation_calls == [], f"(mutation_calls={mutation_calls})")
+check("low-memory rejection leaves no Session Context on disk",
+      not os.path.exists(os.path.join(E2E_PROJECT, ".claude", "agent-sessions")))
+check("low-memory rejection leaves no worktree under the workspace root",
+      not os.path.exists(os.path.join(E2E_WS, "membudget-deny")))
+
+# E2E 用例 2：健康 fixture → 放行并输出 SPAWN_WORKER_MEM_BUDGET 账本行。
+proc = run_spawn("membudget-ok", healthy_fx)
+check("healthy fixture spawn passes the gate and exits 0",
+      proc.returncode == 0, f"(rc={proc.returncode} stderr={proc.stderr[-800:]})")
+ledger = re.search(r"SPAWN_WORKER_MEM_BUDGET: available=(\d+) budget=(\d+) slots=(\d+)",
+                   proc.stdout)
+check("healthy spawn logs the SPAWN_WORKER_MEM_BUDGET ledger line",
+      bool(ledger), f"(stdout_tail={proc.stdout[-400:]})")
+if ledger:
+    check("ledger line reflects the fixture ledger (16GiB-3.2GiB safe, 3GiB budget)",
+          int(ledger.group(1)) == 16 * GIB - int(TOTAL_32G * 0.10)
+          and int(ledger.group(2)) == BUDGET_DEFAULT and int(ledger.group(3)) >= 1,
+          f"(ledger={ledger.group(0)})")
+
+# E2E 用例 3：SPAWN_WORKER_MEM_BUDGET_BYTES=0 → 直通放行。
+proc = run_spawn("membudget-off", lowmem_fx, budget="0")
+check("budget=0 keeps a low-memory spawn flowing (explicit opt-out)",
+      proc.returncode == 0
+      and "SPAWN_WORKER_MEM_BUDGET: disabled" in proc.stdout,
+      f"(rc={proc.returncode} stdout_tail={proc.stdout[-400:]})")
+
+# ---- 清理 ----
+shutil.rmtree(FIXTURES, ignore_errors=True)
+shutil.rmtree(E2E_ROOT, ignore_errors=True)
+
+print(f"mem-budget-probe tests: {passed} passed, {failed} failed")
+sys.exit(1 if failed else 0)


### PR DESCRIPTION
## 摘要

给 spawn 决策新增物理内存预算预检门（mem budget lane）：派发前现场探测 hw.memsize / vm_stat / memory_pressure / vm.swapusage，按 per-worker 预算折算「还能安全承诺几个 worker」；额度不足不 spawn，由 PM 按巡检节奏排队重试，而不是拒绝即丢或忙等。

## 预算与 opt-out

- per-worker 预算默认 3 GiB（agent 本体约 1.2 GiB + 测试/构建余量约 2 GiB，与 v2.20.0 NODE_OPTIONS=--max-old-space-size=2048 堆顶量级对齐）。
- SPAWN_WORKER_MEM_BUDGET_BYTES 可调（十进制字节；非法值 fail-closed exit 1）；=0 显式关闭整道门，spawn 输出 SPAWN_WORKER_MEM_BUDGET: disabled 直通——与 NODE_OPTIONS 堆顶的 opt-out 风格一致。
- 压力收紧：swap used ratio ≥0.95 或 memory_pressure critical → slots=0；≥0.75 或 warn → 可承诺额度折半。可用性 = free+speculative+inactive 页（钳位物理总量）− max(2 GiB, 10%) 系统底仓。

## spawn 接线（fail-closed）

- 门位于既有 worktree 预门禁 / quota preflight 之后，provider lease / Orca worktree create / Session Context / terminal / dispatch 任何副作用之前。
- 额度不足 → 专用退出码 4 + SPAWN_WORKER_MEM_BUDGET_DENIED + 可用/预算/缺口诊断；probe 读失败同样拒绝（坏门永远不放行）；读取全失败 exit 1 且不输出额度字段。
- 放行 → PM 日志输出 SPAWN_WORKER_MEM_BUDGET: available=… budget=… slots=… 账本行。

## 排队规则（SKILL §5）

额度不足 → 本轮不 spawn、任务记 PARKED_FOR_MEMORY 并留存 probe 输出，下一轮巡检重试；同一任务连续 3 轮不足 → 正式泊车并向用户报告（附 probe JSON）。禁止忙等、禁止绕过门手动 spawn。另 SKILL §6 收口清单新增第 6 条：STATUS=done 但进程仍存活的 worker（含跨会话遗留）当轮触发收口或上报——滞留进程持续挤占额度。

## 与 v2.20.0 OOM 退避的联动

- probe 每次 spawn 现场探测、不缓存：同一任务 OOM 后 PM 重拉时天然重跑 probe，额度不足自动排队，不需要退避规则外的叠加检查；SKILL §5 退避段已明确「重拉前必须重跑 probe」。
- 互补关系：单进程堆顶管单个 worker 的失血点（node 到限自身退出），本门管总量叠加承诺，并覆盖无堆顶可依赖的非 node runtime（python 等）。
- OOM 退避的「全局并发 -1」与 slots 账本互补：退避管该任务的失败模式，账本管物理承诺总量。

## 变更文件

- scripts/mem_budget_probe.py（新增）：memory-budget.summary.v1 探测器
- scripts/spawn-worker.sh：mem_budget_gate_run 接线
- scripts/test-mem-budget-probe.py（新增）：52 项测试
- SKILL.md：§5 排队规则 + OOM 段联动、§6 收口第 6 条、§8 读取地图、版本 2.21.0
- references/22-mem-budget-lane.md（新增）：数据源、预算推导、排队状态机、OOM 交互、维护矩阵
- references/19-maintainer-validation.md：维护矩阵收录 test-mem-budget-probe.py
- CHANGELOG.md：[2.21.0] - 2026-09-06

## 验证证据（7 条命令全部真实运行）

1. python3 scripts/test-mem-budget-probe.py → 52 passed, 0 failed
   - 解析：vm_stat（16k/4k page size、行集差异、缺关键行/表头）、memory_pressure（关键词句式/百分比句式/垃圾输入）、vm.swapusage（M/G 后缀、零 swap）
   - 语义：swap 高压 warn 折半、critical 归零；全读失败 exit 1 无额度字段；--json schema key set 逐字段钉住；预算 env 覆盖与 =0 直通
   - E2E（fake Orca CLI 与真实 runtime 隔离）：低内存 fixture 退出码 4 + 诊断 + 零 worktree/terminal 副作用 + 无 Session Context 残留；健康 fixture 放行并输出账本行；=0 低内存直通
   - 真实机器 smoke：现场读源 safe_available 约 21.6–24.4 GiB → slots 7–8，pressure=normal
2. python3 -m py_compile scripts/mem_budget_probe.py → 通过
3. bash -n scripts/spawn-worker.sh → 通过
4. bash scripts/test-spawn-worker-orca.sh → 104 passed, 0 failed（E2E 成功路径带真实内存门通过）
5. bash scripts/test-spawn-worker-flags.sh → 31 passed, 0 failed
6. bash scripts/test-spawn-worker-deps.sh → 18 pass, 0 fail
7. bash scripts/test-spawn-worker-verification.sh → 13 passed, 0 failed

## 关键设计取舍

- 只读门槛、不做回收：不自动杀进程/不降级其他应用/不清 swap；非目标=跨项目全局注册表（现场物理探测天然覆盖跨项目占用）。
- 压力收紧取最坏信号；vm_stat Swapins/Swapouts 为累计计数不参与判定。
- 退出码 4 专用（区别于 3=quota/既有 worktree 预门禁、2=isolation、64=参数配置），PM 可机器区分停车原因。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Task: TASK-2026-09-06-MEM-BUDGET
Agent: membudget-glm53
