### PR TITLE
fix(multi-agent-orchestration): mem budget 百分比兜底钳位与 OOM 段脱敏 [2.21.1]

### DIFF
--- a/skills/multi-agent-orchestration/CHANGELOG.md
+++ b/skills/multi-agent-orchestration/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [2.21.1] - 2026-09-06
+
+### 修复
+
+- `scripts/mem_budget_probe.py` memory_pressure 百分比兜底路径补齐钳位：`available = total × pct/100` 后与 vm_stat 主路径一致地取 `min(available, total)`，病态快照（可用百分比 >100%）不再虚增可用内存（references/22 §3 声明的 [0, total] 钳位至此两条基准路径全覆盖）。
+- SKILL §5 OOM 识别信号脱敏：本机崩溃报告路径 `~/Library/Logs/DiagnosticReports/node-*.ips` 改为抽象表述「系统崩溃报告目录（DiagnosticReports）中 node OOM 报告新增且时间吻合」，识别信号保留、随行 doc 资产不再含本机路径（DEC-141 边界）。
+
+### 验证
+
+- `scripts/test-mem-budget-probe.py` 53/53 通过：新增病态 fixture 用例（memory_pressure 可用百分比 150% 时 `availability_basis=memory_pressure_percent` 且钳位到物理总量），既有 52 项全量回归。
+- `bash -n scripts/spawn-worker.sh` 语法回归通过（本次未改其逻辑）。
+
 ## [2.21.0] - 2026-09-06
 
 ### 新增

--- a/skills/multi-agent-orchestration/SKILL.md
+++ b/skills/multi-agent-orchestration/SKILL.md
@@ -3,7 +3,7 @@ name: multi-agent-orchestration
 description: 编排两个以上边界独立的本地 worker，使用 Orca Run/Task/Dispatch、独立 worktree/session 或 tmux 回退，由 PM 负责拆解、派发、巡检、429 停滞恢复、独立验收、PR 收口与临时资源清理；也用于用户明确要求“并行推进”“多个 worker”“PM 总控”“Wave Autopilot”或防止 PM 直接实现逃逸。不要用于单个短任务、纯状态同步，或仅需 Git 分支、提交、PR、merge 规则的工作。
 license: MIT
 metadata:
-  version: "2.21.0"
+  version: "2.21.1"
   homepage: https://github.com/cat-xierluo/legal-skills
   author: 杨卫薪律师（微信ywxlaw）
 ---
@@ -140,7 +140,7 @@ Wave Autopilot 只有用户明确授权并在项目任务源固定策略后才�
 
 跨项目检查 Orca Worker 是否因 429/usage limit 停在 idle 时，运行 `scripts/orca_rate_limit_recovery.py --manifest <私有清单>`；默认只读，只有显式 `--execute` 才对高置信 `RATE_LIMIT_IDLE` 通过 terminal 输入通道发送一次固定“继续”。tmux、单关键词/陈旧 tail、未分组身份和状态不确定一律不处置；`WAKE_ACCEPTED` 不等于额度恢复或业务继续。完整 manifest、状态机、错峰、幂等、TOCTOU 与退出码读取 `references/20-orca-rate-limit-recovery.md`。
 
-**Worker node OOM 识别与退避**（2026-09-05 事故：多 worker 长输出使会话内 node 进程 V8 堆耗尽 `FatalProcessOutOfMemory → SIGABRT`，PM 周期重拉形成崩溃循环并一度触发整机强制重启）。`spawn-worker.sh` v2.20.0 起默认给 worker 会话注入 `NODE_OPTIONS=--max-old-space-size=2048`（`SPAWN_WORKER_NODE_MAX_OLD_SPACE_MB=0` 可关），worker 到限自身退出而非拖垮系统。PM 巡检发现 worker node OOM（退出码 134 / SIGABRT / 日志含 `FatalProcessOutOfMemory` / 机器 `~/Library/Logs/DiagnosticReports/node-*.ips` 新增且时间吻合）时：同任务不得立即重拉，至少等下一轮巡检并全局并发 -1，且重拉前必须重跑内存预算预检（probe 每次 spawn 都现场探测、不缓存；额度不足按 `PARKED_FOR_MEMORY` 排队，不得绕过）；同一任务连续 2 次 OOM 后停止重拉、泊车并向用户报告——这通常意味着任务本身产生超长输出（全量日志聚合、超大测试跑），需任务侧降输出或拆分，而不是更用力地重试。
+**Worker node OOM 识别与退避**（2026-09-05 事故：多 worker 长输出使会话内 node 进程 V8 堆耗尽 `FatalProcessOutOfMemory → SIGABRT`，PM 周期重拉形成崩溃循环并一度触发整机强制重启）。`spawn-worker.sh` v2.20.0 起默认给 worker 会话注入 `NODE_OPTIONS=--max-old-space-size=2048`（`SPAWN_WORKER_NODE_MAX_OLD_SPACE_MB=0` 可关），worker 到限自身退出而非拖垮系统。PM 巡检发现 worker node OOM（退出码 134 / SIGABRT / 日志含 `FatalProcessOutOfMemory` / 系统崩溃报告目录（DiagnosticReports）中 node OOM 报告新增且时间吻合）时：同任务不得立即重拉，至少等下一轮巡检并全局并发 -1，且重拉前必须重跑内存预算预检（probe 每次 spawn 都现场探测、不缓存；额度不足按 `PARKED_FOR_MEMORY` 排队，不得绕过）；同一任务连续 2 次 OOM 后停止重拉、泊车并向用户报告——这通常意味着任务本身产生超长输出（全量日志聚合、超大测试跑），需任务侧降输出或拆分，而不是更用力地重试。
 
 **物理内存预算排队（mem budget lane）**：`spawn-worker.sh` 在任何 worktree/terminal/lease/dispatch 副作用之前运行 `scripts/mem_budget_probe.py`，按 per-worker 预算（默认 3 GiB；`SPAWN_WORKER_MEM_BUDGET_BYTES` 可调，`=0` 显式关闭整道门）把现场可用物理内存折算成可派发额度。额度不足或探测不可读时 spawn 以专用退出码 4 拒绝，输出 `SPAWN_WORKER_MEM_BUDGET_DENIED` 与 可用/预算/缺口 诊断；放行则在 PM 日志留下 `SPAWN_WORKER_MEM_BUDGET: available=… budget=… slots=…` 账本行。PM 收到该拒绝不得忙等、不得改走手动 spawn：本轮巡检把任务记 `PARKED_FOR_MEMORY` 并留存 probe 输出，下一轮巡检重试；同一任务连续 3 轮额度不足则正式泊车并向用户报告（附 probe JSON）。单进程堆顶（v2.20.0）管单个 worker 的失血点，本门管总量叠加承诺，也覆盖无堆顶可依赖的非 node runtime。数据源、预算推导、压力收紧与排队状态机读取 `references/22-mem-budget-lane.md`。
 

--- a/skills/multi-agent-orchestration/scripts/mem_budget_probe.py
+++ b/skills/multi-agent-orchestration/scripts/mem_budget_probe.py
@@ -318,7 +318,9 @@ def evaluate(snapshots: dict[str, str | None], budget_bytes: int,
         availability_basis = "vm_stat"
         page_size: int | None = vm_stat["page_size"]
     elif memory_pressure is not None and memory_pressure["available_percent"] is not None:
-        available_bytes = int(total_bytes * memory_pressure["available_percent"] / 100.0)
+        # 百分比兜底同样钳位到 [0, total]：病态快照（>100%）不得虚增可用内存。
+        available_bytes = min(int(total_bytes * memory_pressure["available_percent"] / 100.0),
+                              total_bytes)
         availability_basis = "memory_pressure_percent"
         page_size = None
     else:

--- a/skills/multi-agent-orchestration/scripts/test-mem-budget-probe.py
+++ b/skills/multi-agent-orchestration/scripts/test-mem-budget-probe.py
@@ -240,6 +240,8 @@ pctonly_fx = fixture("pctonly", hw_memsize="34359738368\n", memory_pressure=HEAL
 clamp_fx = fixture("clamp", hw_memsize="34359738368\n",
                    vm_stat=vm_stat_text(16384, 10 ** 7, 10 ** 6, 10 ** 6),
                    memory_pressure=HEALTHY_MP, vm_swapusage=HEALTHY_SWAP)
+pctclamp_fx = fixture("pctclamp", hw_memsize="34359738368\n",
+                      memory_pressure="Memory status: (10% of memory in use, 150% available)\n")
 
 # 正常放行：健康快照 + 默认预算 → slots >= 1，schema 字段稳定。
 code, out = run_probe(["--fixture-dir", healthy_fx])
@@ -324,6 +326,14 @@ code, clamp_out = run_probe(["--fixture-dir", clamp_fx])
 check("availability is clamped to the physical total",
       code == 0 and clamp_out and clamp_out["available_bytes"] == TOTAL_32G,
       f"(code={code} out={clamp_out})")
+
+# 病态百分比兜底：memory_pressure 可用百分比 >100%（病态快照）时钳位到物理总量。
+code, pctclamp_out = run_probe(["--fixture-dir", pctclamp_fx])
+check("pathological memory_pressure percent above 100 clamps to the physical total",
+      code == 0 and pctclamp_out
+      and pctclamp_out["availability_basis"] == "memory_pressure_percent"
+      and pctclamp_out["available_bytes"] == TOTAL_32G,
+      f"(code={code} out={pctclamp_out})")
 
 # env 覆盖：预算 1GiB 时低内存档变为可派发 1 slot。
 code, over_out = run_probe(["--fixture-dir", lowmem_fx],


### PR DESCRIPTION
## 摘要
- mem_budget_probe.py memory_pressure 百分比兜底路径补 min(available, total) 钳位，与 references/22 §3 声明一致（reviewer D3 观察项 1）
- SKILL §5 OOM 段识别信号抽象化：本机路径改为"系统崩溃报告目录（DiagnosticReports）"，保留信号不含机器级细节（DEC-141 边界，reviewer D6 观察项 2）
- 版本 2.21.1；CHANGELOG 条目成文

## 测试计划
- test-mem-budget-probe.py 53/53（新增 >100% 病态 fixture 钳位用例；PM 复跑通过）
- py_compile / bash -n / test-spawn-worker-flags.sh 31/31 通过

Task: TASK-2026-09-06-MEM-BUDGET-FOLLOWUPS
Agent: membudget-fix-glm53