### PR TITLE
docs(git-workflow): 长期分支 PR 实战三坑入册 [1.8.3]

### DIFF
--- a/skills/git-workflow/CHANGELOG.md
+++ b/skills/git-workflow/CHANGELOG.md
@@ -1,5 +1,14 @@
 # 变更日志
 
+## [1.8.3] - 2026-09-07 - 长期分支 PR 实战三坑入册（custom-skills 拆分线实证）
+
+### 改进
+
+- **集成 PR 时机红线**（reference §7 新增"时机红线"）：base=默认主干的总 PR 只在里程碑达成时开；功能线推进期只开子 PR（base=长期分支）。提早开的总 PR 保持 open 仅作提醒，并在项目任务源注明。
+- **GitHub 自动关闭 PR 的坑**（reference §7 新增）：head 分支 force-push 重置致与 base 无差异时，PR 被自动 CLOSED（无通知）；重开后 PR 号变化，须更新项目任务源与记忆中的旧号引用。
+- **squash 重做断裂与树等价验证**（reference §4 新增）：同一树内容 squash 重做后与原 squash 无共同祖先，GitHub 判 CONFLICTING；给出本地解决流程（merge→以完成态树 checkout→`git diff <完成态> HEAD --stat` 必须为空才 push），树等价验证是 fail-closed 门。
+- SKILL.md 长期集成分支小节补一行索引指向 §4/§7。
+
 ## [1.8.2] - 2026-09-05
 
 ### 改进

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -3,7 +3,7 @@ name: git-workflow
 description: Git 工作流安全助手。本技能应在需要执行分支管理、长期集成分支（long-lived integration branch）、Monorepo 安全合并、PR 创建/审查/合并、冲突处理、cherry-pick、安全回退、stale/已合并分支审计与清理（branch cleanup，含 squash/rebase merge 校验）、开 worktree 前 base 同步检查（防 main drift 致 PR not mergeable）、多 worktree 并行时 main worktree 占用处理时使用。不要用于：批量生成提交信息、项目任务分配、长期任务状态管理或本地多 Agent 会话编排。
 license: MIT
 metadata:
-  version: "1.8.2"
+  version: "1.8.3"
   homepage: https://github.com/cat-xierluo/legal-skills
   author: 杨卫薪律师（微信ywxlaw）
 ---
@@ -131,6 +131,7 @@ team-feature-a
 - 子 PR 经独立验收后 squash merge 到长期分支；达到预先命名且有退出条件的里程碑后，才由长期分支向默认主干提集成 PR。
 - 默认主干的通用修复先进入默认主干，再在无待合并子 PR 的波次边界 merge 到长期分支；同步后冻结本波 base，避免 worker 基线漂移。
 - 长期分支禁止 rebase、force-push 或随子 PR 删除；里程碑合入默认主干后也继续保留，直到功能线被明确关闭。
+- 集成 PR（base=默认主干）只在里程碑达成时开；功能线推进期只开子 PR（base=长期分支）。head 分支被重置致 PR 自动 CLOSED、squash 重做的 CONFLICTING 与树等价验证，详见 references/long-lived-integration-branch.md 第 4/7 节。
 
 执行建线、同步、PR、里程碑和清理时，读取 `references/long-lived-integration-branch.md`。项目专属的分支名、固定 Worktree 路径、任务字段和里程碑门禁留在项目规则中，不写入本通用 Skill。
 

--- a/skills/git-workflow/references/long-lived-integration-branch.md
+++ b/skills/git-workflow/references/long-lived-integration-branch.md
@@ -45,6 +45,26 @@
 
 ## 4. Worker 分支与子 PR
 
+### 子 PR 的 squash 重做断裂与树等价验证（2026-09-07 实战）
+
+长期分支上的提交只应经子 PR 进入（不直推）。若历史上已有直推提交、事后回退分支改走 PR 重做，注意：**同一树内容经 squash 重做后与原 squash 提交无共同祖先**——即使内容逐字节相同，GitHub 也判 `CONFLICTING`（merge-base 落在更早的基点，两边"各自"做了同样改动）。处置流程：
+
+```bash
+# 1) 本地合并，冲突一律以"完成态"树为准
+git checkout <integration-branch>
+git merge --no-ff <step-branch> || true
+git checkout <step-branch> -- . && git add -A
+git commit --no-edit -m "merge: <step>（PR #N，冲突以完成态树解决）"
+# 2) 树等价验证——必须 0 差异才允许 push
+git diff <step-branch> HEAD --stat   # 输出必须为空
+git push origin <integration-branch>
+# 3) push 后 PR 自动转 MERGED（head 已包含于 base）
+```
+
+树等价验证是本流程的 fail-closed 门：`--stat` 非空说明冲突解决引入了内容偏差，禁止 push。
+
+
+
 每个 worker 在创建 Worktree 前刷新远端，并从长期集成分支的远端跟踪 ref 创建短分支：
 
 ```bash
@@ -108,6 +128,20 @@ gh pr create \
 同步期间若长期分支、默认主干、任务合同或待合并 PR 发生漂移，旧验收失效，重新核验后再派发或合并。
 
 ## 7. 里程碑集成 PR
+
+### 时机红线（2026-09-07 实战教训）
+
+集成 PR（base=默认主干）只在里程碑真正达成时开——"还要继续拆/还有子 PR 在排"就不是里程碑。提早开总 PR 的代价：功能线未完就得反复关注它的过期与 rebase，且总 PR 会掩盖"哪些子 PR 已合入"的可见性。正确形态是**先只开子 PR（base=长期分支），总 PR 留到退出条件满足的那一刻**。若总 PR 已提早存在且功能线仍在推进，保持 open 但不合并，并在项目任务源注明"总 PR 仅作合并提醒，里程碑未到"。
+
+### GitHub 自动关闭 PR 的坑（2026-09-07 实战）
+
+对 PR 的 head 分支 force-push 重置（如把分支回退到 base 以重做子 PR 纪律）时，一旦 head 与 base 无差异，GitHub 会**自动把该 PR 置为 CLOSED**——不留通知、容易被误读为"被拒绝"。处置：
+
+- 重做完成后必须重开 PR（`gh pr create` 同 base/head），PR 号会变；
+- 项目任务源、会话记忆里凡引用旧 PR 号的地方逐一更新；
+- 判别方法：`gh pr view <n> --json state` 显示 `CLOSED` 且 commits=0，即此坑。
+
+
 
 长期分支向默认主干提 PR 前，必须满足：
 


### PR DESCRIPTION
## 来源：custom-skills 拆分线（2026-09-06/07）实战

今晚长期分支（feat/runner-split-e-d-f-260906）PR 化改造中踩出的三个 skill 未覆盖场景，全部实证后入册：

### 1. 集成 PR 时机红线（§7 新增）
杨律师指出：总 PR（base=main）在功能线还要继续拆时就提是错的——skill 原则已有但表述不够防呆。新增"时机红线"小节：里程碑未到只开子 PR；提早开的总 PR 保持 open 仅作合并提醒。

### 2. GitHub 自动关闭 PR 的坑（§7 新增）
实证事件：#109 因 head 分支重置（改走子 PR 纪律回退分支）被 GitHub 静默 CLOSED（commits=0）。入册：判别方法（state=CLOSED 且 commits=0）、重开改号须更新项目任务源引用。

### 3. squash 重做断裂与树等价验证（§4 新增）
实证事件：#112 与 #111 内容树相同仍判 CONFLICTING——squash 重做后无共同祖先，merge-base 落在基点。入册完整 fail-closed 流程：merge → `git checkout <完成态> -- .` → **树等价验证**（`git diff <完成态> HEAD --stat` 为空才 push）→ push 后 PR 自动 MERGED。

## 改动
- references/long-lived-integration-branch.md §4/§7 两节新增
- SKILL.md 长期集成分支小节补一行索引
- CHANGELOG [1.8.3]；纯文档