### PR TITLE
fix(tingwu-asr): 登录 cookie 落盘前暖机并校验关键字段

### DIFF
--- a/skills/tingwu-asr/scripts/login_pw.py
+++ b/skills/tingwu-asr/scripts/login_pw.py
@@ -187,10 +187,68 @@ def main():
                 sys.exit(3)
             print("[5] 登录成功 ✓")
 
-        print("[6] 保存 cookie...")
+        print("[6] 等待 SPA 完整初始化(暖机 + cookie 轮询)...")
         page.goto("https://tingwu.aliyun.com/home", wait_until="domcontentloaded", timeout=60000)
+        page.wait_for_timeout(5000)
+        # 触发听悟关键 API 拉取,促使 XSRF-TOKEN / JSESSIONID / arms_uid 等
+        # 二次下发完成(SPA 登录态 cookie 集分两批下发,首批是 aliyun 主域,
+        # 第二批是听悟自身的 _bl_uid / XSRF-TOKEN 等)
+        try:
+            warmup = page.evaluate(
+                """async () => {
+                  try {
+                    await fetch('/api/account/v2/user/info?c=web', { credentials: 'include' });
+                    await fetch('/api/tingwu/account/info?c=web', { credentials: 'include' });
+                    return 'ok';
+                  } catch (e) { return 'err: ' + e.message; }
+                }"""
+            )
+            print(f"   暖机 API 调用: {warmup}")
+        except Exception as e:
+            print(f"   (暖机 API 调用失败: {e};继续,可能受限)")
         page.wait_for_timeout(3000)
+
+        # 多轮 ctx.cookies() 直到两次结果数量稳定(关键 cookie 已全部下发)
+        # 经验值:登录后 ~8s 内会追加 XSRF-TOKEN/JSESSIONID/arms_uid/_bl_uid 等
+        print("[6] 等待 cookie 集合稳定(轮询)...")
+        stable = 0
+        prev = -1
+        for i in range(20):
+            cur = len([
+                c for c in ctx.cookies()
+                if any(d in c.get("domain", "") for d in
+                       ("aliyun.com", "taobao.com", "alicdn.com"))
+            ])
+            if cur == prev and cur >= 20:
+                stable += 1
+                if stable >= 2:
+                    print(f"   cookie 已稳定({cur} 个,稳定 {stable} 轮)")
+                    break
+            else:
+                stable = 0
+            prev = cur
+            page.wait_for_timeout(1500)
+        else:
+            print(f"   (警告:cookie 集合未完全稳定,当前 {prev} 个;继续保存)")
+
         raw = ctx.cookies()
+        names = {c["name"] for c in raw}
+        # 听悟 API 双重校验关键 cookie;缺失则 [CMN.NotLogin]
+        # - login_aliyunid_ticket: HttpOnly 主会话 ticket
+        # - XSRF-TOKEN: API 反 CSRF token(配合 header 双重校验)
+        # - JSESSIONID: aliyun 网关会话
+        # - atpsida / isg: 风控标识
+        critical = ("login_aliyunid_ticket", "login_aliyunid",
+                    "XSRF-TOKEN", "JSESSIONID", "atpsida", "isg")
+        missing = [k for k in critical if k not in names]
+        if missing:
+            print(f"!! 关键 cookie 缺失: {missing}")
+            print("   听悟 API 将判 [CMN.NotLogin] 并拒绝转录。请:")
+            print("   1) 重新运行本脚本登录;")
+            print("   2) 检查浏览器是否被广告拦截/隐私插件劫持 cookie。")
+            browser.close()
+            sys.exit(4)
+
         cookie_map = {}
         for c in raw:
             d = c.get("domain", "")
@@ -199,6 +257,7 @@ def main():
         data = {
             "saved_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             "cookies": cookie_map,
+            "verified_critical_cookies": list(critical),
         }
         COOKIE_PATH.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
         print(f"[6] 已保存 {len(cookie_map)} 个 cookie → {COOKIE_PATH}")


### PR DESCRIPTION
## 摘要

修复听悟 skill 登录流程偶发的 `[CMN.NotLogin]: 未登录` 失败：保存 cookie 前仅等 3 秒，SPA 第二批关键字段（XSRF-TOKEN / JSESSIONID / arms_uid / _bl_uid / aliyun_lang 等）尚未下发，导致 API 双重校验失败。

## 复现条件

- 用户凭据正常、浏览器能正常弹出阿里云登录框
- `python3 scripts/login_pw.py` 跑通流程，但 `check_auth.py` 返回 `[CMN.NotLogin]: 未登录`
- 手工用 `context.cookies()` 抓 cookie 时只能拿到 19 个（少 7 个），其中关键的 `XSRF-TOKEN` / `JSESSIONID` 缺失

## 修复

- 保存 cookie 前，先导航 `/home` 等 5 秒 + 主动触发 `user/info` 与 `tingwu/account/info` 两个 API（暖机），促使第二批 cookie 下发
- 多轮 `ctx.cookies()` 轮询直到 cookie 数稳定 2 轮（默认阈值 ≥20），覆盖 SPA 分批下发窗口期
- 增加关键 cookie 校验：`login_aliyunid_ticket / login_aliyunid / XSRF-TOKEN / JSESSIONID / atpsida / isg`，缺失则 `sys.exit(4)` 并提示重试
- cookies.json 增加 `verified_critical_cookies` 字段留痕，便于事后排错

## 测试计划

- [x] 语法校验 `python3 -m py_compile`
- [x] 实测一次完整登录：抓到 26 个 cookie，`check_auth.py` 返回账户信息（userId 19354）
- [ ] 复现路径未自动化（依赖 SPA 加载时序，单测意义有限）

## Agent 归属

- Agent: Claude Code (MiniMax-M3)
- Git author: maoking <maoking@example.com>
- 触发来源: 用户要求以 PR 方式提交 2026-09-09 听悟登录修复

## 关联任务

- 关联 2026-09-09 听悟转录 425MB 视频流程：转录成功后发现 [login_pw.py 抽出 cookie 不全](本地对话)；用户要求修这个 bug 并 PR 提交

## 风险

- 低风险。cookie 校验失败时 `sys.exit(4)`，CI/CD 中若有此流程需要适配新的退出码
- 多轮轮询最多耗时约 30 秒（20 轮 × 1.5s），登录总时长从 ~30 秒 增加到 ~45-60 秒，可接受