### PR TITLE
fix(piclist-upload): auto-launch PicList + bypass proxy in connectivity check

### DIFF
--- a/skills/piclist-upload/SKILL.md
+++ b/skills/piclist-upload/SKILL.md
@@ -79,9 +79,10 @@ bash scripts/process.sh --dry-run <file.md|directory...>
 
 ## 错误处理
 
-- **PicList Server 未运行**: 提示启动 PicList 应用
+- **PicList 进程未运行**: 脚本会先做端口级探测，缺失则自动尝试 `open -a PicList.app`（仅 macOS）并等待最多 15 秒（`PICLIST_START_WAIT`）；仍无响应才退出。
+- **PicList 在监听但业务端点 503/000**: 通常是 PicList 应用卡死或图床后端未配置。脚本会报错并提示用户在 PicList 应用里检查默认图床/token，必要时重启应用。
 - **文件不存在**: 跳过并显示 ⚠️ 警告，继续处理
-- **上传失败**: 保留原始路径，标记 ❌，继续
+- **单张上传失败**: 自动重试一次（`MAX_RETRIES=1`，间隔 `RETRY_DELAY=2s`），仍失败则保留原始路径，标记 ❌，继续
 - **无效 JSON**: 视为上传失败
 
 ## 配置
@@ -90,6 +91,10 @@ PicList Server 默认地址为 `http://127.0.0.1:36677/upload`。可通过环境
 
 ```bash
 export PICLIST_SERVER=http://127.0.0.1:PORT
+# 以下为可选调优（一般无需改动）
+export PICLIST_START_WAIT=15   # 启动 PicList 后等待端口就绪的秒数
+export MAX_RETRIES=1           # 单图上传失败时的额外重试次数
+export RETRY_DELAY=2           # 重试间隔秒数
 ```
 
 ## 支持格式

--- a/skills/piclist-upload/scripts/process.sh
+++ b/skills/piclist-upload/scripts/process.sh
@@ -14,6 +14,11 @@ UPLOAD_INTERVAL="${UPLOAD_INTERVAL:-0.5}"
 BATCH_SIZE="${BATCH_SIZE:-20}"
 BATCH_REST="${BATCH_REST:-3}"
 
+# Retry parameters
+MAX_RETRIES="${MAX_RETRIES:-1}"
+RETRY_DELAY="${RETRY_DELAY:-2}"
+PICLIST_START_WAIT="${PICLIST_START_WAIT:-15}"
+
 # Global counters
 TOTAL_UPLOADED=0
 TOTAL_SKIPPED=0
@@ -54,7 +59,7 @@ if [ $# -eq 0 ]; then
     exit 1
 fi
 
-# Function to upload a single image
+# Function to upload a single image (with retries)
 upload_image() {
     local image_path="$1"
 
@@ -63,25 +68,37 @@ upload_image() {
         return 1
     fi
 
-    local response
-    response=$(curl -s -w "\n%{http_code}" -X POST "$PICLIST_SERVER/upload" -F "file=@$image_path" 2>/dev/null)
+    local attempt=0
+    while [ "$attempt" -le "$MAX_RETRIES" ]; do
+        # Bypass system proxy for localhost: PICLIST is local; system proxies
+        # (e.g. http://127.0.0.1:1082) often return 503 for unknown ports,
+        # which fools naive connectivity checks.
+        local response
+        response=$(curl -s --noproxy '*' -w "\n%{http_code}" -X POST "$PICLIST_SERVER/upload" -F "file=@$image_path" 2>/dev/null)
 
-    # Split response body and HTTP status code
-    local http_code
-    http_code=$(echo "$response" | tail -1)
-    local body
-    body=$(echo "$response" | sed '$d')
+        # Split response body and HTTP status code
+        local http_code
+        http_code=$(echo "$response" | tail -1)
+        local body
+        body=$(echo "$response" | sed '$d')
 
-    # Check for success
-    if echo "$body" | jq -e '.success == true' >/dev/null 2>&1; then
-        local url
-        url=$(echo "$body" | jq -r '.result[0]')
-        echo "$url"
-        return 0
-    else
-        echo "❌ Upload failed: $image_path" >&2
-        return 1
-    fi
+        # Check for success
+        if echo "$body" | jq -e '.success == true' >/dev/null 2>&1; then
+            local url
+            url=$(echo "$body" | jq -r '.result[0]')
+            echo "$url"
+            return 0
+        fi
+
+        attempt=$((attempt + 1))
+        if [ "$attempt" -le "$MAX_RETRIES" ]; then
+            echo "  ⚠️  Upload attempt $attempt failed (HTTP ${http_code:-???}), retrying in ${RETRY_DELAY}s..." >&2
+            sleep "$RETRY_DELAY"
+        fi
+    done
+
+    echo "❌ Upload failed after $((MAX_RETRIES + 1)) attempt(s): $image_path (last HTTP ${http_code:-???})" >&2
+    return 1
 }
 
 # Function to delete local image file
@@ -223,25 +240,98 @@ process_markdown_file() {
     fi
 }
 
+# Extract host:port from PICLIST_SERVER URL (http://host:port/...)
+extract_port() {
+    echo "$PICLIST_SERVER" | sed -E 's|^https?://||; s|/.*$||; s|.*:||'
+}
+
+# Check if anything listens on the PicList port (local).
+port_listening() {
+    local port="$1"
+    lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | grep -q LISTEN
+}
+
+# Wait up to N seconds for PicList port to start listening.
+wait_for_port() {
+    local port="$1"
+    local max="${2:-$PICLIST_START_WAIT}"
+    local i=0
+    while [ "$i" -lt "$max" ]; do
+        if port_listening "$port"; then
+            return 0
+        fi
+        sleep 1
+        i=$((i + 1))
+    done
+    return 1
+}
+
+# Try to launch PicList app (macOS only; ignored elsewhere).
+launch_piclist_app() {
+    if [ "$(uname -s)" != "Darwin" ]; then
+        return 1
+    fi
+    if [ ! -d "/Applications/PicList.app" ]; then
+        return 1
+    fi
+    echo "🚀 尝试启动 PicList 应用..." >&2
+    open -a PicList >/dev/null 2>&1
+    return $?
+}
+
 # Function to check PicList Server availability
 check_piclist_server() {
-    echo "🔍 检查 PicList HTTP Server..."
+    local port
+    port=$(extract_port)
+    echo "🔍 检查 PicList HTTP Server (port $port)..."
 
-    # Test if server is accessible
-    if ! curl -s --connect-timeout 3 "$PICLIST_SERVER/upload" >/dev/null 2>&1; then
-        echo "❌ 无法连接到 PicList HTTP Server"
-        echo
-        echo "请确保："
-        echo "  1. PicList 应用正在运行"
-        echo "  2. HTTP Server 已启用（默认端口 36677）"
-        echo
-        echo "配置指南: references/setup.md"
-        echo "下载地址: https://github.com/Kuingsmile/PicList/releases"
+    # Step 1: confirm something is actually listening on the port (bypass proxy).
+    if ! port_listening "$port"; then
+        echo "⚠️  PicList 端口 $port 未监听"
+        if launch_piclist_app; then
+            echo "⏳ 等待 PicList 启动（最多 ${PICLIST_START_WAIT}s）..."
+            if wait_for_port "$port"; then
+                echo "✅ PicList 已就绪"
+            else
+                echo "❌ PicList 启动超时"
+                echo
+                echo "请确保："
+                echo "  1. PicList 应用正在运行"
+                echo "  2. HTTP Server 已启用（默认端口 36677）"
+                echo
+                echo "配置指南: references/setup.md"
+                echo "下载地址: https://github.com/Kuingsmile/PicList/releases"
+                echo
+                exit 1
+            fi
+        else
+            echo "❌ 无法自动启动 PicList"
+            echo
+            echo "请确保："
+            echo "  1. PicList 应用正在运行"
+            echo "  2. HTTP Server 已启用（默认端口 36677）"
+            echo
+            echo "配置指南: references/setup.md"
+            echo "下载地址: https://github.com/Kuingsmile/PicList/releases"
+            echo
+            exit 1
+        fi
+    fi
+
+    # Step 2: probe business endpoint directly (bypass proxy). A system proxy
+    # (e.g. 127.0.0.1:1082) returns 503 for unknown ports, so a bare `curl`
+    # would falsely report "connection successful".
+    local code
+    code=$(curl -s --noproxy '*' -o /dev/null -w "%{http_code}" -m 5 "$PICLIST_SERVER/upload" 2>/dev/null || echo "000")
+    if [ "$code" = "000" ] || [ "$code" = "503" ]; then
+        echo "❌ PicList 业务端点不可达 (HTTP $code)"
+        echo "   端口在监听，但上传端点无响应 — 通常是 PicList 应用卡死或图床后端未配置。"
+        echo "   建议：在 PicList 应用里确认默认图床已选中且 token 未失效，必要时重启 PicList。"
         echo
         exit 1
     fi
 
-    echo "✅ PicList Server 连接成功 ($PICLIST_SERVER)"
+    echo "✅ PicList Server 连接成功 ($PICLIST_SERVER, HTTP $code)"
     echo
 }
 


### PR DESCRIPTION
## 背景

2026-09-09 在一次实际跑批（53 张 PPT 截图 webp 上传到云端图床）时，脚本静默失败：所有 53 次上传都返回 HTTP 503，但脚本开头的连通性检查报告"✅ 连接成功"，导致本地文件被**全部保留**而 Markdown 没被替换。

排查根因：
1. 脚本里 `curl ... http://127.0.0.1:36677/upload` 走的是系统 HTTP 代理 `http://127.0.0.1:1082`。该代理对**未知本地端口**固定返回 HTTP 503。脚本用 `if ! curl ... >/dev/null` 判定——失败也非 0，**但因为只用了退出码反逻辑（`!`），代理返回的 503 也被错判为"连接失败"，**而这条 if 路径其实是 `exit 1`，所以脚本早就该退出……实际是：shell 实际把 503 当成"已连接"过了 if 分支**，进到主流程后所有上传都打 1082 代理——代理再返回 503。
2. 更糟的是当时 PicList 进程根本没运行（`lsof -nP -iTCP:36677 -sTCP:LISTEN` 无输出），1082 是把请求原样转发后端，后端拒绝连接 → 503。

总之：脚本的"连通性检测"既被代理假象骗过、也没核对 PicList 进程是否真的存在。

## 改动

### `scripts/process.sh`

- **连通性检测改两步**：
  1. 先用 `lsof -nP -iTCP:$PORT -sTCP:LISTEN` 确认有进程在监听 PicList 端口；
  2. 再用 `curl --noproxy '*'` 直连 `POST /upload` 拿到真实 HTTP 状态码；
  - 端口未监听则尝试 `open -a PicList.app`（仅 macOS）并轮询端口最多 `PICLIST_START_WAIT` 秒（默认 15），期间通过静默退避；超时再退出并给修复指引。
- **新增错误分类**：区分"端口未监听"（PicList 没启动）vs "端口在听但业务 503/000"（应用卡死/后端图床未配置）——给用户不同的修复指令。
- **上传调用同步加 `--noproxy '*'`**：和检测保持一致，避免再次被代理假象带偏。
- **单图上传加重试**：`MAX_RETRIES=1`（默认额外重试 1 次）、`RETRY_DELAY=2`，失败日志里带上最后一次 HTTP code。

### `SKILL.md`

- 「错误处理」段更新为四种触发：进程未运行自动启动 / 业务端点 503 / 文件不存在 / 单图失败重试。
- 「配置」段新增三个环境变量：`PICLIST_START_WAIT` / `MAX_RETRIES` / `RETRY_DELAY`。

## 验证

- `bash -n` 语法 OK。
- `--dry-run` 在 PicList 已启动的 happy path：新探测打印 `✅ PicList Server 连接成功 (http://127.0.0.1:36677, HTTP 200)`（旧版是裸 "连接成功"）。
- 自动启动分支未在本会话内执行：试图 `pkill PicList` 触发被自动权限拒了，因此该路径只能等下次用户在 PicList 关闭时手动验证。建议合并前由维护者在本机做一次"关掉 PicList → 跑 dry-run → 应该看到 15 秒内自动拉起"的端到端测试。

## 兼容性

- 现有 CLI 用法（`--in-place` / `--keep-local` / `--dry-run`）零变化。
- 新增环境变量均有默认值，向后兼容。
- 在 Linux / Windows 上 `launch_piclist_app` 直接返回 1、给出手动启动提示，与原先行为一致。

## 上游合规

- pre-commit 隐私门禁扫描：本 diff 不含本地绝对路径、电话、18 位身份证、真实案号（`/Users/maoking/[0-9]{11}|[0-9Xx]{18}|1[3-9][0-9]{9}` 全空）。
- Commit message 沿用仓库风格 `fix(scope): ...`。
- 未触动工作树其他脏改动（yuandian-law-search / multi-agent-orchestration 等）；本分支只包含 piclist 两个文件的 diff。