### PR TITLE
fix(multi-agent-orchestration): zcode driver 安全底座(就绪屏障/显式隔离/失败关闭)

### DIFF
--- a/skills/multi-agent-orchestration/references/24-zcode-driver-safety.md
+++ b/skills/multi-agent-orchestration/references/24-zcode-driver-safety.md
@@ -1,0 +1,143 @@
+# ZCode Worker Driver 安全底座（TASK-2026-09-13-ZCODE-DRIVER-SAFETY）
+
+> 配套脚本：`scripts/zcode-worker-driver.py`（重构）、
+> `scripts/test-zcode-driver.sh`（契约测试，27 项）、
+> `scripts/test_zcode_driver_safety.py`（故障注入，59 项，全部真实
+> driver+stub 进程）。上游背景见 references/09-zcode-cli-worker.md。
+
+## 0. 定位与边界
+
+本轮是 zcode worker 安全底座，为后续"社区同会话控制器"与"Start 宿主桥"
+接线做前置，**不宣称打通 Start/Weekend、官方远控或机器控制**。官方
+0.16.5 `app-server` 不接受 `--settings`，因此本 driver 在该版本上以
+`UNSUPPORTED_CONFIG_ISOLATION`（退出码 68）失败关闭，**不能作为默认
+worker 入口部署**；待支持 `--settings` 的社区运行时（另立合同）接入后
+可直接复用本 driver。
+
+## 1. 启动就绪屏障（readiness barrier）
+
+旧版行为：create 返回即 flush backlog、setModel 失败仅警告并回退全局
+模型——存在"套餐错用"风险（任务文本进了未验证的模型会话）。
+
+新版状态机：
+
+```
+create → setModel(仅 --model 时) → session/read
+       → 实际 {providerId, modelId} 与冻结期望完全一致 → READY → drain
+```
+
+- 期望 modelRef 在启动时**冻结**：有 `--model` 用其解析值；无 `--model`
+  用私有 settings `model` 字段的完整 `providerId/modelId`（不再"无
+  --model 就不校验"）。
+- 任何 create/setModel/read 错误、响应畸形、超时（`--bootstrap-timeout`，
+  默认 45s）、模型不符 → 退出码 65，**0 条任务文本发出**，排队输入丢弃
+  并显式报告，绝不回退到其他模型、绝不标 READY。
+- 早到 PM 文本排队，READY 后按序 drain（drain 完才置 ready 事件，无
+  乱序/搁浅窗口）；启动期 `/status /stop /compact /quit` 是控制指令，
+  **绝不作为会话文本送给模型**。`/quit` 与 EOF 若在有未 drain 输入时
+  到达，先等待启动结论（有界），再正常关闭。
+
+## 2. 私有配置隔离（显式入口，失败关闭）
+
+- `--settings <path>` 是**唯一**配置入口：调度方提供的 per-worker 私有
+  settings 文件（0600；group/world 可读直接退出 64）。driver 把它以官方
+  `--settings` 旗标传给子 CLI（绝对路径——官方 loader 对相对路径按子进程
+  自身 cwd 解析）。
+- driver **永不**读写共享 `~/.zcode/cli/config.json`、**永不**在退出时
+  恢复/改写全局模型（旧版 `restore_global_model` 已删除，不存在
+  last-writer-wins 写路径）、**永不**重定向 HOME 或用环境变量注入配置。
+  旧 `ZCODE_CLI_CONFIG` 环境变量支持已移除：官方 bundle 无此字面键，
+  它只影响 driver 自身读配置、从未隔离子进程（这正是被修复的错用面）。
+- **官方 0.16.5 实证**（PM live 回执 2026-09-13）：`app-server --settings`
+  报 `Unknown option --settings` 退出 1（`--help` 列出的该旗标属于其他
+  入口）。driver 识别该子进程输出，打印 `UNSUPPORTED_CONFIG_ISOLATION`
+  行并以退出码 68 结束，0 条协议流量。
+- 隔离范围声明：`--settings` 只隔离**用户 settings 层**。会话 DB
+  （`~/.zcode/cli/db/`）、桌面认证存储（`~/.zcode/v2/`）、工作区内项目级
+  `.zcode` 配置**不在**此隔离范围内（项目层配置位于 PM 控制的 worktree
+  内，属可接受残留并在此明示）。
+- 语义参考（静态）：官方 bundle 的用户配置解析为
+  `tI() = ws("~/.zcode/cli") + "config.json"`，`ws()` 经 `os.homedir()`
+  展开 `~`；显式传入路径走 `path.resolve`。本轮未对真实 bundle 做
+  live 配置加载验证（`NOT_VERIFIED`）。
+
+## 3. 权限模式显式化
+
+- `--mode build|edit|plan|yolo`，默认 **build**（安全默认：无交互权限
+  客户端时变更类工具被拒）；`yolo` 仅显式传入（无人值守，等同
+  bypassPermissions 风险级）。旧版硬编码 `"mode": "yolo"` 已移除。
+- 反向权限请求（`interaction/requestPermission`、`requestUserInput`、
+  `requestOfficialMcpAuthHeaders`）及一切未知 server→client 请求：
+  回**可识别错误帧**（-32601 + "driver does not support …"），绝不猜
+  成功回包、绝不静默放行；对应工作随拒绝停止，不会挂死 15s。本次未
+  获得完整可靠的权限应答 schema，故一律拒绝（`NOT_VERIFIED`：真实
+  权限流程交互）。
+
+## 4. Start/Weekend runtime headers：失败关闭
+
+- `interaction/requestProviderRuntimeHeaders`（含 `captcha-retry`）按
+  官方 fail-closed 通道回 `{headersApplied: false, errorMessage: …}`——
+  bundle 静态证据（`EKi`/`nAt` strict zod）表明该 false 会使模型请求
+  结构化失败（-32031），**错误不等于完成**。
+- 未接正式宿主桥的 driver 明确**不具备**该能力：不采集/输出/转发/缓存
+  验证码、header、票据材料；宿主桥是另立的合同。
+
+## 5. 输出卫生（脱敏 ≠ 截短）
+
+- 所有渲染行经单一出口 `emit()`：先结构化掩码（`mask_value`：header
+  块/凭证键），再文本正则脱敏（bearer/sk-/authorization/cookie/apiKey/
+  password…），最后限长。**截短从不替代脱敏**。
+- 未知通知只打印方法名 + 参数**键名**（值永不渲染）；`state.updated`
+  只渲染白名单字段（status/reason）；子进程非 JSON 行（含 stderr 合流）
+  同样先脱敏再限长。
+
+## 6. 有界关闭与精确 child 句柄
+
+- `/quit`：发 `session/close`，有界等待 ack（`--close-timeout`，默认 5s）
+  → 精确句柄 SIGTERM → 3s 等待 → SIGKILL → 等待；**绝不按进程名
+  kill**。ack 确认（或从未建会话）才退出 0，未确认退出 70。
+- EOF（tmux pane 被杀）：有界 teardown，退出 0。
+- SIGINT→130 / SIGTERM→143：信号驱动有界结算。
+- 子进程异常退出：退出 66；启动期拒绝 `--settings`：退出 68。
+- 读线程**不再 `os._exit`**：子进程死亡置事件，由主线程统一结算清理。
+- request id 与 pending 表加锁（读写双线程安全）；写帧经 write_lock
+  串行化。
+
+## 7. 退出码一览
+
+| 码 | 含义 |
+|---|---|
+| 0 | /quit 干净关闭（close 确认或无会话）/ EOF 有界 teardown |
+| 64 | 配置错误（--mode/--settings/--bin/--cwd、权限过松、modelRef 不可用） |
+| 65 | 启动未验证（create/setModel/read 错误、超时、畸形、模型不符），0 条任务 |
+| 66 | 子进程异常退出 |
+| 68 | UNSUPPORTED_CONFIG_ISOLATION（官方 0.16.5 拒绝 --settings） |
+| 70 | /quit 的 close 未在限时内确认 |
+| 130/143 | SIGINT/SIGINT 结算完成 |
+
+## 8. 验证与未验证范围
+
+已验证（stub 真实进程，两套件 86 项全绿）：
+
+- setModel 延迟/失败、read 回读不符、无回包、无 create → 65 + 0 发送；
+- 早输入按序 drain、控制指令永不入会话、延迟 /quit 不丢 drain；
+- 双实例并发各自验证各自模型、settings 源文件字节不变；
+- 恶意子进程改写自己拿到的 settings（写入落在私有文件，全局配置不在场）；
+- 68/66/70/130/0 各关闭路径有界；
+- 敏感字段脱敏（token/cookie/ticket/apiKey）、未知通知只出键名、
+  runtime-headers fail-closed 回包、权限请求可识别拒绝。
+
+`NOT_VERIFIED`（本轮明确不声称）：
+
+- 真实 provider 上的任何请求（0 模型请求、0 凭证使用）；
+- 官方 bundle 的 `--settings` 配置加载行为（已知反而被拒）与任何真实
+  隔离效果；支持该旗标的社区运行时尚未接入；
+- 桌面宿主 / Start 宿主桥 / 官方远控 / MAO ZCode supervised 链路；
+- `spawn-worker.sh` 默认命令仍指向本 driver——**在官方 0.16.5 上会
+  得到 68**，需 PM 决策切换条件（不在本任务 4 文件范围）。
+
+## 版本记录
+
+- 2026-09-13：随 TASK-2026-09-13-ZCODE-DRIVER-SAFETY 新增。driver
+  就绪屏障/显式隔离/安全 mode/脱敏/有界关闭落地；官方 0.16.5 拒绝
+  --settings 的失败关闭路径（68）与 PM 实测回执入库。

--- a/skills/multi-agent-orchestration/scripts/test-zcode-driver.sh
+++ b/skills/multi-agent-orchestration/scripts/test-zcode-driver.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # zcode-worker-driver.py contract tests against a stub app-server.
 # No ZCode desktop app, no real credentials, no network — CI-safe.
+# Stub proves the DRIVER contract only (argv, readiness barrier, isolation
+# entry, control-command routing); it does not simulate official config
+# loading — official 0.16.5 app-server rejects --settings (exit 68 case).
 set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -14,15 +17,20 @@ ok() { printf 'PASS: %s\n' "$1"; pass=$((pass + 1)); }
 bad() { printf 'FAIL: %s\n' "$1" >&2; fail=$((fail + 1)); }
 
 # ---- stub app-server: speaks the bare-frame protocol -------------------------
-# Behavior: answers session/create + session/send, pushes one runtime
-# preferences request, emits a state.updated notification, records what it
-# received into $STUB_LOG for assertions.
+# Behavior controlled by STUB_MODE:
+#   ok         answer create[/setModel]/read/send/close; STUB_MODEL echoes the
+#              model the driver set (or the config model when no setModel)
+#   mismatch   read answers a DIFFERENT model (read-back verification fault)
+#   reject_settings  print "Unknown option --settings" to stderr, exit 1
+# The stub logs every received frame plus its own argv into $STUB_LOG.
 STUB="$TMP_ROOT/stub-app-server.py"
 STUB_LOG="$TMP_ROOT/stub-received.log"
 cat > "$STUB" <<PYEOF
 #!/usr/bin/env python3
-import json, os, sys, threading
+import json, os, sys
 log_path = os.environ["STUB_LOG"]
+stub_mode = os.environ.get("STUB_MODE", "ok")
+stub_model = os.environ.get("STUB_MODEL", "")  # "provider/model" echoed in read
 
 def log(event, payload):
     with open(log_path, "a") as fh:
@@ -32,60 +40,89 @@ def emit(frame):
     sys.stdout.write(json.dumps(frame) + "\n")
     sys.stdout.flush()
 
+log("argv", sys.argv)
+
+if stub_mode == "reject_settings":
+    sys.stderr.write("error: Unknown option --settings\n")
+    sys.exit(1)
+
 # Push a server->client request right away; driver must answer in-window.
 emit({"id": "server-test", "method": "session/requestRuntimePreferences",
       "params": {"scope": "runtime-materialization"}})
 emit({"method": "state.updated",
       "params": {"patch": {"status": "idle"}, "reason": "session_ready"}})
 
+current_model = stub_model or "x/glm"
 for line in sys.stdin:
     line = line.strip()
     if not line:
         continue
     frame = json.loads(line)
     log("received", frame)
-    if frame.get("method") == "session/create":
-        # Real protocol shape: sessionId nested under result.session.
+    method = frame.get("method")
+    if method == "session/create":
         emit({"id": frame["id"], "result": {"session": {"sessionId": "sess_stub_001"}}})
-    elif frame.get("method") == "session/setModel":
+    elif method == "session/setModel":
+        if stub_mode != "mismatch":
+            model = frame.get("params", {}).get("model", {})
+            current_model = f"{model.get('providerId')}/{model.get('modelId')}"
         emit({"id": frame["id"], "result": {}})
-    elif frame.get("method") == "session/send":
+    elif method == "session/read":
+        provider, _, model_id = ("evil/other" if stub_mode == "mismatch" else current_model).partition("/")
+        emit({"id": frame["id"], "result": {"session": {
+            "sessionId": "sess_stub_001", "status": "idle",
+            "model": {"providerId": provider, "modelId": model_id}}}})
+    elif method == "session/send":
         emit({"id": frame["id"], "result": {"accepted": True}})
         emit({"method": "state.updated",
               "params": {"patch": {"status": "running"}, "reason": "prompt_started"}})
-    elif frame.get("method") == "session/close":
+    elif method == "session/close":
         emit({"id": frame["id"], "result": {}})
         break
 PYEOF
 chmod +x "$STUB"
 
+# ---- private settings files (0600, synthetic) ---------------------------------
+mk_settings() { # $1=file $2=model
+  printf '{"model": "%s", "provider": {"x": {}}}' "$2" > "$1"
+  chmod 600 "$1"
+}
+mk_settings "$TMP_ROOT/good-config.json" "x/glm"
+mk_settings "$TMP_ROOT/flash-config.json" "builtin:bigmodel-coding-plan/GLM-5.3-Flash"
+
 # ---- helper: run driver against the stub -------------------------------------
-run_driver() {
-  local input="$1" cfg="$2"
-  shift 2
+run_driver() { # $1=stdin input, rest = driver args
+  local input="$1"; shift
   printf '%s\n' "$input" | \
     STUB_LOG="$STUB_LOG" \
-    ZCODE_CLI_CONFIG="$cfg" \
     python3 "$DRIVER" --bin "$STUB" --cwd "$TMP_ROOT" "$@" 2>&1
 }
 
-# ---- Case 1: missing/invalid model config fails fast (exit 64) ---------------
-out=$(printf '/quit\n' | ZCODE_CLI_CONFIG="$TMP_ROOT/nope.json" \
-  python3 "$DRIVER" --bin "$STUB" --cwd "$TMP_ROOT" 2>&1) && rc=0 || rc=$?
-if [ "$rc" -eq 64 ]; then ok "missing config exits 64"; else bad "missing config rc=$rc: $out"; fi
+# ---- Case 1: config entry is mandatory and fail-closed ------------------------
+out=$(printf '/quit\n' | python3 "$DRIVER" --bin "$STUB" --cwd "$TMP_ROOT" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -eq 64 ]; then ok "missing --settings exits 64 (no shared-config fallback)"; else bad "missing --settings rc=$rc: $out"; fi
 
-echo '{"model": "x/glm", "provider": {"x": {}}}' > "$TMP_ROOT/good-config.json"
-echo '{"skills": {}}' > "$TMP_ROOT/bad-config.json"
-out=$(printf '/quit\n' | ZCODE_CLI_CONFIG="$TMP_ROOT/bad-config.json" \
-  python3 "$DRIVER" --bin "$STUB" --cwd "$TMP_ROOT" 2>&1) && rc=0 || rc=$?
-if [ "$rc" -eq 64 ]; then ok "config without model/provider exits 64"; else bad "bad config rc=$rc: $out"; fi
+out=$(printf '/quit\n' | python3 "$DRIVER" --bin "$STUB" --cwd "$TMP_ROOT" --settings "$TMP_ROOT/nope.json" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -eq 64 ]; then ok "missing settings file exits 64"; else bad "missing file rc=$rc: $out"; fi
 
-# ---- Case 2: full flow — prefs answered, send forwarded, render visible -------
+printf '{"model": "x/glm", "provider": {"x": {}}}' > "$TMP_ROOT/loose-config.json"
+chmod 644 "$TMP_ROOT/loose-config.json"
+out=$(printf '/quit\n' | python3 "$DRIVER" --bin "$STUB" --cwd "$TMP_ROOT" --settings "$TMP_ROOT/loose-config.json" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -eq 64 ]; then ok "group/world-readable settings exits 64"; else bad "loose perms rc=$rc: $out"; fi
+
+printf '{"skills": {}}' > "$TMP_ROOT/bad-config.json"; chmod 600 "$TMP_ROOT/bad-config.json"
+out=$(printf '/quit\n' | python3 "$DRIVER" --bin "$STUB" --cwd "$TMP_ROOT" --settings "$TMP_ROOT/bad-config.json" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -eq 64 ]; then ok "settings without model/provider exits 64"; else bad "bad settings rc=$rc: $out"; fi
+
+out=$(printf '/quit\n' | python3 "$DRIVER" --bin "$STUB" --cwd "$TMP_ROOT" --settings "$TMP_ROOT/good-config.json" --mode bogus 2>&1) && rc=0 || rc=$?
+if [ "$rc" -eq 2 ] || [ "$rc" -eq 64 ]; then ok "invalid --mode rejected (rc=$rc)"; else bad "invalid --mode rc=$rc: $out"; fi
+
+# ---- Case 2: full flow — ready barrier, prefs, send, render --------------------
 : > "$STUB_LOG"
 out=$(run_driver '创建 hello.txt
-/quit' "$TMP_ROOT/good-config.json") && rc=0 || rc=$?
+/quit' --settings "$TMP_ROOT/good-config.json") && rc=0 || rc=$?
 
-if [ "$rc" -eq 0 ]; then ok "driver exits 0 after /quit"; else bad "driver rc=$rc"; fi
+if [ "$rc" -eq 0 ]; then ok "driver exits 0 after /quit"; else bad "driver rc=$rc: $out"; fi
 
 if grep -q '"id": "server-test", "result"' "$STUB_LOG"; then
   ok "runtimePreferences auto-answered"
@@ -99,13 +136,35 @@ else
   bad "session/create missing"
 fi
 
+# Settings isolation entry: the child argv must carry --settings <private file>
+if grep -q "\"--settings\", \".*good-config.json\"" "$STUB_LOG" && \
+   ! grep -q '"mode": "yolo"' "$STUB_LOG"; then
+  ok "child argv carries --settings; create mode is build (default)"
+else
+  bad "argv/mode wrong; log head: $(grep '"argv"' "$STUB_LOG" | head -1)"
+fi
+
+# Without --model: NO setModel write, but read-back verification required.
+if grep -q '"method": "session/setModel"' "$STUB_LOG"; then
+  bad "setModel dispatched without --model (must verify, not write)"
+else
+  ok "no setModel without --model"
+fi
+if grep -q '"method": "session/read"' "$STUB_LOG" && \
+   printf '%s\n' "$out" | grep -q 'READY model=x/glm verified'; then
+  ok "read-back verify gates READY even without --model"
+else
+  bad "read verify missing; output: $out; log: $(cat "$STUB_LOG")"
+fi
+
+# Queued early text only drains AFTER ready: send must follow read.
 if grep -q '"content": "创建 hello.txt"' "$STUB_LOG"; then
   ok "plain stdin text forwarded as session/send content"
 else
   bad "session/send content missing; log: $(cat "$STUB_LOG")"
 fi
 
-if printf '%s\n' "$out" | grep -q 'session ready: sess_stub_001'; then
+if printf '%s\n' "$out" | grep -q 'session created: sess_stub_001'; then
   ok "sessionId captured from create response"
 else
   bad "sessionId not captured; output: $out"
@@ -117,38 +176,89 @@ else
   bad "rendered state line missing; output: $out"
 fi
 
-if grep -q '"method": "session/setModel"' "$STUB_LOG"; then
-  bad "setModel dispatched without --model (must keep global model)"
+# Source settings file must not be modified by the run.
+sha_after=$(shasum "$TMP_ROOT/good-config.json" | cut -d' ' -f1)
+if [ "$sha_after" = "$(printf '{"model": "x/glm", "provider": {"x": {}}}' | shasum | cut -d' ' -f1)" ]; then
+  ok "settings file unchanged after run"
 else
-  ok "no setModel without --model"
+  bad "settings file was modified"
 fi
 
-# ---- Case 3: --model providerId/modelId — setModel dispatched with exact ref ----
+# ---- Case 3: --model providerId/modelId — setModel then verify -----------------
 : > "$STUB_LOG"
-out=$(run_driver $'ping\n/quit' "$TMP_ROOT/good-config.json" \
+out=$(run_driver $'ping\n/quit' --settings "$TMP_ROOT/good-config.json" \
   --model 'builtin:bigmodel-coding-plan/GLM-5.3-Flash') && rc=0 || rc=$?
 
-if [ "$rc" -eq 0 ]; then ok "driver exits 0 with --model"; else bad "driver rc=$rc"; fi
+if [ "$rc" -eq 0 ]; then ok "driver exits 0 with --model"; else bad "driver rc=$rc: $out"; fi
 
 if grep -q '"method": "session/setModel", "params": {"sessionId": "sess_stub_001", "model": {"providerId": "builtin:bigmodel-coding-plan", "modelId": "GLM-5.3-Flash"}, "persistAsWorkspaceLastUsed": false}' "$STUB_LOG"; then
-  ok "setModel dispatched with exact modelRef"
+  ok "setModel dispatched with exact modelRef + persist opt-out"
 else
   bad "setModel params wrong; log: $(cat "$STUB_LOG")"
 fi
 
-if printf '%s\n' "$out" | grep -q '\[driver\] setModel ✓ per-worker model applied'; then
-  ok "setModel success rendered"
+# setModel result must be followed by session/read verification before READY.
+if printf '%s\n' "$out" | grep -q 'READY model=builtin:bigmodel-coding-plan/GLM-5.3-Flash verified'; then
+  ok "read-back verify confirms requested model before READY"
 else
-  bad "setModel success line missing; output: $out"
+  bad "verified READY line missing; output: $out"
 fi
 
-# ---- Case 4: bare --model (no provider) — providerId falls back to config ----
+if ! grep -q '"content": "ping"' "$STUB_LOG" || \
+   [ "$(grep -n '"method": "session/read"' "$STUB_LOG" | head -1 | cut -d: -f1)" -lt "$(grep -n '"content": "ping"' "$STUB_LOG" | head -1 | cut -d: -f1)" ]; then
+  ok "queued ping drained only after the read verify"
+else
+  bad "ping sent before verify; log: $(cat "$STUB_LOG")"
+fi
+
+# ---- Case 4: bare --model — providerId falls back to settings prefix -----------
 : > "$STUB_LOG"
-out=$(run_driver $'ping\n/quit' "$TMP_ROOT/good-config.json" --model 'GLM-5.3-Flash') && rc=0 || rc=$?
+out=$(run_driver $'ping\n/quit' --settings "$TMP_ROOT/good-config.json" --model 'GLM-5.3-Flash') && rc=0 || rc=$?
 if grep -q '"model": {"providerId": "x", "modelId": "GLM-5.3-Flash"}, "persistAsWorkspaceLastUsed": false' "$STUB_LOG"; then
-  ok "bare --model falls back to config provider prefix"
+  ok "bare --model falls back to settings provider prefix"
 else
   bad "provider fallback wrong; log: $(cat "$STUB_LOG")"
+fi
+
+# ---- Case 5: read-back mismatch — startup fails, zero task sends ---------------
+: > "$STUB_LOG"
+out=$(printf 'ping\n/quit\n' | STUB_LOG="$STUB_LOG" STUB_MODE=mismatch STUB_MODEL="x/glm" \
+  python3 "$DRIVER" --bin "$STUB" --cwd "$TMP_ROOT" --settings "$TMP_ROOT/good-config.json" --bootstrap-timeout 10 2>&1) && rc=0 || rc=$?
+if [ "$rc" -eq 65 ]; then ok "model mismatch exits 65"; else bad "mismatch rc=$rc: $out"; fi
+if grep -q '"method": "session/send"' "$STUB_LOG"; then
+  bad "task text sent despite model mismatch"
+else
+  ok "zero session/send after model mismatch"
+fi
+if printf '%s\n' "$out" | grep -q 'STARTUP NOT VERIFIED'; then
+  ok "startup failure reason rendered"
+else
+  bad "failure reason missing; output: $out"
+fi
+
+# ---- Case 6: explicit --mode yolo reaches create params -----------------------
+: > "$STUB_LOG"
+out=$(run_driver '/quit' --settings "$TMP_ROOT/good-config.json" --mode yolo) && rc=0 || rc=$?
+if grep -q '"mode": "yolo"' "$STUB_LOG"; then
+  ok "explicit --mode yolo forwarded to session/create"
+else
+  bad "yolo mode missing; log: $(cat "$STUB_LOG")"
+fi
+
+# ---- Case 7: official 0.16.5 --settings rejection → 68, zero sends -------------
+: > "$STUB_LOG"
+out=$(printf 'ping\n/quit\n' | STUB_LOG="$STUB_LOG" STUB_MODE=reject_settings \
+  python3 "$DRIVER" --bin "$STUB" --cwd "$TMP_ROOT" --settings "$TMP_ROOT/good-config.json" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -eq 68 ]; then ok "settings rejection exits 68 (UNSUPPORTED_CONFIG_ISOLATION)"; else bad "reject rc=$rc: $out"; fi
+if printf '%s\n' "$out" | grep -q 'UNSUPPORTED_CONFIG_ISOLATION'; then
+  ok "UNSUPPORTED_CONFIG_ISOLATION marker rendered"
+else
+  bad "marker missing; output: $out"
+fi
+if grep -q '"method": "session/send"' "$STUB_LOG" || grep -q '"method": "session/create"' "$STUB_LOG"; then
+  bad "protocol requests sent to a child that never spoke the protocol"
+else
+  ok "zero protocol traffic on settings rejection"
 fi
 
 # ---- summary ------------------------------------------------------------------

--- a/skills/multi-agent-orchestration/scripts/test_zcode_driver_safety.py
+++ b/skills/multi-agent-orchestration/scripts/test_zcode_driver_safety.py
@@ -1,0 +1,523 @@
+#!/usr/bin/env python3
+"""Fault-injection safety tests for zcode-worker-driver.py.
+
+Every case launches the REAL driver process against a REAL stub app-server
+child (no internal-method mocking, no ZCode desktop app, no credentials, no
+network). The stub proves the DRIVER contract only — official 0.16.5 config
+loading is out of scope (it rejects --settings; see the exit-68 case).
+
+Covers the TASK-2026-09-13-ZCODE-DRIVER-SAFETY acceptance matrix:
+  * startup readiness barrier: setModel delayed / error / read-back mismatch /
+    no read-back / no create -> exit 65, ZERO session/send of task text
+  * early PM text + control commands during bootstrap: queued text drains in
+    order only after READY; /status /stop /compact /quit are never forwarded
+    to the model as session content
+  * explicit private --settings entry: child argv carries it; source files
+    stay byte-identical; two concurrent instances never cross-contaminate
+  * child crashing / rejecting --settings: exit 66 / 68 + marker line
+  * clean /quit (0), close-not-acked (70), EOF teardown (0), SIGINT (130)
+  * sensitive-output hygiene: unknown notifications render key names only;
+    token/header/credential material is REDACTED (never merely truncated);
+    runtime-headers requests fail closed via headersApplied:false; permission
+    requests get an identifiable error reply, never a guessed success
+"""
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DRIVER = os.path.join(HERE, "zcode-worker-driver.py")
+
+STUB_SOURCE = r'''#!/usr/bin/env python3
+"""Configurable stub app-server. Behavior via STUB_MODE:
+
+  ok                 full happy path; read echoes setModel'd / STUB_MODEL model
+  slow_create        answer session/create only after STUB_DELAY seconds
+  setmodel_error     answer create ok, setModel with a protocol error
+  read_error         answer create ok, read with a protocol error
+  no_create          never answer create
+  no_read            answer create (+setModel), never answer read
+  delayed_setmodel   answer setModel only after STUB_DELAY seconds
+  mismatch           read answers the model "evil/other"
+  crash_after_ready  ok bootstrap, then exit(1) on first session/send
+  close_noack        ok bootstrap, never ack session/close
+  reject_settings    "Unknown option --settings" on stderr, exit 1
+  sensitive          ok path + hostile frames with credential material
+  permission         ok path + interaction/requestPermission reverse request
+  malicious_settings rewrite the --settings file from our own argv, then ok
+
+Everything received (frames + argv) is appended to STUB_LOG as JSON lines.
+"""
+import json, os, sys, time
+
+log_path = os.environ["STUB_LOG"]
+mode = os.environ.get("STUB_MODE", "ok")
+delay = float(os.environ.get("STUB_DELAY", "1.5"))
+stub_model = os.environ.get("STUB_MODEL", "")
+
+def log(event, payload):
+    with open(log_path, "a") as fh:
+        fh.write(json.dumps({"event": event, "payload": payload}, ensure_ascii=False) + "\n")
+
+def emit(frame):
+    sys.stdout.write(json.dumps(frame) + "\n")
+    sys.stdout.flush()
+
+log("argv", sys.argv)
+if mode == "reject_settings":
+    sys.stderr.write("error: Unknown option --settings\n")
+    sys.exit(1)
+if mode == "malicious_settings":
+    # Hostile child: rewrite the settings file we were handed via --settings.
+    # The driver must not care (it already froze its model ref) and must
+    # never echo the file contents; the GLOBAL config is never in play.
+    try:
+        idx = sys.argv.index("--settings")
+        with open(sys.argv[idx + 1], "w") as fh:
+            fh.write('{"pwned": true}')
+    except (ValueError, OSError, IndexError):
+        pass
+
+if mode == "sensitive":
+    emit({"method": "weird/notification", "params": {
+        "api_key": "sk-stubsecret1234567890",
+        "headers": {"set-cookie": ["acw_tc=STUBCOOKIEVALUE", "cdn_sec_tc=X"]}}})
+    emit({"id": "rh-1", "method": "interaction/requestProviderRuntimeHeaders",
+          "params": {"requestId": "rh-1", "sessionId": "sess_stub_001",
+                     "providerId": "builtin:bigmodel-start-plan",
+                     "reason": "captcha-retry",
+                     "headers": {"x-aliyun-captcha-ticket": "STUBTICKET123456"}}})
+    sys.stderr.write("ERROR login refresh failed token=abc123def456ghi789\n")
+if mode == "permission":
+    emit({"id": "perm-1", "method": "interaction/requestPermission", "params": {
+        "tool": "Bash", "command": "rm -rf /", "token": "sk-permsecret123456789"}})
+
+emit({"id": "server-test", "method": "session/requestRuntimePreferences",
+      "params": {"scope": "runtime-materialization"}})
+
+current_model = stub_model or "x/glm"
+if mode == "slow_create":
+    time.sleep(delay)
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    frame = json.loads(line)
+    log("received", frame)
+    method = frame.get("method")
+    if method == "session/create":
+        if mode == "no_create":
+            continue
+        emit({"id": frame["id"], "result": {"session": {"sessionId": "sess_stub_001"}}})
+    elif method == "session/setModel":
+        if mode == "setmodel_error":
+            emit({"id": frame["id"], "error": {"code": -32004, "message": "unknown model"}})
+            continue
+        if mode == "delayed_setmodel":
+            time.sleep(delay)
+        if mode != "mismatch":
+            model = frame.get("params", {}).get("model", {})
+            current_model = f"{model.get('providerId')}/{model.get('modelId')}"
+        emit({"id": frame["id"], "result": {}})
+    elif method == "session/read":
+        if mode == "read_error":
+            emit({"id": frame["id"], "error": {"code": -32004, "message": "Session is not active"}})
+            continue
+        if mode == "no_read":
+            continue
+        provider, _, model_id = ("evil/other" if mode == "mismatch" else current_model).partition("/")
+        emit({"id": frame["id"], "result": {"session": {
+            "sessionId": "sess_stub_001", "status": "idle",
+            "model": {"providerId": provider, "modelId": model_id}}}})
+    elif method == "session/send":
+        if mode == "crash_after_ready":
+            emit({"id": frame["id"], "result": {"accepted": True}})
+            sys.stdout.flush()
+            os._exit(1)
+        emit({"id": frame["id"], "result": {"accepted": True}})
+    elif method == "session/stop":
+        emit({"id": frame["id"], "result": {}})
+    elif method == "session/compact":
+        emit({"id": frame["id"], "result": {}})
+    elif method == "session/close":
+        if mode != "close_noack":
+            emit({"id": frame["id"], "result": {}})
+            break
+    elif "id" in frame and method is not None:
+        # Server-request replies FROM the driver (prefs answer, declines).
+        pass
+'''
+
+PASS = 0
+FAIL = 0
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+        print(f"PASS: {name}")
+    else:
+        FAIL += 1
+        FAILURES.append(f"{name}: {detail}")
+        print(f"FAIL: {name} :: {detail}")
+
+
+def sha256(path: str) -> str:
+    with open(path, "rb") as fh:
+        return hashlib.sha256(fh.read()).hexdigest()
+
+
+class Lab:
+    """One temp workspace: stub binary + private settings + stub log."""
+
+    def __init__(self, root: str, model: str = "x/glm", name: str = "w") -> None:
+        self.root = root
+        self.name = name
+        self.settings = os.path.join(root, f"settings-{name}.json")
+        with open(self.settings, "w", encoding="utf-8") as fh:
+            fh.write(json.dumps({"model": model, "provider": {model.split("/")[0]: {}}}))
+        os.chmod(self.settings, 0o600)
+        self.stub = os.path.join(root, f"stub-{name}.py")
+        with open(self.stub, "w", encoding="utf-8") as fh:
+            fh.write(STUB_SOURCE)
+        os.chmod(self.stub, 0o755)
+        self.log = os.path.join(root, f"stub-{name}.log")
+        open(self.log, "w").close()
+
+    def frames(self, event: str | None = None) -> list[dict]:
+        out = []
+        with open(self.log, "r", encoding="utf-8") as fh:
+            for line in fh:
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if event is None or rec.get("event") == event:
+                    out.append(rec.get("payload"))
+        return out
+
+    def sent_contents(self) -> list[str]:
+        return [
+            f.get("params", {}).get("content")
+            for f in self.frames("received")
+            if f.get("method") == "session/send"
+        ]
+
+
+class Run:
+    """A live driver process against a Lab stub."""
+
+    def __init__(self, lab: Lab, mode: str, args: list[str], env_extra: dict | None = None,
+                 stdin_lines: list[str] | None = None, keep_stdin: bool = False) -> None:
+        env = dict(os.environ)
+        env["STUB_LOG"] = lab.log
+        env["STUB_MODE"] = mode
+        if env_extra:
+            env.update(env_extra)
+        self.proc = subprocess.Popen(
+            [sys.executable, DRIVER, "--bin", lab.stub, "--cwd", lab.root,
+             "--settings", lab.settings] + args,
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, bufsize=1, env=env,
+        )
+        self.out_lines: list[str] = []
+        self._reader = threading.Thread(target=self._pump, daemon=True)
+        self._reader.start()
+        if stdin_lines:
+            for line in stdin_lines:
+                self.proc.stdin.write(line + "\n")
+            self.proc.stdin.flush()
+        if not keep_stdin:
+            self.proc.stdin.close()
+            self.stdin_closed = True
+        else:
+            self.stdin_closed = False
+
+    def _pump(self) -> None:
+        assert self.proc.stdout is not None
+        for line in self.proc.stdout:
+            self.out_lines.append(line.rstrip("\n"))
+
+    @property
+    def output(self) -> str:
+        return "\n".join(self.out_lines)
+
+    def wait(self, timeout: float = 25.0) -> int | None:
+        try:
+            code = self.proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            return None
+        self._reader.join(timeout=2.0)
+        if not self.stdin_closed:
+            try:
+                self.proc.stdin.close()
+            except OSError:
+                pass
+        return code
+
+    def sigint(self) -> None:
+        self.proc.send_signal(signal.SIGINT)
+
+    def kill(self) -> None:
+        if self.proc.poll() is None:
+            self.proc.kill()
+            try:
+                self.proc.wait(timeout=3.0)
+            except subprocess.TimeoutExpired:
+                pass
+        self._reader.join(timeout=2.0)
+
+
+def drive(lab: Lab, mode: str, args: list[str], stdin_lines: list[str],
+          env_extra: dict | None = None, timeout: float = 25.0, keep_stdin: bool = False):
+    """Run a driver to completion; returns (exit_code|None, output)."""
+    run = Run(lab, mode, args, env_extra=env_extra, stdin_lines=stdin_lines,
+              keep_stdin=keep_stdin)
+    code = run.wait(timeout=timeout)
+    if code is None:
+        run.kill()
+    return code, run.output
+
+
+def main() -> int:
+    root = tempfile.mkdtemp(prefix="zcode-driver-safety-")
+    try:
+        return run_suite(root)
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def run_suite(root: str) -> int:
+    fast = ["--bootstrap-timeout", "2", "--close-timeout", "1"]
+    roomy = ["--bootstrap-timeout", "10", "--close-timeout", "1"]
+
+    # ---- G1: setModel delayed past the deadline -> 65, zero sends -----------
+    lab = Lab(root, name="g1")
+    before = sha256(lab.settings)
+    code, out = drive(lab, "delayed_setmodel", fast + ["--model", "x/glm"], ["do the task"],
+                      env_extra={"STUB_DELAY": "4"}, keep_stdin=True)
+    check("g1 delayed setModel exits 65", code == 65, f"code={code} out={out[-400:]}")
+    check("g1 zero session/send", lab.sent_contents() == [], f"sent={lab.sent_contents()}")
+    check("g1 dropped backlog reported", "dropped 1 queued input" in out, out[-300:])
+    check("g1 source settings unchanged", sha256(lab.settings) == before)
+
+    # ---- G2: setModel protocol error -> 65, zero sends -----------------------
+    lab = Lab(root, name="g2")
+    code, out = drive(lab, "setmodel_error", roomy + ["--model", "x/glm"], ["do the task"], keep_stdin=True)
+    check("g2 setModel error exits 65", code == 65, f"code={code} out={out[-400:]}")
+    check("g2 zero session/send", lab.sent_contents() == [], f"sent={lab.sent_contents()}")
+    check("g2 no READY line", "READY" not in out, out[-300:])
+
+    # ---- G3: read-back model mismatch -> 65, zero sends ----------------------
+    lab = Lab(root, name="g3")
+    code, out = drive(lab, "mismatch", roomy, ["do the task"], keep_stdin=True)
+    check("g3 mismatch exits 65", code == 65, f"code={code} out={out[-400:]}")
+    check("g3 zero session/send", lab.sent_contents() == [], f"sent={lab.sent_contents()}")
+    check("g3 mismatch reason named", "model mismatch" in out, out[-300:])
+
+    # ---- G4: read never answered -> 65 within the bounded deadline -----------
+    lab = Lab(root, name="g4")
+    started = time.monotonic()
+    code, out = drive(lab, "no_read", fast, ["do the task"], keep_stdin=True)
+    elapsed = time.monotonic() - started
+    check("g4 no read-back exits 65", code == 65, f"code={code} out={out[-400:]}")
+    check("g4 bounded in <6s", elapsed < 6.0, f"elapsed={elapsed:.1f}s")
+    check("g4 zero session/send", lab.sent_contents() == [])
+
+    # ---- G5: create never answered -> 65 -------------------------------------
+    lab = Lab(root, name="g5")
+    code, out = drive(lab, "no_create", fast, ["do the task"], keep_stdin=True)
+    check("g5 no create exits 65", code == 65, f"code={code} out={out[-400:]}")
+    check("g5 zero session/send", lab.sent_contents() == [])
+
+    # ---- G6: early text + control commands during bootstrap ------------------
+    lab = Lab(root, name="g6")
+    code, out = drive(lab, "slow_create", roomy,
+                      ["first task", "/status", "/stop", "/compact", "second task", "/quit"],
+                      env_extra={"STUB_DELAY": "1.2"})
+    check("g6 deferred /quit still exits 0", code == 0, f"code={code} out={out[-400:]}")
+    check("g6 queued text drained in order",
+          lab.sent_contents() == ["first task", "second task"],
+          f"sent={lab.sent_contents()}")
+    check("g6 control commands never sent to model",
+          not any(c in lab.sent_contents() for c in ("/status", "/stop", "/compact", "/quit")),
+          f"sent={lab.sent_contents()}")
+    check("g6 /status before ready is local-only",
+          '"state": "starting"' in out and "/status dropped" not in out, out)
+    check("g6 /stop dropped while starting", "/stop dropped: session not ready" in out, out)
+    check("g6 READY barrier line", re.search(r"READY model=x/glm verified mode=build drained=2", out) is not None, out)
+    create_frames = [f for f in lab.frames("received") if f.get("method") == "session/create"]
+    check("g6 default mode is build", create_frames and create_frames[0]["params"].get("mode") == "build",
+          f"create={create_frames}")
+
+    # ---- G7: explicit --mode yolo reaches create params ----------------------
+    lab = Lab(root, name="g7")
+    code, out = drive(lab, "ok", roomy + ["--mode", "yolo"], ["/quit"])
+    create_frames = [f for f in lab.frames("received") if f.get("method") == "session/create"]
+    check("g7 yolo forwarded",
+          code == 0 and bool(create_frames) and create_frames[0]["params"].get("mode") == "yolo",
+          f"code={code} create={create_frames}")
+
+    # ---- G8: child argv carries the private --settings path ------------------
+    lab = Lab(root, name="g8")
+    code, out = drive(lab, "ok", roomy, ["/quit"])
+    argvs = lab.frames("argv")
+    ok_settings = bool(argvs) and any(
+        argvs[0][i] == "--settings" and argvs[0][i + 1] == lab.settings
+        for i in range(len(argvs[0]) - 1)
+    )
+    check("g8 argv includes --settings <private file>", ok_settings, f"argv={argvs}")
+    check("g8 no global config path anywhere in argv",
+          bool(argvs) and not any(".zcode/cli/config.json" in str(a) for a in argvs[0]), f"argv={argvs}")
+
+    # ---- G9: two concurrent instances, isolated settings ---------------------
+    labA = Lab(root, model="alpha/glm-a", name="g9a")
+    labB = Lab(root, model="beta/glm-b", name="g9b")
+    shaA, shaB = sha256(labA.settings), sha256(labB.settings)
+    runA = Run(labA, "ok", roomy + ["--model", "alpha/glm-a"],
+               stdin_lines=["task A", "/quit"], keep_stdin=True)
+    runB = Run(labB, "ok", roomy + ["--model", "beta/glm-b"],
+               stdin_lines=["task B", "/quit"], keep_stdin=True)
+    codeA, codeB = runA.wait(), runB.wait()
+    outA, outB = runA.output, runB.output
+    check("g9 both instances exit 0", codeA == 0 and codeB == 0, f"{codeA}/{codeB}")
+    check("g9 A verified its own model", "READY model=alpha/glm-a verified" in outA, outA[-300:])
+    check("g9 B verified its own model", "READY model=beta/glm-b verified" in outB, outB[-300:])
+    check("g9 A only sent A's task", labA.sent_contents() == ["task A"], f"{labA.sent_contents()}")
+    check("g9 B only sent B's task", labB.sent_contents() == ["task B"], f"{labB.sent_contents()}")
+    check("g9 settings sources unchanged",
+          sha256(labA.settings) == shaA and sha256(labB.settings) == shaB)
+
+    # ---- G10: malicious child rewrites ITS OWN settings file -----------------
+    lab = Lab(root, name="g10")
+    code, out = drive(lab, "malicious_settings", roomy, ["ping", "/quit"])
+    with open(lab.settings, "r", encoding="utf-8") as fh:
+        after = fh.read()
+    check("g10 child rewrote the private settings (writes redirected there)",
+          code == 0 and "pwned" in after, f"code={code} content={after!r}")
+    check("g10 driver never echoes settings contents", '"provider"' not in out, out)
+
+    # ---- G11: official-style --settings rejection -> 68 ----------------------
+    lab = Lab(root, name="g11")
+    code, out = drive(lab, "reject_settings", roomy, ["ping"], keep_stdin=True)
+    check("g11 rejection exits 68", code == 68, f"code={code} out={out[-400:]}")
+    check("g11 UNSUPPORTED_CONFIG_ISOLATION marker", "UNSUPPORTED_CONFIG_ISOLATION" in out, out[-300:])
+    check("g11 zero protocol traffic", lab.frames("received") == [], f"{lab.frames('received')}")
+
+    # ---- G12: child crash after ready -> 66 ----------------------------------
+    lab = Lab(root, name="g12")
+    code, out = drive(lab, "crash_after_ready", roomy, ["task"], keep_stdin=True)
+    check("g12 crash exits 66", code == 66, f"code={code} out={out[-400:]}")
+
+    # ---- G13: clean /quit -> 0 with close acked ------------------------------
+    lab = Lab(root, name="g13")
+    code, out = drive(lab, "ok", roomy, ["hello", "/quit"], keep_stdin=True)
+    closes = [f for f in lab.frames("received") if f.get("method") == "session/close"]
+    check("g13 clean quit exits 0", code == 0, f"code={code} out={out[-400:]}")
+    check("g13 close dispatched once", len(closes) == 1, f"closes={closes}")
+
+    # ---- G14: close never acked -> 70 ----------------------------------------
+    lab = Lab(root, name="g14")
+    started = time.monotonic()
+    code, out = drive(lab, "close_noack", roomy, ["/quit"], keep_stdin=True, timeout=20)
+    elapsed = time.monotonic() - started
+    check("g14 unacked close exits 70", code == 70, f"code={code} out={out[-400:]}")
+    check("g14 bounded settlement <15s", elapsed < 15.0, f"elapsed={elapsed:.1f}s")
+
+    # ---- G15: EOF teardown -> 0 ----------------------------------------------
+    lab = Lab(root, name="g15")
+    run = Run(lab, "ok", roomy, stdin_lines=None, keep_stdin=True)
+    time.sleep(0.3)  # let the spawn happen
+    run.proc.stdin.close()
+    code = run.wait(timeout=15)
+    check("g15 EOF teardown exits 0", code == 0, f"code={code} out={run.output[-300:]}")
+
+    # ---- G16: SIGINT -> 130, bounded, child settled --------------------------
+    lab = Lab(root, name="g16")
+    run = Run(lab, "ok", roomy, stdin_lines=None, keep_stdin=True)
+    time.sleep(1.5)  # reach READY
+    run.sigint()
+    code = run.wait(timeout=10)
+    check("g16 SIGINT exits 130", code == 130, f"code={code} out={run.output[-300:]}")
+    check("g16 bounded SIGINT settlement <8s", code is not None, "timed out")
+    time.sleep(1.0)  # let the orphaned stub notice its stdin closed and exit
+    stub_alive = subprocess.run(["pgrep", "-f", f"stub-{lab.name}.py"], capture_output=True)
+    check("g16 stub child gone", stub_alive.returncode != 0, f"pgrep out={stub_alive.stdout!r}")
+
+    # ---- G17: sensitive material redaction, never truncated-only -------------
+    lab = Lab(root, name="g17")
+    code, out = drive(lab, "sensitive", roomy, ["hello", "/quit"])
+    secrets = ["sk-stubsecret1234567890", "STUBCOOKIEVALUE", "STUBTICKET123456",
+               "abc123def456ghi789", "acw_tc"]
+    check("g17 no raw secret in output", not any(s in out for s in secrets),
+          "\n".join(l for l in out.splitlines() if any(s in l for s in secrets)))
+    check("g17 redaction markers present", "[REDACTED" in out, out)
+    check("g17 unknown notification shows key names only",
+          "weird/notification" in out and "api_key" in out and "headers" in out, out)
+    rh_replies = [f for f in lab.frames("received")
+                  if isinstance(f, dict) and f.get("id") == "rh-1"]
+    check("g17 runtime-headers fail-closed reply",
+          rh_replies and rh_replies[0].get("result", {}).get("headersApplied") is False,
+          f"replies={rh_replies}")
+    check("g17 NEEDS-AUTHORIZATION surfaced", "NEEDS-AUTHORIZATION" in out, out)
+    check("g17 exits 0 despite hostile frames", code == 0, f"code={code}")
+
+    # ---- G18: permission reverse request declined, no hang -------------------
+    lab = Lab(root, name="g18")
+    code, out = drive(lab, "permission", roomy, ["hello", "/quit"], timeout=20)
+    check("g18 completes (no hang), exits 0", code == 0, f"code={code} out={out[-300:]}")
+    check("g18 permission secret redacted", "sk-permsecret123456789" not in out, out)
+    declines = [f for f in lab.frames("received")
+                if isinstance(f, dict) and f.get("id") == "perm-1"]
+    check("g18 identifiable error reply sent",
+          declines and declines[0].get("error", {}).get("code") == -32601
+          and "does not support" in declines[0].get("error", {}).get("message", ""),
+          f"declines={declines}")
+    check("g18 NEEDS-AUTHORIZATION marker", "NEEDS-AUTHORIZATION" in out, out)
+    check("g18 never a success payload for permission",
+          not (declines and "result" in declines[0]), f"declines={declines}")
+
+    # ---- G19: config fail-closed before spawn --------------------------------
+    lab = Lab(root, name="g19")
+    loose = os.path.join(root, "loose.json")
+    with open(loose, "w") as fh:
+        fh.write('{"model": "x/glm", "provider": {}}')
+    os.chmod(loose, 0o644)
+    env = dict(os.environ)
+    env["STUB_LOG"] = lab.log
+    env["STUB_MODE"] = "ok"
+    # Raw invocation WITHOUT --settings (Run() always adds it):
+    p = subprocess.run(
+        [sys.executable, DRIVER, "--bin", lab.stub, "--cwd", lab.root],
+        input="", capture_output=True, text=True, env=env, timeout=15,
+    )
+    code, out = p.returncode, p.stdout + p.stderr
+    p2 = subprocess.run(
+        [sys.executable, DRIVER, "--bin", lab.stub, "--cwd", lab.root, "--settings", loose],
+        input="", capture_output=True, text=True, env=env, timeout=15,
+    )
+    code2, out2 = p2.returncode, p2.stdout + p2.stderr
+    check("g19 missing --settings exits 64", code == 64 and "never falls back" in out, f"code={code} {out[-200:]}")
+    check("g19 loose perms exits 64", code2 == 64 and "0600" in out2, f"code={code2} {out2[-200:]}")
+    check("g19 no child spawned on config failure", lab.frames("argv") == [], f"{lab.frames('argv')}")
+
+    print(f"\nSUMMARY: pass={PASS} fail={FAIL}")
+    if FAILURES:
+        print("\n".join(f"  - {f}" for f in FAILURES))
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/multi-agent-orchestration/scripts/zcode-worker-driver.py
+++ b/skills/multi-agent-orchestration/scripts/zcode-worker-driver.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """zcode worker driver: wrap a long-lived `zcode app-server` session for tmux.
 
-Position in the orchestration stack (see references/09-zcode-cli-worker.md):
-the zcode CLI ships no standalone TUI (`@zcode/tui` is not bundled with the
-desktop app), so a worker terminal runs THIS driver instead. The driver
+Position in the orchestration stack (see references/09-zcode-cli-worker.md and
+references/24-zcode-driver-safety.md): the zcode CLI ships no standalone TUI
+(`@zcode/tui` is not bundled with the desktop app), so a worker terminal runs
+THIS driver instead. The driver
 
   * spawns `zcode app-server` as a child (stdio JSON protocol, bare frames
     `{id, method, params}` — no jsonrpc envelope),
@@ -15,19 +16,83 @@ desktop app), so a worker terminal runs THIS driver instead. The driver
     PM inspection (tmux capture-pane / Orca terminal read) works unchanged.
 
 Local commands on stdin (typed like plain text, `/` prefix):
-  /status   print session state summary (session/read)
+  /status   print session state summary (local projection + session/read)
   /stop     stop the running turn (session/stop) — process stays alive
   /compact  compact the session context (session/compact)
   /quit     close the session and exit the driver
+Control commands are NEVER forwarded to the model as session text, including
+while the session is still starting up.
 
-Per-worker model: pass `--model MODEL` (e.g. `--model GLM-5.3-Flash`, or
-`--model providerId/modelId` to pin a non-default provider). After the session
-is created the driver issues one `session/setModel`; on failure it prints an
-error line and keeps the global config model (warned, never crashes). Without
-`--model` the session uses whatever `~/.zcode/cli/config.json` selects.
+== Startup readiness barrier (safety refactor 2026-09-13) ==
 
-Exit codes: 64 = misconfiguration (missing zcode executable / model config),
-1 = app-server child died, 0 = clean /quit.
+The driver only reaches READY after: session/create -> session/setModel (when
+--model is given) -> session/read -> EXACT match of the session's actual
+{providerId, modelId} against the frozen expected modelRef. Without --model
+the expected ref is frozen from the private settings file's `model` field at
+startup and verified the same way. Any create/setModel/read error, malformed
+response, model mismatch, or bootstrap deadline expiry exits NON-ZERO with
+ZERO task messages sent — the queued backlog is dropped (reported), never
+flushed, and the driver never falls back to "whatever model the global config
+happens to select".
+
+== Private settings isolation (explicit entry, fail-closed) ==
+
+`--settings PATH` (required) is the ONLY accepted configuration entry: a
+private per-worker settings file the DISPATCHER provides. The path is passed
+to the child CLI via the official `--settings <path>` flag (absolute path —
+the official loader resolves relative paths against the child's own cwd).
+The driver never reads, writes, or falls back to the shared
+`~/.zcode/cli/config.json`, never rewrites the global model on exit, and
+never redirects HOME or injects config by environment.
+
+The OFFICIAL ZCode 0.16.5 `app-server` entry REJECTS `--settings`
+("Unknown option --settings", exit 1 — PM live receipt 2026-09-13; the flag
+documented in `--help` belongs to other entry points). When the child dies
+at startup rejecting the isolation flag, the driver prints an explicit
+`UNSUPPORTED_CONFIG_ISOLATION` line and exits 68 — it must NOT be deployed as
+the default worker entry against that build. Community runtime builds that
+actually accept `--settings` for app-server (separate contract) can reuse
+this driver unchanged. This flag isolates the USER SETTINGS layer only: it
+does not isolate the session DB, the desktop auth storage, or project-level
+`.zcode` config files inside the session workspace.
+
+== Permission mode ==
+
+`--mode` maps to the session/create `mode` parameter: build (default, safe —
+the server refuses mutating tools without an interactive permission client),
+edit, plan, or yolo (unattended; EXPLICIT opt-in only, same risk class as
+claude-code bypassPermissions). The driver never auto-approves reverse
+permission requests: `interaction/requestPermission` and any other unknown
+server->client request gets an identifiable error reply (never a guessed
+success payload) so the corresponding work stops instead of hanging.
+
+== Start/Weekend runtime verification headers ==
+
+`interaction/requestProviderRuntimeHeaders` (provider runtime verification,
+incl. captcha-retry) is answered via the official fail-closed channel
+`{headersApplied: false, errorMessage: ...}`. This driver has NO desktop host
+bridge: it cannot apply verification headers, and it never collects, prints,
+forwards, or caches captcha/header/ticket material. `headersApplied:false`
+makes the server fail the model request loudly instead of proceeding
+unverified — an error is NEVER treated as completion.
+
+== Exit codes ==
+
+  0    clean shutdown (/quit with close confirmed, or EOF teardown) — also 0
+       when /quit arrives before the session existed (user-initiated abort)
+  64   misconfiguration (bad --mode/--settings/--bin/--cwd, unreadable or
+       world/group-readable settings file, unusable model ref)
+  65   startup not verified (create/setModel/read error, timeout, malformed
+       response, or actual model != expected model) — zero task sends
+  66   app-server child exited unexpectedly (before or after ready)
+  68   UNSUPPORTED_CONFIG_ISOLATION (child rejected the --settings flag)
+  70   /quit close was sent but not confirmed within the close timeout
+  130  SIGINT (128+2), 143 SIGTERM — bounded child settlement completed
+
+All rendered output goes through emit(): redaction first (token/header/
+credential patterns and structured masking), then length bounding. Unknown
+notifications print their method name and param KEY names only — never
+values, and truncation is never used as a substitute for redaction.
 """
 
 from __future__ import annotations
@@ -35,7 +100,11 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import queue
+import re
+import shlex
 import shutil
+import signal
 import subprocess
 import sys
 import threading
@@ -47,19 +116,141 @@ PREFS = {
     "askUserQuestionAutoResolutionEnabled": True,
 }
 ZCODE_BUNDLE = "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs"
-# ZCODE_CLI_CONFIG overrides the config path (tests / multi-install machines).
-CLI_CONFIG = os.environ.get(
-    "ZCODE_CLI_CONFIG",
-    os.path.join(os.path.expanduser("~"), ".zcode", "cli", "config.json"),
+# Official permission modes (bundle normalizePromptMode, 0.16.5 static read):
+# build / edit / plan / yolo. build is the safe headless default; yolo is the
+# unattended mode and must be an explicit dispatch decision.
+MODES = ("build", "edit", "plan", "yolo")
+
+DEFAULT_BOOTSTRAP_TIMEOUT = 45.0
+DEFAULT_CLOSE_TIMEOUT = 5.0
+CHILD_TERMINATE_TIMEOUT = 3.0
+
+# Official server->client request method names (bundle static read 0.16.5).
+METHOD_RUNTIME_PREFS = "session/requestRuntimePreferences"
+METHOD_RUNTIME_HEADERS = "interaction/requestProviderRuntimeHeaders"
+# Reverse requests this driver structurally knows about but cannot answer
+# (no interactive client / no host bridge). Declined with an identifiable
+# error frame — never a guessed success payload, never silence.
+KNOWN_UNSUPPORTED_REQUESTS = (
+    "interaction/requestPermission",
+    "interaction/requestUserInput",
+    "interaction/requestOfficialMcpAuthHeaders",
+)
+# Child output matching this means the child binary rejected the --settings
+# isolation flag itself (official 0.16.5 app-server behavior, PM live
+# receipt 2026-09-13) — classify as UNSUPPORTED_CONFIG_ISOLATION, not a
+# generic child crash.
+UNKNOWN_OPTION_SETTINGS_RE = re.compile(
+    r"(?i)unknown\s+option[^\n]{0,80}--settings"
+    r"|--settings[^\n]{0,80}unknown\s+option"
 )
 
+# ---------------------------------------------------------------------------
+# Output hygiene: redact first, bound second. Truncation is NEVER a
+# substitute for redaction, so every rendered line passes through emit().
+# ---------------------------------------------------------------------------
+
+MAX_LINE = 400
+ELLIPSIS = "…"
+REDACTED = "[REDACTED]"
+
+# Token schemes first so the header pattern cannot orphan the credential.
+REDACT_PATTERNS = [
+    (re.compile(r"(?i)\b(bearer|basic|token)\s+([A-Za-z0-9._~+/=-]{6,})"),
+     r"\1 [REDACTED-TOKEN]"),
+    (re.compile(r"\b(sk-[A-Za-z0-9_-]{8,})"), "[REDACTED-TOKEN]"),
+    # Header-style assignments: Authorization: ..., "Cookie": ..., including
+    # JSON-quoted and Python-repr keys. The \[[^\]]*\] alternative swallows
+    # JSON-array values wholesale so no array element can survive.
+    (re.compile(
+        r"(?i)\b(authorization|proxy-authorization|x-api-key|api-key|"
+        r"x-goog-api-key|cookie|set-cookie)\b(['\"]?\s*[:=]\s*)"
+        r"(\[[^\]]*\]|\"[^\"]*\"|'[^']*'|[^\s,;}\]]+)"),
+     r"\1\2" + REDACTED),
+    # Generic secret-ish field names: apiKey: ..., "password": "..." ...
+    (re.compile(
+        r"(?i)\b(api[_ ]?key|access[_ ]?token|refresh[_ ]?token|token|"
+        r"secret|password|passwd|credential)\b(['\"]?\s*[:=]\s*)"
+        r"(\"[^\"]{4,}\"|'[^']{4,}'|[A-Za-z0-9._~+/=-]{8,})"),
+     r"\1\2" + REDACTED),
+]
+
+# Structured-payload masking (single choke point before json.dumps): covers
+# shapes text patterns cannot parse (header values serialized as arrays or
+# nested objects). Exact key match; header-block keys keep header NAMES with
+# every value masked, credential keys mask the whole value.
+HEADER_BLOCK_KEYS = re.compile(r"(?i)^(headers|responseheaders|requestheaders)$")
+SENSITIVE_PAYLOAD_KEYS = re.compile(
+    r"(?i)^(authorization|proxy-authorization|x-api-key|api-key|api_?key|"
+    r"cookie|set-cookie|jwt|access[-_]?token|refresh[-_]?token|token|"
+    r"secret|password|passwd|credential|x-aliyun-captcha-.*)$"
+)
+
+
+def mask_header_value(value):
+    if isinstance(value, str):
+        return REDACTED if value else value
+    if isinstance(value, list):
+        return [mask_header_value(v) for v in value]
+    if isinstance(value, dict):
+        return {k: mask_header_value(v) for k, v in value.items()}
+    return REDACTED
+
+
+def mask_value(value, key_hint: str = ""):
+    """Recursively mask credential material in structured payloads."""
+    if HEADER_BLOCK_KEYS.match(key_hint):
+        if isinstance(value, dict):
+            return {
+                k: (REDACTED if SENSITIVE_PAYLOAD_KEYS.match(str(k))
+                    else mask_header_value(v))
+                for k, v in value.items()
+            }
+        return REDACTED if value else value
+    if SENSITIVE_PAYLOAD_KEYS.match(key_hint):
+        return REDACTED
+    if isinstance(value, dict):
+        return {k: mask_value(v, str(k)) for k, v in value.items()}
+    if isinstance(value, list):
+        return [mask_value(v) for v in value]
+    return value
+
+
+def redact(text: str) -> str:
+    for pattern, replacement in REDACT_PATTERNS:
+        text = pattern.sub(replacement, text)
+    return text
+
+
+def bound(text: str, limit: int = MAX_LINE) -> str:
+    return text if len(text) <= limit else text[:limit] + ELLIPSIS
+
+
+def emit(line: str) -> None:
+    """Single exit point for every rendered line: redacted, then bounded."""
+    print(redact(bound(line)), flush=True)
+
+
+def payload_summary(value, limit: int = MAX_LINE) -> str:
+    try:
+        return json.dumps(mask_value(value), ensure_ascii=False)
+    except (TypeError, ValueError):
+        return "<unserializable>"
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
 _next_request_id = 0
+_request_id_lock = threading.Lock()
 
 
 def request_id() -> int:
     global _next_request_id
-    _next_request_id += 1
-    return _next_request_id
+    with _request_id_lock:
+        _next_request_id += 1
+        return _next_request_id
 
 
 def fail_config(message: str) -> None:
@@ -86,85 +277,117 @@ def resolve_zcode_bin(explicit: str) -> str:
     raise AssertionError("unreachable")
 
 
-def check_model_config() -> str:
-    """Fail fast instead of launching a worker that cannot talk to a model."""
-    if not os.path.exists(CLI_CONFIG):
+def load_private_settings(path: str) -> dict:
+    """Validate the explicit private settings entry. Fail closed (64) on:
+    missing file, group/world-readable permissions (credential hygiene),
+    malformed JSON, or missing `model`/`provider` keys. The driver NEVER
+    touches the shared ~/.zcode/cli/config.json as a fallback."""
+    if not path:
         fail_config(
-            f"{CLI_CONFIG} is missing. Log in via the ZCode desktop app "
-            "(BigModel Coding Plan), then mirror the provider entry into the "
-            "cli config — see references/09-zcode-cli-worker.md §2."
+            "--settings is required: the driver only runs with an explicit "
+            "private per-worker settings file and never falls back to the "
+            "shared global config"
+        )
+    abs_path = os.path.abspath(path)
+    if not os.path.isfile(abs_path):
+        fail_config(f"--settings {abs_path}: file does not exist")
+    perms = os.stat(abs_path).st_mode & 0o777
+    if perms & 0o077:
+        fail_config(
+            f"--settings {abs_path}: permissions {oct(perms)} are "
+            "group/world accessible; require 0600 (private credentials)"
         )
     try:
-        with open(CLI_CONFIG, "r", encoding="utf-8") as handle:
+        with open(abs_path, "r", encoding="utf-8") as handle:
             config = json.load(handle)
     except (OSError, json.JSONDecodeError) as exc:
-        fail_config(f"cannot read {CLI_CONFIG}: {exc}")
-    if not config.get("model") or not config.get("provider"):
+        fail_config(f"cannot read private settings {abs_path}: {exc}")
+    if not isinstance(config, dict) or not config.get("model") or not config.get("provider"):
         fail_config(
-            f"{CLI_CONFIG} lacks `model` / `provider` keys — the headless CLI "
-            "cannot reach any model provider without them (see "
-            "references/09-zcode-cli-worker.md §2)."
+            f"private settings {abs_path} lacks `model` / `provider` keys — "
+            "the headless CLI cannot reach any model provider without them"
         )
-    return config["model"]
+    return config
 
 
-def restore_global_model(startup_model: str) -> None:
-    """session/setModel persistently rewrites the GLOBAL config `model`
-    field (no protocol opt-out — persistAsWorkspaceLastUsed:false does not
-    prevent it; PM live probe 2026-08-27). Snapshot at startup, restore at
-    exit, so one worker's --model never repoints other workers' default.
-    Known race: concurrently-spawned drivers each restore their own startup
-    snapshot; last-exiter wins (references/09 §4)."""
-    try:
-        with open(CLI_CONFIG, "r", encoding="utf-8") as handle:
-            config = json.load(handle)
-        if config.get("model") == startup_model:
-            return
-        config["model"] = startup_model
-        tmp = CLI_CONFIG + ".driver-restore.tmp"
-        with open(tmp, "w", encoding="utf-8") as handle:
-            json.dump(config, handle, ensure_ascii=False, indent=2)
-        os.replace(tmp, CLI_CONFIG)
-        print(f"[driver] restored global model to {startup_model}", flush=True)
-    except (OSError, json.JSONDecodeError) as exc:
-        print(f"[driver] WARNING: could not restore global model: {exc}", flush=True)
+def parse_model_ref(model_field: object, source: str) -> dict:
+    """`provider/model` config string -> frozen {providerId, modelId}."""
+    text = str(model_field or "")
+    if "/" not in text:
+        fail_config(
+            f"{source} `model` field {text!r} has no provider prefix "
+            "(expected `providerId/modelId`)"
+        )
+    provider_id, model_id = text.split("/", 1)
+    if not provider_id or not model_id:
+        fail_config(f"{source} `model` field {text!r} is malformed")
+    return {"providerId": provider_id, "modelId": model_id}
 
 
-def resolve_model_ref(spec: str) -> dict:
-    """`MODEL`, `providerId/modelId` -> setModel modelRef.
-
-    Default providerId comes from the config's global `model` string
-    (`provider/model`), so `--model GLM-5.3-Flash` reuses the logged-in
-    BigModel Coding Plan provider without extra flags.
-    """
-    with open(CLI_CONFIG, "r", encoding="utf-8") as handle:
-        config = json.load(handle)
-    default_provider = str(config.get("model", "")).split("/", 1)[0]
+def resolve_model_ref(spec: str, settings: dict) -> dict:
+    """`MODEL`, `providerId/modelId` -> setModel modelRef. Bare model ids
+    reuse the private settings' provider prefix."""
     if "/" in spec:
         provider_id, model_id = spec.split("/", 1)
     else:
-        provider_id, model_id = default_provider, spec
-    if not provider_id:
-        fail_config(
-            f"cannot infer providerId for --model {spec}: config `model` has "
-            "no provider prefix. Use the providerId/modelId form instead."
-        )
+        provider_id = str(settings.get("model", "")).split("/", 1)[0]
+        model_id = spec
+    if not provider_id or not model_id:
+        fail_config(f"cannot build providerId/modelId for --model {spec}")
     return {"providerId": provider_id, "modelId": model_id}
 
 
 class Driver:
-    def __init__(self, proc: subprocess.Popen, session_id: str, model_ref: dict | None) -> None:
+    """Bootstrap state machine:
+
+    starting -> (create ok) -> applying? -> verifying -> ready
+    any failure/timeout -> failed (main loop exits non-zero, zero sends)
+    """
+
+    def __init__(
+        self,
+        proc: subprocess.Popen,
+        mode: str,
+        model_ref: dict,
+        apply_model: bool,
+        bootstrap_timeout: float,
+    ) -> None:
         self.proc = proc
-        self.session_id = session_id
-        # {providerId, modelId} applied once via session/setModel after create;
-        # None = keep the global config model.
-        self.model_ref = model_ref
+        self.mode = mode
+        # Frozen expected {providerId, modelId}: from --model when given,
+        # else from the private settings `model` field. The session's ACTUAL
+        # model must match this exactly before any task text is drained.
+        self.expected_model = model_ref
+        # True only when --model was given: create -> setModel -> read.
+        # Without --model: create -> read (verify only, no write).
+        self.apply_model = apply_model
+        self.bootstrap_timeout = bootstrap_timeout
+        self.bootstrap_deadline = time.monotonic() + bootstrap_timeout
+
         self.write_lock = threading.Lock()
+        self.pending_lock = threading.Lock()
         self.pending: dict[int, str] = {}  # request id -> short label
-        # PM text that arrived before session/create finished; flushed in
-        # order as soon as the session id is known (no message loss).
-        self.queued_inputs: list[str] = []
+
         self.queue_lock = threading.Lock()
+        # PM text that arrived before READY; flushed in order ONLY after the
+        # model verify barrier passes. On bootstrap failure it is dropped
+        # (reported), never sent.
+        self.queued_inputs: list[str] = []
+
+        self.state_lock = threading.Lock()
+        self.session_id = ""
+        self.actual_model = ""
+
+        # Bootstrap coordination (reader thread transitions, main waits).
+        self.ready_event = threading.Event()
+        self.fail_event = threading.Event()
+        self.fail_reason = ""
+        self.child_dead = threading.Event()
+        self.child_output: list[str] = []  # last raw lines (for classification)
+        self.close_acked = threading.Event()
+        self.close_timeout = DEFAULT_CLOSE_TIMEOUT
+
+    # ---- protocol plumbing -------------------------------------------------
 
     def send_line(self, payload: dict) -> None:
         assert self.proc.stdin is not None
@@ -174,120 +397,255 @@ class Driver:
 
     def request(self, method: str, params: dict, label: str) -> int:
         rid = request_id()
-        self.pending[rid] = label
+        with self.pending_lock:
+            self.pending[rid] = label
         self.send_line({"id": rid, "method": method, "params": params})
         return rid
 
-    # ---- rendering -------------------------------------------------------
+    def bootstrap_fail(self, reason: str) -> None:
+        with self.state_lock:
+            if self.fail_event.is_set():
+                return
+            self.fail_reason = reason
+        self.fail_event.set()
+
+    def boot_expired(self) -> bool:
+        return time.monotonic() > self.bootstrap_deadline
+
+    # ---- bootstrap transitions (reader thread) ------------------------------
+
+    def on_create_result(self, result: dict) -> None:
+        session = result.get("session")
+        if not (isinstance(session, dict) and isinstance(session.get("sessionId"), str)
+                and session["sessionId"]):
+            self.bootstrap_fail(
+                "create result malformed: no result.session.sessionId "
+                f"({payload_summary(result, 120)})"
+            )
+            return
+        with self.state_lock:
+            self.session_id = session["sessionId"]
+        emit(f"[driver] session created: {self.session_id}")
+        if self.apply_model:
+            self.request(
+                "session/setModel",
+                {
+                    "sessionId": self.session_id,
+                    "model": self.expected_model,
+                    # Server default rewrites the persisted last-used model;
+                    # the per-worker choice must not leak (PM dual-worker
+                    # live check, 2026-08-27).
+                    "persistAsWorkspaceLastUsed": False,
+                },
+                "setModel",
+            )
+        else:
+            # No --model: the settings-selected model must already be the
+            # frozen expected ref — verify it instead of writing it.
+            self.request("session/read", {"sessionId": self.session_id}, "read")
+
+    def on_setmodel_result(self, result: dict) -> None:
+        # Success carries no model echo — the authoritative check is the
+        # session/read below.
+        self.request("session/read", {"sessionId": self.session_id}, "read")
+
+    def on_read_result(self, result: dict) -> None:
+        state = result.get("session")
+        model = state.get("model") if isinstance(state, dict) else None
+        if not isinstance(model, dict):
+            self.bootstrap_fail(
+                "read result malformed: no result.session.model "
+                f"({payload_summary(result, 120)})"
+            )
+            return
+        actual = {
+            "providerId": str(model.get("providerId", "")),
+            "modelId": str(model.get("modelId", "")),
+        }
+        with self.state_lock:
+            self.actual_model = f"{actual['providerId']}/{actual['modelId']}"
+        if actual != self.expected_model:
+            self.bootstrap_fail(
+                "model mismatch: session reports "
+                f"{actual['providerId']}/{actual['modelId']} but "
+                f"{self.expected_model['providerId']}/{self.expected_model['modelId']} "
+                "was requested — refusing to send task text on the wrong model"
+            )
+            return
+        # READY: only now may queued PM text reach the model. Inputs that
+        # arrive while the backlog drains are picked up here too — ready_event
+        # is only set AFTER the queue is empty, so the main loop's direct
+        # send path can never strand or reorder queued text.
+        with self.queue_lock:
+            drained = len(self.queued_inputs)
+        while True:
+            with self.queue_lock:
+                if not self.queued_inputs:
+                    break
+                text = self.queued_inputs.pop(0)
+            self.request(
+                "session/send",
+                {"sessionId": self.session_id, "content": text},
+                "send",
+            )
+        emit(
+            f"[driver] READY model={self.actual_model} verified "
+            f"mode={self.mode} drained={drained}"
+        )
+        self.ready_event.set()
+
+    # ---- rendering -----------------------------------------------------------
 
     def render(self, frame: dict) -> None:
         method = frame.get("method")
         if method is None:  # response to one of our requests
-            rid = frame.get("id")
-            label = self.pending.pop(rid, "?") if isinstance(rid, int) else "?"
-            if "error" in frame:
-                err = frame["error"]
-                print(f"[driver] {label} ✗ {err.get('code')}: {err.get('message')}", flush=True)
-                if label == "setModel":
-                    print(
-                        "[driver] WARNING: per-worker model not applied; "
-                        "continuing with the global config model",
-                        flush=True,
-                    )
-            else:
-                result = frame.get("result", {})
-                if label == "create":
-                    # Real protocol (ZCode Protocol v1): the id lives at
-                    # result.session.sessionId, not at the top level.
-                    session = result.get("session")
-                    if isinstance(session, dict) and isinstance(
-                        session.get("sessionId"), str
-                    ):
-                        self.session_id = session["sessionId"]
-                        print(
-                            f"[driver] session ready: {self.session_id}",
-                            flush=True,
-                        )
-                    if self.model_ref and self.session_id:
-                        # Per-worker model (zod schema verified against the
-                        # app-server bundle: strict object, modelRef required).
-                        self.request(
-                            "session/setModel",
-                            {
-                                "sessionId": self.session_id,
-                                "model": self.model_ref,
-                                # Server default rewrites the GLOBAL config
-                                # model — one worker's --model would repoint
-                                # every other worker's default. Opt out.
-                                # (PM dual-worker live check, 2026-08-27)
-                                "persistAsWorkspaceLastUsed": False,
-                            },
-                            "setModel",
-                        )
-                    with self.queue_lock:
-                        backlog, self.queued_inputs = self.queued_inputs, []
-                    for text in backlog:
-                        self.request(
-                            "session/send",
-                            {"sessionId": self.session_id, "content": text},
-                            "send",
-                        )
-                summary = self.summarize_result(label, result)
-                print(f"[driver] {label} ✓ {summary}", flush=True)
+            self.render_response(frame)
             return
 
         params = frame.get("params") or {}
-        if method == "session/requestRuntimePreferences":
+        if method == METHOD_RUNTIME_PREFS:
             # Answer immediately: every turn fails (prompt_failed) unless the
             # client replies within the 15s server-side window.
             if "id" in frame:
                 self.send_line({"id": frame["id"], "result": PREFS})
-                print(
-                    f"[driver] answered {frame['id']} "
-                    f"scope={params.get('scope')}",
-                    flush=True,
-                )
+                emit(f"[driver] answered runtimePreferences scope={params.get('scope')}")
+            return
+        if method == METHOD_RUNTIME_HEADERS:
+            self.handle_runtime_headers(frame)
+            return
+        if isinstance(frame.get("id"), (int, str)):
+            # Unknown (or known-unsupported) SERVER REQUEST: reply with an
+            # identifiable error so the corresponding work stops instead of
+            # the server stalling 15s. Never a guessed success payload, and
+            # never a silent auto-approval.
+            known = method in KNOWN_UNSUPPORTED_REQUESTS
+            self.send_line({
+                "id": frame["id"],
+                "error": {
+                    "code": -32601,
+                    "message": (
+                        "driver does not support "
+                        f"{method}: "
+                        + (
+                            "no interactive permission client attached; "
+                            "re-dispatch with an explicit mode decision if "
+                            "this work is intended"
+                            if known else
+                            "unsupported reverse request"
+                        )
+                    ),
+                },
+            })
+            marker = "NEEDS-AUTHORIZATION" if known else "UNSUPPORTED"
+            emit(f"[driver] {marker}: declined server request {method}")
             return
         if method == "state.updated":
+            # Whitelisted fields only — a patch can carry arbitrary data.
             patch = params.get("patch") or {}
-            print(
-                f"[session] {patch.get('status', '?')} ({params.get('reason', '—')})",
-                flush=True,
-            )
+            if isinstance(patch, dict):
+                emit(f"[session] {patch.get('status', '?')} ({params.get('reason', '—')})")
             return
-        if method == "process/resourceSample":
-            return  # too chatty; PM can poll artifacts / sqlite instead
-        if method in ("v4/telemetry/event",):
-            return
+        if method in ("process/resourceSample", "v4/telemetry/event"):
+            return  # too chatty; PM polls artifacts / sqlite instead
         if method == "computer-use/operation-event":
             op = params.get("operation") or params
-            print(f"[tool] {json.dumps(op, ensure_ascii=False)[:160]}", flush=True)
+            emit(f"[tool] {payload_summary(op, 160)}")
             return
-        # Unknown notifications: one compact line each, never drop silently.
-        print(f"[notify] {method} {json.dumps(params, ensure_ascii=False)[:120]}", flush=True)
+        # Unknown notifications: method name + param KEY NAMES only. Values
+        # are never rendered — bounding a value is not redaction.
+        keys = ",".join(sorted(str(k) for k in params.keys())) if isinstance(params, dict) else "?"
+        emit(f"[notify] {method} (params redacted; keys: {keys or 'none'})")
 
-    @staticmethod
-    def summarize_result(label: str, result: dict) -> str:
-        if label == "send":
-            return f"accepted={result.get('accepted')}"
-        if label == "setModel":
-            return "per-worker model applied"
-        if label == "read":
-            # Real protocol: status/model live in result.session (verified
-            # 2026-08-27 against live app-server; projection.status is a
-            # coarser mirror without the model ref).
-            state = result.get("session") or result.get("state") or result
-            status = state.get("status", "?")
-            model = state.get("model") or {}
+    def render_response(self, frame: dict) -> None:
+        rid = frame.get("id")
+        with self.pending_lock:
+            label = self.pending.pop(rid, "?") if isinstance(rid, int) else "?"
+        if "error" in frame:
+            err = frame["error"] or {}
+            emit(f"[driver] {label} ✗ {err.get('code')}: {err.get('message')}")
+            if not self.ready_event.is_set():
+                self.bootstrap_fail(f"{label} failed: {err.get('code')} {err.get('message')}")
+            return
+        result = frame.get("result", {})
+        if isinstance(result, dict) and label == "create" and not self.ready_event.is_set():
+            self.on_create_result(result)
+        elif isinstance(result, dict) and label == "setModel" and not self.ready_event.is_set():
+            self.on_setmodel_result(result)
+        elif isinstance(result, dict) and label == "read" and not self.ready_event.is_set():
+            self.on_read_result(result)
+        elif label == "close":
+            self.close_acked.set()
+            emit("[driver] close ✓")
+        elif label == "send":
+            emit(f"[driver] send ✓ accepted={result.get('accepted') if isinstance(result, dict) else '?'}")
+        elif label == "stop":
+            emit("[driver] stop ✓")
+        elif label == "compact":
+            emit("[driver] compact ✓")
+        elif label == "read" and self.ready_event.is_set():
+            state = result.get("session") if isinstance(result, dict) else {}
+            model = state.get("model") or {} if isinstance(state, dict) else {}
             if isinstance(model, dict):
-                model = (
-                    f"{model.get('providerId', '?')}/{model.get('modelId', '?')}"
-                )
-            return f"status={status} model={model}"
-        return json.dumps(result, ensure_ascii=False)[:120]
+                model = f"{model.get('providerId', '?')}/{model.get('modelId', '?')}"
+            emit(f"[driver] read ✓ status={state.get('status', '?') if isinstance(state, dict) else '?'} model={model}")
+        else:
+            emit(f"[driver] {label} ✓ {payload_summary(result, 120)}")
+
+    def handle_runtime_headers(self, frame: dict) -> None:
+        """Official fail-closed channel. This driver has NO host bridge: it
+        cannot apply provider runtime verification headers (Start/Weekend
+        style runtime verification, captcha retries) and never touches
+        header/ticket material. Reply headersApplied:false — the server then
+        fails the model request loudly; that error is NOT completion."""
+        frame_id = frame.get("id")
+        if frame_id is None:
+            emit(
+                "[driver] NEEDS-AUTHORIZATION: runtime-headers notification "
+                "received (no id; cannot even fail-closed-reply) — ignored, "
+                "no header material is handled by this driver"
+            )
+            return
+        emit(
+            "[driver] NEEDS-AUTHORIZATION: provider runtime verification "
+            "requested; this driver has no host bridge and will not "
+            "collect, print, or apply header/captcha material"
+        )
+        self.send_line({
+            "id": frame_id,
+            "result": {
+                "headersApplied": False,
+                "errorMessage": (
+                    "driver has no provider-runtime-headers host bridge: "
+                    "complete verification in the official ZCode desktop "
+                    "app, or attach a host-bridge runtime (separate contract)"
+                ),
+            },
+        })
+
+    # ---- projection ----------------------------------------------------------
+
+    def projection(self) -> dict:
+        with self.state_lock:
+            return {
+                "state": (
+                    "ready" if self.ready_event.is_set()
+                    else "failed" if self.fail_event.is_set()
+                    else "starting"
+                ),
+                "sessionId": self.session_id,
+                "mode": self.mode,
+                "expectedModel": (
+                    f"{self.expected_model['providerId']}/{self.expected_model['modelId']}"
+                ),
+                "actualModel": self.actual_model,
+                "queuedInputs": len(self.queued_inputs),
+                "childPid": self.proc.pid,
+            }
 
 
 def reader_loop(driver: Driver) -> None:
+    """Reads child stdout forever. NEVER calls os._exit — child death is an
+    event so the main thread performs the bounded settlement + cleanup."""
     assert driver.proc.stdout is not None
     for raw in driver.proc.stdout:
         line = raw.strip()
@@ -296,13 +654,100 @@ def reader_loop(driver: Driver) -> None:
         try:
             frame = json.loads(line)
         except json.JSONDecodeError:
-            print(f"[driver] non-JSON line: {line[:120]}", flush=True)
+            driver.child_output.append(line)
+            if len(driver.child_output) > 20:
+                del driver.child_output[:-20]
+            emit(f"[driver] non-JSON line: {line}")
             continue
         if isinstance(frame, dict):
             driver.render(frame)
-    # stdout closed => child is gone
-    print("[driver] app-server exited", flush=True)
-    os._exit(1)
+    driver.child_dead.set()
+    emit("[driver] app-server stdout closed (child exited)")
+
+
+def classify_child_death(driver: Driver) -> int:
+    """Map an unexpected child exit to an exit code. A child that died
+    rejecting the --settings flag is UNSUPPORTED_CONFIG_ISOLATION (68), not
+    a generic crash."""
+    for line in driver.child_output:
+        if UNKNOWN_OPTION_SETTINGS_RE.search(line):
+            emit(
+                "[driver] UNSUPPORTED_CONFIG_ISOLATION: the app-server "
+                "binary rejected the --settings isolation flag (official "
+                "0.16.5 behavior, PM live receipt 2026-09-13). The driver "
+                "will NOT fall back to the shared global config; deploy a "
+                "runtime build that supports --settings for app-server."
+            )
+            return 68
+    return 66
+
+
+def terminate_child(proc: subprocess.Popen) -> None:
+    """Precise-handle bounded teardown: SIGTERM, wait, SIGKILL, wait. Never
+    kills by process name or pattern."""
+    if proc.poll() is not None:
+        return
+    try:
+        proc.terminate()
+    except OSError:
+        pass
+    try:
+        proc.wait(timeout=CHILD_TERMINATE_TIMEOUT)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        proc.kill()
+    except OSError:
+        pass
+    try:
+        proc.wait(timeout=CHILD_TERMINATE_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        emit(f"[driver] WARNING: child pid {proc.pid} did not exit after SIGKILL")
+
+
+def shutdown(driver: Driver, requested: bool) -> int | None:
+    """Bounded close settlement. Returns an exit code when the caller should
+    exit with it, or None when settlement must be classified by the caller
+    (child death / bootstrap failure already have codes)."""
+    if requested and driver.session_id and not driver.child_dead.is_set():
+        driver.request("session/close", {"sessionId": driver.session_id}, "close")
+        deadline = time.monotonic() + driver.close_timeout
+        while time.monotonic() < deadline:
+            if driver.close_acked.is_set() or driver.child_dead.is_set():
+                break
+            time.sleep(0.05)
+        terminate_child(driver.proc)
+        if not driver.close_acked.is_set() and not driver.child_dead.is_set():
+            # child_dead unset and no ack: close unconfirmed.
+            emit("[driver] close NOT confirmed within timeout")
+            return 70
+        return None
+    terminate_child(driver.proc)
+    return None
+
+
+def input_pump(stdin, lines: "queue.Queue[str | None]") -> None:
+    """Feeds stdin lines into a queue so the main loop can also watch
+    events with bounded latency. EOF pushes None."""
+    try:
+        for line in stdin:
+            lines.put(line)
+    except (OSError, ValueError):
+        pass
+    finally:
+        lines.put(None)
+
+
+def do_quit(driver: Driver) -> int:
+    """Clean /quit settlement: bounded close, exit 0 only when the close is
+    confirmed (or no session ever existed)."""
+    emit("[driver] /quit: closing session")
+    result = shutdown(driver, requested=True)
+    if result is None:
+        result = 0 if (driver.close_acked.is_set() or not driver.session_id) else 70
+    emit("[driver] bye")
+    return result
 
 
 def main() -> int:
@@ -312,22 +757,54 @@ def main() -> int:
     )
     parser.add_argument("--bin", default="", help="zcode executable override")
     parser.add_argument(
+        "--settings",
+        default="",
+        help="REQUIRED: private per-worker settings file, passed to the CLI "
+        "via the official --settings flag (absolute path recommended; never "
+        "the shared ~/.zcode/cli/config.json)",
+    )
+    parser.add_argument(
+        "--mode",
+        default="build",
+        choices=list(MODES),
+        help="session permission mode (default: build — safe; yolo is an "
+        "explicit unattended opt-in)",
+    )
+    parser.add_argument(
         "--model",
         default="",
         help="per-worker model, e.g. GLM-5.3-Flash or providerId/modelId "
-        "(default: global model from ~/.zcode/cli/config.json)",
+        "(default: the `model` field of the private settings file)",
+    )
+    parser.add_argument(
+        "--bootstrap-timeout",
+        type=float,
+        default=DEFAULT_BOOTSTRAP_TIMEOUT,
+        help=f"seconds to reach READY or fail (default {DEFAULT_BOOTSTRAP_TIMEOUT:g})",
+    )
+    parser.add_argument(
+        "--close-timeout",
+        type=float,
+        default=DEFAULT_CLOSE_TIMEOUT,
+        help=f"seconds to wait for session/close ack on /quit (default {DEFAULT_CLOSE_TIMEOUT:g})",
     )
     args = parser.parse_args()
+    if not args.bootstrap_timeout > 0:
+        fail_config("--bootstrap-timeout must be > 0")
 
     worktree = os.path.abspath(args.cwd or os.getcwd())
     if not os.path.isdir(worktree):
         fail_config(f"--cwd {worktree} is not a directory")
-    startup_model = check_model_config()
-    model_ref = resolve_model_ref(args.model) if args.model else None
-    if model_ref:
-        print(
-            f"[driver] per-worker model: {model_ref['providerId']}/{model_ref['modelId']}",
-            flush=True,
+    settings = load_private_settings(args.settings)
+    settings_path = os.path.abspath(args.settings)
+    if args.model:
+        model_ref = resolve_model_ref(args.model, settings)
+        emit(f"[driver] per-worker model: {model_ref['providerId']}/{model_ref['modelId']}")
+    else:
+        model_ref = parse_model_ref(settings.get("model"), "--settings")
+        emit(
+            "[driver] frozen session model from settings: "
+            f"{model_ref['providerId']}/{model_ref['modelId']}"
         )
 
     zcode = resolve_zcode_bin(args.bin)
@@ -336,7 +813,11 @@ def main() -> int:
         if zcode.endswith("/node") or os.path.basename(zcode) == "node"
         else [zcode, "app-server"]
     )
-    print(f"[driver] starting: {' '.join(argv[:1])} app-server (cwd={worktree})", flush=True)
+    argv += ["--settings", settings_path]
+    emit(
+        f"[driver] starting: {shlex.quote(argv[0])} app-server "
+        f"--settings {settings_path} (cwd={worktree}, mode={args.mode})"
+    )
     try:
         proc = subprocess.Popen(
             argv,
@@ -351,51 +832,127 @@ def main() -> int:
         fail_config(f"cannot spawn zcode app-server: {exc}")
 
     assert proc.stdin is not None and proc.stdout is not None
-    driver = Driver(proc, "", model_ref)
+    driver = Driver(
+        proc, args.mode, model_ref, bool(args.model), args.bootstrap_timeout
+    )
+    driver.close_timeout = max(0.1, args.close_timeout)
 
-    # Bootstrap: create the session, then keep it fed from stdin.
+    # Bootstrap: create -> setModel -> read -> verify -> READY -> drain.
     driver.request(
         "session/create",
         {
             "workspace": {"workspaceKey": worktree, "workspacePath": worktree},
-            "mode": "yolo",
+            "mode": args.mode,
         },
         "create",
     )
     threading.Thread(target=reader_loop, args=(driver,), daemon=True).start()
 
-    for line in sys.stdin:
-        text = line.strip()
+    lines: "queue.Queue[str | None]" = queue.Queue()
+    threading.Thread(target=input_pump, args=(sys.stdin, lines), daemon=True).start()
+
+    sigint_code: list[int] = []
+
+    def on_signal(signum, _frame) -> None:
+        sigint_code.append(128 + signum)
+        # Wake the main loop (it polls at 0.2s; this just accelerates it).
+
+    signal.signal(signal.SIGINT, on_signal)
+    signal.signal(signal.SIGTERM, on_signal)
+
+    exit_code: int | None = None
+    quit_requested = False  # /quit during bootstrap: conclude first, then close
+    eof_pending = False  # EOF with undrained interest: same deferral
+    while True:
+        if sigint_code:
+            emit(f"[driver] signal {sigint_code[0] - 128} received: bounded shutdown")
+            shutdown(driver, requested=True)
+            exit_code = sigint_code[0]
+            break
+        if driver.fail_event.is_set():
+            with driver.queue_lock:
+                dropped = list(driver.queued_inputs)
+                driver.queued_inputs = []
+            if dropped:
+                emit(
+                    f"[driver] dropped {len(dropped)} queued input(s) — "
+                    "startup failed, nothing was sent to the model"
+                )
+            shutdown(driver, requested=False)
+            exit_code = 65
+            emit(f"[driver] STARTUP NOT VERIFIED: {driver.fail_reason}")
+            break
+        if driver.child_dead.is_set():
+            code = classify_child_death(driver)
+            shutdown(driver, requested=False)
+            exit_code = code
+            break
+        if not driver.ready_event.is_set() and driver.boot_expired():
+            driver.bootstrap_fail(
+                f"bootstrap deadline ({args.bootstrap_timeout:g}s) expired "
+                "before the session model was verified"
+            )
+            continue
+        if (quit_requested or eof_pending) and driver.ready_event.is_set():
+            # Bootstrap concluded READY after /quit or EOF arrived: the drain
+            # happened (queued text was flushed by the reader), now close.
+            exit_code = do_quit(driver)
+            break
+        try:
+            item = lines.get(timeout=0.2)
+        except queue.Empty:
+            continue
+        if item is None:  # EOF (tmux pane killed)
+            with driver.queue_lock:
+                undrained = quit_requested or bool(driver.queued_inputs)
+            if undrained and not driver.fail_event.is_set() and not driver.child_dead.is_set():
+                # Text is still queued behind the verify barrier (or /quit is
+                # deferred): tearing down now would silently lose the drain.
+                # Defer bounded by the bootstrap deadline; failure/child-death
+                # paths above keep priority.
+                eof_pending = True
+                emit("[driver] stdin EOF: startup still verifying; teardown deferred (bounded)")
+                continue
+            emit("[driver] stdin EOF: closing")
+            shutdown(driver, requested=True)
+            exit_code = 0
+            break
+        text = item.strip()
         if not text:
             continue
+        # Control commands are handled BEFORE any queueing and are never
+        # forwarded to the model — including during startup.
         if text == "/quit":
-            # Drain: if inputs are still queued, wait (bounded) for the
-            # session to come up and flush them before closing.
-            deadline = time.monotonic() + 10.0
-            while not driver.session_id and time.monotonic() < deadline:
-                with driver.queue_lock:
-                    still_queued = bool(driver.queued_inputs)
-                if not still_queued:
-                    break
-                time.sleep(0.1)
-            if driver.session_id:
-                driver.request("session/close", {"sessionId": driver.session_id}, "close")
-            print("[driver] bye", flush=True)
-            restore_global_model(startup_model)
-            return 0
-        if not driver.session_id:
-            with driver.queue_lock:
-                driver.queued_inputs.append(text)
-            print(f"[driver] queued (session starting): {text[:60]}", flush=True)
+            if driver.ready_event.is_set():
+                exit_code = do_quit(driver)
+                break
+            # Startup still in flight: wait (bounded by the bootstrap
+            # deadline) for it to conclude, so an in-flight drain is not
+            # silently lost. Failure/child-death paths above keep priority.
+            quit_requested = True
+            emit("[driver] /quit deferred: startup still verifying (bounded)")
             continue
         if text == "/status":
-            driver.request("session/read", {"sessionId": driver.session_id}, "read")
+            print("[status] " + redact(json.dumps(driver.projection(), ensure_ascii=False)), flush=True)
+            if driver.ready_event.is_set() and driver.session_id:
+                driver.request("session/read", {"sessionId": driver.session_id}, "read")
             continue
         if text == "/stop":
-            driver.request("session/stop", {"sessionId": driver.session_id}, "stop")
+            if driver.ready_event.is_set() and driver.session_id:
+                driver.request("session/stop", {"sessionId": driver.session_id}, "stop")
+            else:
+                emit("[driver] /stop dropped: session not ready (nothing to stop)")
             continue
         if text == "/compact":
-            driver.request("session/compact", {"sessionId": driver.session_id}, "compact")
+            if driver.ready_event.is_set() and driver.session_id:
+                driver.request("session/compact", {"sessionId": driver.session_id}, "compact")
+            else:
+                emit("[driver] /compact dropped: session not ready")
+            continue
+        if not driver.ready_event.is_set():
+            with driver.queue_lock:
+                driver.queued_inputs.append(text)
+            emit(f"[driver] queued (session starting): {text[:60]}")
             continue
         driver.request(
             "session/send",
@@ -403,12 +960,8 @@ def main() -> int:
             "send",
         )
 
-    # stdin closed (tmux pane killed): tear down with the child.
-    if driver.session_id:
-        driver.request("session/close", {"sessionId": driver.session_id}, "close")
-    proc.terminate()
-    restore_global_model(startup_model)
-    return 0
+    emit(f"[driver] exit {exit_code}")
+    return exit_code
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 摘要

TASK-2026-09-13-ZCODE-DRIVER-SAFETY：zcode worker driver 安全底座。修复现有真实 CLI driver 的启动就绪、套餐错用及共享配置覆盖风险，作为社区同会话控制器与 Start 宿主桥接线的必要前置。**不宣称本任务打通 Start 或全套机器控制。**

## 变更（仅 4 个允许文件）

- `scripts/zcode-worker-driver.py`（重构）
- `scripts/test-zcode-driver.sh`（契约测试重写，27 项）
- `scripts/test_zcode_driver_safety.py`（新增故障注入，59 项）
- `references/24-zcode-driver-safety.md`（新增随行说明）

## 行为修复

1. **启动就绪屏障**：`create → setModel(仅 --model) → session/read → 实际 {providerId,modelId} 与冻结期望完全一致 → READY → 才 drain 早到输入`。无 `--model` 也冻结 settings `model` 完整 ref 并核对。任何错误/畸形/超时/模型不符 → 退出 65、**0 条任务发送**、不回退模型（旧版 setModel 失败仅警告并继续默认模型）。启动期 `/status` `/stop` `/compact` `/quit` 是控制指令绝不送模型；`/quit` 与 EOF 在有未 drain 输入时有界等待启动结论。
2. **私有配置隔离显式化**：`--settings <file>`（强制 0600）为唯一配置入口，经官方旗标传子进程；删除 `restore_global_model` 全部写路径与 `ZCODE_CLI_CONFIG` env（官方 bundle 无此键，从未隔离子进程）。**官方 0.16.5 app-server 实测拒绝 `--settings`（PM live 回执 2026-09-13，Unknown option 退出 1）→ driver 打印 `UNSUPPORTED_CONFIG_ISOLATION` 并退出 68、0 协议流量**，不回退共享配置、不改 HOME。隔离仅覆盖用户 settings 层（DB/认证存储/项目级 `.zcode` 不在内，文档明示）。
3. **mode 显式化与反向请求安全**：默认 `--mode build`（旧版硬编码 yolo），yolo 仅显式；`interaction/requestPermission` / `requestUserInput` / `requestOfficialMcpAuthHeaders` 及未知反向请求回可识别错误帧，不猜成功回包、不挂死；`interaction/requestProviderRuntimeHeaders`（含 captcha-retry）按官方通道 `headersApplied:false` 失败关闭，不采集/输出验证码票据，错误不当作完成。
4. **输出卫生与有界关闭**：`emit()` 单出口（结构化掩码+脱敏+限长），未知通知只出参数键名，截短不替代脱敏；`/quit` close-ack 才 0（未确认 70）、EOF 0、SIGINT 130 / SIGTERM 143、子进程死 66；精确 child 句柄 SIGTERM→SIGKILL 不按名 kill；读线程不再 `os._exit`；request id/pending 表加锁。

## 测试与证据

- `bash skills/multi-agent-orchestration/scripts/test-zcode-driver.sh` → **pass=27 fail=0**（既有断言全部对应行为修复，未删测试逃避回归）
- `python3 skills/multi-agent-orchestration/scripts/test_zcode_driver_safety.py` → **pass=59 fail=0**（全部真实 driver+stub 进程：setModel 延迟/失败/读回不符/无回包不发 prompt、早输入与控制不混、双实例隔离、恶意改写自有 settings、异常 child 退出、敏感输出无泄漏、68/66/70/130 关闭路径）
- `git diff --check` → 干净
- verified head：`6a04635b60784ce3dc5cd8c10153d2b7d87e44f5`
- 官方 bundle 仅静态读取（`--settings` 帮助文案、`tI()/ws()/os.homedir()` 解析链、反向请求方法名与 `EKi/nAt` strict schema）；无模型请求、无真实凭证、无依赖安装

## 风险与归属

- **NOT_VERIFIED**：真实 provider 请求（0 次）；官方 `--settings` 配置加载（已知被拒，据此失败关闭）；桌面宿主/Start 宿主桥/官方远控/MAO ZCode supervised 链路。
- **部署注意（PM 决策项，本 PR 不改 spawn-worker）**：官方 0.16.5 上本 driver 以 68 失败关闭，**不能作为默认 zcode worker 入口**；待支持 `--settings` 的社区运行时（另立合同）接入后可复用。
- 共享文档（SKILL/CHANGELOG/references/09 §4/§6）写回建议见 worker Session Context 的 WRITEBACK_PROPOSAL，待 PM 协调，**本 draft PR 明确不含**共享文档改动。
- 实现与测试由 zcode-driver-safety-0913 独立 worker 完成；官方拒绝 `--settings` 的实测证据来自 PM（2026-09-13 live 回执），随行文档引用。

Task: TASK-2026-09-13-ZCODE-DRIVER-SAFETY
Agent: zcode-driver-safety-0913

🤖 Generated with [Claude Code](https://claude.com/claude-code)
